### PR TITLE
Fixed issues with page description

### DIFF
--- a/app/components/Breadcrumbs.js
+++ b/app/components/Breadcrumbs.js
@@ -4,12 +4,12 @@
 
 import React, { Component,PropTypes } from 'react';
 import InlineEdit from 'react-edit-inline';
+import {EditableLabel} from './basic';
 
 export default class Breadcrumbs extends Component {
     static propTypes = {
         pagesList: PropTypes.array.isRequired,
         onPageNameChange: PropTypes.func.isRequired,
-        onPageDescriptionChange: PropTypes.func.isRequired,
         onPageSelected: PropTypes.func.isRequired
     };
 
@@ -20,38 +20,15 @@ export default class Breadcrumbs extends Component {
                 elements.push(<div key={p.id} className='section' onClick={()=>{this.props.onPageSelected(p);} }>{p.name}</div>);
                 elements.push(<span key={'d_'+p.id} className="divider">/</span>);
             } else {
-                if (this.props.isEditMode) {
-                    elements.push(
-                        <span key={p.id + "_name"} className='section active pageTitle'>
-                            <InlineEdit
-                                text={p.name}
-                                change={data=>this.props.onPageNameChange(p.id,data.name)}
-                                paramName="name"
-                                />
-                        </span>
-                        );
-                     elements.push(
-                        <span key={p.id + "_description"} className='pageDescription'>
-                            <InlineEdit
-                                text={p.description}
-                                change={data=>this.props.onPageDescriptionChange(p.id,data.description)}
-                                paramName="description"
-                                />
-                        </span>
-                     );
-                }
-                else
-                {
-                    elements.push(
-                        <span key={p.id + "_name"} className='section active pageTitle'>
-                            {p.name}
-                        </span>
-                        );
-                     elements.push(
-                        <span key={p.id + "_description"} className="pageDescription"> {p.description}  </span>
-                     );
-                }
-                //elements.push(<span key={p.id} className='section active'>{p.name}</span>);
+                elements.push(
+                    <EditableLabel key={p.id}
+                        text={p.name}
+                        placeHolder='You must fill a page name'
+                        className='section active pageTitle'
+                        isEditEnable={this.props.isEditMode}
+                        onEditDone={(newName)=>this.props.onPageNameChange(p.id,newName)}
+                        />
+                );
             }
 
         });

--- a/app/components/Page.js
+++ b/app/components/Page.js
@@ -4,11 +4,11 @@
 
 
 import React, { Component, PropTypes } from 'react';
-//import InlineEdit from 'react-edit-inline';
 
 import AddWidget from '../containers/AddWidget';
 import WidgetsList from './WidgetsList';
 import Breadcrumbs from './Breadcrumbs';
