### PR TITLE
STAGE-168 - Create deployment modal inconsistency

### DIFF
--- a/widgets/blueprints/src/DeployBlueprintModal.js
+++ b/widgets/blueprints/src/DeployBlueprintModal.js
@@ -76,7 +76,6 @@ export default class DeployModal extends React.Component {
                 deploymentInputs[inputName] = inputValue;
             }
         });
-        console.log(deploymentInputs);
 
         if (!_.isEmpty(errors)) {
             this.setState({errors});
@@ -118,8 +117,7 @@ export default class DeployModal extends React.Component {
     render() {
         var {Modal, Icon, Form, Message, Popup} = Stage.Basic;
 
-        var blueprint = Object.assign({},{id: '', plan: {inputs: {}}}, this.props.blueprint);
-
+        let blueprint = Object.assign({},{id: '', plan: {inputs: {}}}, this.props.blueprint);
         let deploymentInputs = _.sortBy(_.map(blueprint.plan.inputs, (input, name) => ({'name': name, ...input})),
                                         [(input => !_.isNil(input.default)), 'name']);
 


### PR DESCRIPTION
Updated create deployment button modal to be consistent with deploy blueprint modal activated from blueprints widget:
- added red asterisk for mandatory inputs
- added validation only for mandatory inputs
- added inputs sorting (mandatory first)
- added popup with default value for optional inputs

![createdepmodal](https://cloud.githubusercontent.com/assets/5202105/23401185/1473f3ec-fda7-11e6-9866-77befe6b8155.PNG)
