### PR TITLE
Added commons support for widgets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,10 @@
 dist
 node_modules
 bower_components
-logs
+/logs
+/backedn/logs
 
-widgets/*/widget.js
+/widgets/*/widget.js
 
 stage.tar.gz
+/widgets/common/common.js

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -7,12 +7,11 @@ module.exports = function(grunt) {
 
     grunt.registerTask("prepareModules", "Finds and prepares modules for concatenation.", function() {
 
+        // get the current concat object from initConfig
+        var browserify = grunt.config.get('browserify') || {};
+
         // get all module directories
         grunt.file.expand("widgets/**/src").forEach(function (dir) {
-
-
-            // get the current concat object from initConfig
-            var browserify = grunt.config.get('browserify') || {};
 
             var destDir = dir.substr(0,dir.lastIndexOf('/src'));
 
@@ -21,17 +20,19 @@ module.exports = function(grunt) {
 
             // create a subtask for each module, find all src files
             // and combine into a single js file per module
-            browserify.widgets.files[destDir+'/widget.js'] = [dir + '/**/*.js'];
-            browserify.dist.files[destDir+'/widget.js'] = [dir + '/**/*.js'];
-            //    src: [dir + '/**/*.js'],
-            //    dest: destDir+'/widget.js'
-            //};
-
-            // add module subtasks to the concat task in initConfig
-            grunt.config.set('browserify', browserify);
-
-            console.log(browserify.widgets.files);
+            if (dirName === 'common') {
+                browserify.widgets.files[destDir+'/common.js'] = [dir + '/**/*.js'];
+                browserify.dist.files[destDir+'/common.js'] = [dir + '/**/*.js'];
+            } else {
+                browserify.widgets.files[destDir+'/widget.js'] = [dir + '/**/*.js'];
+                browserify.dist.files[destDir+'/widget.js'] = [dir + '/**/*.js'];
+            }
         });
+
+        // add module subtasks to the concat task in initConfig
+        grunt.config.set('browserify', browserify);
+        console.log('browserify files:' ,browserify.widgets.files);
+        
     });
 
     grunt.initConfig({

--- a/app/containers/Home.js
+++ b/app/containers/Home.js
@@ -8,7 +8,7 @@ import Home from '../components/Home';
 import {clearContext,setValue} from '../actions/context';
 
 const mapStateToProps = (state, ownProps) => {
-    var selectedPageId = ownProps.params.pageId;
+    var selectedPageId = ownProps.params.pageId || "0";
     var pages = state.pages;
 
     return {

--- a/app/utils/widgetDefinitionsLoader.js
+++ b/app/utils/widgetDefinitionsLoader.js
@@ -42,17 +42,24 @@ export default class WidgetDefinitionsLoader {
             ComponentToHtmlString: (component)=>{
                 return ReactDOMServer.renderToString(component);
             },
-            GenericConfig
+            GenericConfig,
+            Common: [],
+            defineCommon: (def) =>{
+                Stage.Common[def.name] = def.common;
+            }
         };
 
         window.moment = momentImport;
     }
 
-    static load() {
 
-        return fetch('/widgets/widgets.json')
-            .then(response => response.json())
-            .then((data)=> {
+    static load() {
+        return Promise.all([
+                    new ScriptLoader('/widgets/common/common.js').load(), // Commons has to load before the widgets
+                    fetch('/widgets/widgets.json').then(response => response.json()) // We can load the list of widgets in the meanwhile
+                ])
+            .then((results)=> {
+                var data = results[1]; // widgets data
                 var promises = [];
                 data.forEach((widgetName)=>{
                     promises.push(new ScriptLoader('/widgets/'+widgetName+'/widget.js').load());

--- a/widgets/common/src/CommonActions.js
+++ b/widgets/common/src/CommonActions.js
@@ -1,0 +1,18 @@
+/**
+ * Created by kinneretzin on 02/03/2017.
+ */
+
+class actions {
+    doAction1() {
+        console.log('posting');
+    }
+
+    doAction1() {
+        console.log('abc');
+    }
+}
+
+Stage.defineCommon({
+    name: 'BlueprintActions',
+    common: actions
+});

--- a/widgets/common/src/CommonComponent.js
+++ b/widgets/common/src/CommonComponent.js
@@ -1,0 +1,17 @@
+/**
+ * Created by kinneretzin on 02/03/2017.
+ */
+
+
+export default class CommonComponent extends React.Component {
+    render() {
+        return (
+            <div>Im from Common {this.props.prop}</div>
+        );
+    }
+}
+
+Stage.defineCommon({
+    name: 'Comp1',
+    common: CommonComponent
+});

--- a/widgets/common/src/CommonConsts.js
+++ b/widgets/common/src/CommonConsts.js
@@ -1,0 +1,15 @@
+/**
+ * Created by kinneretzin on 02/03/2017.
+ */
+
+var consts = {
+    A: 'a',
+    B: 'b',
+    C: 'c',
+    ABC: "AAA"
+};
+
+Stage.defineCommon({
+    name: 'someConsts',
+    common: consts
+});


### PR DESCRIPTION
Usage example:

```javascript
        (new Stage.Common.BlueprintActions()).doAction1();
        return (
            <Stage.Common.Comp1 prop={Stage.Common.someConsts.ABC}></Stage.Common.Comp1>
        );

```