+import {EditableLabel} from './basic';
 
 export default class Page extends Component {
     static propTypes = {
@@ -18,23 +18,25 @@ export default class Page extends Component {
         onPageDescriptionChange: PropTypes.func.isRequired,
         onWidgetsGridDataChange: PropTypes.func.isRequired,
         onPageSelected: PropTypes.func.isRequired,
-        onPageRemoved: PropTypes.func.isRequired
-        }
+        onPageRemoved: PropTypes.func.isRequired,
+        isEditMode: PropTypes.bool.isRequired
+        };
 
     render() {
         return (
             <div className="">
-                <Breadcrumbs pagesList={this.props.pagesList} onPageNameChange={this.props.onPageNameChange} onPageDescriptionChange={this.props.onPageDescriptionChange} isEditMode={this.props.isEditMode} onPageSelected={this.props.onPageSelected} onPageRemoved={this.props.onPageRemoved}/>
-                {/*
-                 <h3 className='ui header dividing'>
-                    <InlineEdit
-                        text={this.props.page.name}
-                        change={data=>this.props.onPageNameChange(this.props.page.id,data.name)}
-                        paramName="name"
+                <Breadcrumbs pagesList={this.props.pagesList} onPageNameChange={this.props.onPageNameChange} isEditMode={this.props.isEditMode} onPageSelected={this.props.onPageSelected} onPageRemoved={this.props.onPageRemoved}/>
+
+                <div>
+                    <EditableLabel
+                       text={this.props.page.description}
+                       placeholder='Page description'
+                       className='pageDescription'
+                       isEditEnable={this.props.isEditMode}
+                       onEditDone={(newDesc)=>this.props.onPageDescriptionChange(this.props.page.id,newDesc)}
                         />
-                </h3>
-                 */}
-                 {
+                </div>
+                {
                     this.props.isEditMode ?
                     <AddWidget pageId={this.props.page.id}/>
                     :

--- a/app/components/basic/EditableLabel.js
+++ b/app/components/basic/EditableLabel.js
@@ -1,0 +1,44 @@
+/**
+ * Created by kinneretzin on 15/11/2016.
+ */
+
+import React, { Component, PropTypes } from 'react';
+import InlineEdit from 'react-edit-inline';
+
+export default class EditableLabel extends Component {
+
+    static propTypes = {
+        id: PropTypes.any,
+        text: PropTypes.string,
+        placeholder: PropTypes.string,
+        className: PropTypes.string,
+        isEditEnable: PropTypes.bool,
+        onEditDone: PropTypes.func
+    };
+
+    static defaultProps = {
+        text: '',
+        placeholder: '',
+        isEditEnable: true,
+        onEditDone : () => {}
+    };
+
+    render() {
+        console.log('editable label for : '+(this.props.text || this.props.placeholder) +' is '+ this.props.isEditEnable);
+        if (this.props.isEditEnable) {
+            return (
+                <InlineEdit
+                    text={!_.isEmpty(this.props.text) ? this.props.text : this.props.placeholder}
+                    className={this.props.className +' '+ (_.isEmpty(this.props.text) ? 'editPlaceholder' : '')}
+                    change={(data)=>this.props.onEditDone(data.text)}
+                    paramName="text"
+                    minLength={0}
+                    />
+            );
+        } else {
+            return (
+                <span className={this.props.className}>{this.props.text}</span>
+            );
+        }
+    }
+}

--- a/app/components/basic/index.js
+++ b/app/components/basic/index.js
@@ -6,6 +6,7 @@ import Modal, {Header,Body,Footer} from './Modal';
 import Confirm from './Confirm';
 import KeyIndicator from './KeyIndicator';
 import ErrorMessage from './ErrorMessage';
+import EditableLabel from './EditableLabel';
 
-export {Modal, Header as  ModalHeader, Footer as ModalFooter, Body as ModalBody, Confirm, KeyIndicator, ErrorMessage};
+export {Modal, Header as  ModalHeader, Footer as ModalFooter, Body as ModalBody, Confirm, KeyIndicator, ErrorMessage,EditableLabel};
 

--- a/app/containers/Page.js
+++ b/app/containers/Page.js
@@ -53,7 +53,7 @@ const mapStateToProps = (state, ownProps) => {
     return {
         page: pageData,
         pagesList: buildPagesList(state.pages,pageId),
-        isEditMode: state.config.isEditMode
+        isEditMode: state.config.isEditMode || false
     }
 };
 

--- a/app/reducers/pageReducer.js
+++ b/app/reducers/pageReducer.js
@@ -14,10 +14,9 @@ const page = (state = {}, action) => {
             return {
                 id: action.newPageId,
                 name: action.name,
-                description: 'Please add description...',
+                description: '',
                 widgets: []
             };
-        case types.REMOVE_PAGE:
         case types.CREATE_DRILLDOWN_PAGE:
             return Object.assign({
                     isDrillDown: true
@@ -43,7 +42,14 @@ const page = (state = {}, action) => {
                 }
             }
             return pageData;
-
+        case types.UPDATE_PAGE_DESCRIPTION:
+            return Object.assign({}, state, {
+                description: action.description
+            });
+        case types.RENAME_PAGE:
+            return Object.assign({}, state, {
+                name: action.name
+            });
         default:
             return state;
     }
@@ -77,22 +83,13 @@ const pages = (state = [], action) => {
                 ...state.slice(removeIndex+1)
             ];
         case types.RENAME_PAGE:
-            return state.map( (page) => {
-                if (page.id === action.pageId) {
-                    return Object.assign({}, page, {
-                        name: action.name
-                    })
-                }
-                return page
-            });
         case types.UPDATE_PAGE_DESCRIPTION:
-            return state.map( (page) => {
-                if (page.id === action.pageId) {
-                    return Object.assign({}, page, {
-                        description: action.description
-                    })
+
+            return state.map( (p) => {
+                if (p.id === action.pageId) {
+                    return page(p,action);
                 }
-                return page
+                return p
             });
         case types.SET_DRILLDOWN_PAGE:
             // Add drilldown page to children list of this page, and drilldown page parent id

--- a/app/styles/style.scss
+++ b/app/styles/style.scss
@@ -81,13 +81,16 @@ body {
 }
 
 .pageDescription {
-  clear: both;
-  float:left;
+  opacity: 0.6;
+  font-size: 12px;
+
+  &.editPlaceholder {
+    font-style: italic;
+  }
 }
 
 .pageTitle {
   clear: both;
-  float:left;
   line-height: 1.5;
 }
 

--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
     "run-sequence": "^1.2.2",
     "semantic-ui": "^2.2.4",
     "url-loader": "^0.5.7",
-    "yamljs": "^0.2.8"
+    "yamljs": "^0.2.8",
+    "react-edit-inline": "^1.0.8"
   },
   "devDependencies": {
     "babel-core": "^6.14.0",
@@ -89,7 +90,6 @@
     "json-loader": "^0.5.4",
     "load-grunt-tasks": "^3.5.2",
     "node-sass": "^3.8.0",
-    "react-edit-inline": "^1.0.7",
     "react-hot-loader": "^1.3.0",
     "sass-loader": "^4.0.0",
     "style-loader": "^0.13.1",


### PR DESCRIPTION
Fixed problems with page description: 
Nested pages breadcrumbs were messed up, 
description was removed from breadcrumb to page, 
added a new basic component - EditableLabel, 
Styled description, default description is empty. 
If in edit mode and description is empty, will show a placeholder text (so it can be clicked) in italic font style

Also moved some stuff around in the pageReducer, it was not handled correctly.
Updated react-edit-inline to 1.0.8 , to solve error with unknow property 'onReturn'
