### PR TITLE
STAGE-118 - Improve input handling in deployment creation

### DIFF
--- a/app/index.tmpl.html
+++ b/app/index.tmpl.html
@@ -3,13 +3,13 @@
 <head>
     <meta charset="UTF-8">
     <title>Cloudify UI</title>
-    <link rel="stylesheet" type="text/css" href="style.css">
+    <link rel="stylesheet" type="text/css" href="/style.css">
 </head>
 <body>
     <div id="app"></div>
     <div id="splash" class="active">
         <div id="logo">
-            <img src="app/images/Cloudify-logo.png" />
+            <img src="/app/images/Cloudify-logo.png" />
         </div>
         <div id="loader">
         </div>

--- a/app/styles/style.scss
+++ b/app/styles/style.scss
@@ -220,15 +220,19 @@ a:hover {
   }
 }
 
+.loginPage {
+  margin: 0 !important;
+  padding: 0 !important;
+}
 
-.configManager.ui.segment , .loginPage.ui.segment {
+.configManager.ui.segment, .loginPage.ui.segment {
   position: absolute;
   left: 0;
   right: 0;
   top: 0;
   bottom: 0;
 
-  .configManagerContainer,.loginContainer {
+  .configManagerContainer, .loginContainer {
     margin: auto;
     width: 400px;
     height: 170px;

--- a/widgets/blueprints/src/DeployBlueprintModal.js
+++ b/widgets/blueprints/src/DeployBlueprintModal.js
@@ -120,6 +120,9 @@ export default class DeployModal extends React.Component {
 
         var blueprint = Object.assign({},{id: '', plan: {inputs: {}}}, this.props.blueprint);
 
+        let deploymentInputs = _.sortBy(_.map(blueprint.plan.inputs, (input, name) => ({'name': name, ...input})),
+                                        [(input => !_.isNil(input.default)), 'name']);
+
         return (
             <Modal show={this.props.show} onDeny={this.onDeny.bind(this)} onApprove={this.onApprove.bind(this)} loading={this.state.loading}>
                 <Modal.Header>
@@ -141,21 +144,21 @@ export default class DeployModal extends React.Component {
                         }
 
                         {
-                            blueprint.id && _.isEmpty(blueprint.plan.inputs)
+                            blueprint.id && _.isEmpty(deploymentInputs)
                             &&
                             <Message content="No inputs available for the blueprint"/>
                         }
                         {
-                            _.map(blueprint.plan.inputs, (input, name) => {
+                            _.map(deploymentInputs, (input) => {
                                 let formInput = () =>
-                                    <Form.Input name={name} placeholder={input.description}
-                                                value={this.state.deploymentInputs[name]}
+                                    <Form.Input name={input.name} placeholder={input.description}
+                                                value={this.state.deploymentInputs[input.name]}
                                                 onChange={this._handleInputChange.bind(this)}
                                                 className={DeployModal.DEPLOYMENT_INPUT_CLASSNAME} />
                                 return (
-                                    <Form.Field key={name} error={this.state.errors[name]}>
+                                    <Form.Field key={input.name} error={this.state.errors[input.name]}>
                                         <label>
-                                            {name}&nbsp;
+                                            {input.name}&nbsp;
                                             {
                                                 _.isNil(input.default)
                                                 ? <Icon name='asterisk' color='red' size='tiny' className='superscripted' />


### PR DESCRIPTION
1. Improved input handling in deployment creation by moving all mandatory deployment inputs at the beginning in deploy blueprint modal (STAGE-118)
![capture](https://cloud.githubusercontent.com/assets/5202105/23257549/a41f11ac-f9c4-11e6-8a71-e1f29365119f.PNG)
Possible improvements:
- list of inputs-related validation errors can be presented on the top as currently when a lot of deployment inputs is in modal after click you need to scroll down to see errors (of course empty deployment inputs are marked red, so that will be visible for the user)

2. Fixed position of Cloudify logo in login page to be in the same place as in splash loading screen and in application page
![capture1](https://cloud.githubusercontent.com/assets/5202105/23257579/c7c30398-f9c4-11e6-878c-115b159ad2d9.PNG)
There was padding on whole window and because of that logo was placed closer to center.

3. Fixed path to static resources in index.html