### PR TITLE
STAGE-159 - blueprint upload yaml file issue

### DIFF
--- a/widgets/blueprints/src/BlueprintsList.js
+++ b/widgets/blueprints/src/BlueprintsList.js
@@ -49,13 +49,13 @@ export default class extends React.Component {
         }
 
         var actions = new Actions(this.props.toolbox);
+        this.setState({confirmDelete: false});
         actions.doDelete(this.state.item)
             .then(()=> {
-                this.setState({confirmDelete: false});
                 this.props.toolbox.getEventBus().trigger('blueprints:refresh');
             })
             .catch((err)=>{
-                this.setState({confirmDelete: false, error: err.message});
+                this.setState({error: err.message});
             });
     }
 

--- a/widgets/blueprints/src/actions.js
+++ b/widgets/blueprints/src/actions.js
@@ -23,10 +23,12 @@ export default class {
 
     doUpload(blueprintName, blueprintFileName, blueprintUrl, file) {
         var params = {};
+        const YAML_EXTENSION = '.yaml';
 
         if (!_.isEmpty(blueprintFileName)) {
-            params['application_file_name'] = blueprintFileName
-                                            + _.endsWith(blueprintFileName, '.yaml') ? '' : '.yaml';
+            params['application_file_name'] = _.endsWith(blueprintFileName, YAML_EXTENSION)
+                                              ? blueprintFileName
+                                              : blueprintFileName + YAML_EXTENSION;
         }
         if (!_.isEmpty(blueprintUrl)) {
             params['blueprint_archive_url'] = blueprintUrl;


### PR DESCRIPTION
1. Updated blueprint upload yaml file logic to handle blueprint filenames with and without .yaml ending
- .yaml extension not specified & clicked Upload button:
![capture](https://cloud.githubusercontent.com/assets/5202105/23263686/41971d70-f9df-11e6-8cc8-17ab100364ca.PNG)
- .yaml extension specified & clicked Upload button:
![capture1](https://cloud.githubusercontent.com/assets/5202105/23263689/440e4402-f9df-11e6-9c0a-dda7cadd43ee.PNG)

2. Updated delete blueprint confirm modal logic to always close after Confirm/No click (as it popped up back again after modal confirmation and before blueprint deletion HTTP request was answered, potential error will be printend in blueprint widget)