### PR TITLE
STAGE-140 - deployment delete is not working

### DIFF
--- a/widgets/deployments/src/DeploymentsList.js
+++ b/widgets/deployments/src/DeploymentsList.js
@@ -42,32 +42,33 @@ export default class extends React.Component {
     }
 
     _deleteDeployment() {
-        if (!this.state.deleteDep) {
-            this.setState({error: 'Something went wrong, no deployment was selected for delete'});
+        this._hideModal();
+
+        if (!this.state.deployment) {
+            this._handleError('Something went wrong, no deployment was selected for delete');
             return;
         }
 
         this.props.toolbox.loading(true);
 
         var actions = new Actions(this.props.toolbox);
-        actions.doDelete(this.state.deleteDep).then(()=>{
-            this._hideModal();
+        actions.doDelete(this.state.deployment).then(() => {
             this.props.toolbox.getEventBus().trigger('deployments:refresh');
             this.props.toolbox.loading(false);
-        }).catch((err)=>{
-            this.setState({error: err.message});
+        }).catch((err) => {
+            this._handleError(err.message);
             this.props.toolbox.loading(false);
         });
     }
 
     _cancelExecution(execution, forceCancel) {
         let actions = new Actions(this.props.toolbox);
-        actions.doCancel(execution, forceCancel)
-            .then(() => {
-                this.props.toolbox.getEventBus().trigger('deployments:refresh');
-                this.props.toolbox.getEventBus().trigger('executions:refresh');
-            })
-            .catch((err) => {this.setState({error: err.message});});
+        actions.doCancel(execution, forceCancel).then(() => {
+            this.props.toolbox.getEventBus().trigger('deployments:refresh');
+            this.props.toolbox.getEventBus().trigger('executions:refresh');
+        }).catch((err) => {
+            this._handleError(err.message);
+        });
     }
 
     _refreshData() {

--- a/widgets/deployments/src/actions.js
+++ b/widgets/deployments/src/actions.js
@@ -9,8 +9,8 @@ export default class {
         this.toolbox = toolbox;
     }
 
-    doDelete(blueprint) {
-        return this.toolbox.getManager().doDelete(`/deployments/${blueprint.id}`);
+    doDelete(deployment) {
+        return this.toolbox.getManager().doDelete(`/deployments/${deployment.id}`);
     }
 
     doCancel(execution,force) {


### PR DESCRIPTION
The reason for the problem was that `this.state.deleteDep` instead of `this.state.deployment` was used as a variable containing selected deployment object.

Another problem which I had to deal with here was that in case of deployment deletion we do not get response quickly. As you can see below it takes 11-14 seconds.
![capture](https://cloud.githubusercontent.com/assets/5202105/22732164/7eb2bfaa-eded-11e6-84cf-550361499a05.PNG)

I decided to hide modal always just after click on Yes or No buttons. Errors are always presented in table, not in confirmation modal, so we don't lose any information. After clicking Yes button (confirm deletion) deployment changes state and it looks like that in table:
![capture1](https://cloud.githubusercontent.com/assets/5202105/22732440/73bc3eb8-edee-11e6-9319-ebd6ef8c8594.PNG)
then deployment switches to:
![capture2](https://cloud.githubusercontent.com/assets/5202105/22732529/c77e0f7c-edee-11e6-9533-f5ba928f14b3.PNG)

The question is are we going to keep user informed about the deletion situation any other way or it is enough?