### PR TITLE
Paginator pagesize dropdown is broken

### DIFF
--- a/app/components/basic/pagination/PaginationInfo.js
+++ b/app/components/basic/pagination/PaginationInfo.js
@@ -46,6 +46,7 @@ export default class PaginationInfo extends Component {
                 Page size:&nbsp;
 
                 <Dropdown compact search selection allowAdditions value={this.props.pageSize} additionLabel="Set "
+                          closeOnBlur={false}
                           options={options} onChange={this._handleChange.bind(this)} className="upward"/>
 
                 &nbsp;&nbsp;{start} to {stop}


### PR DESCRIPTION
for some reason a blur event is sent to the dropdown causeing it to ignore the click and close the dropdown. It arrives before the click event.

a cool way to debug it , setting debug on localstorage:
https://github.com/Semantic-Org/Semantic-UI-React#debugger

I found that in componentDidUpdate of the Dropdown component (in semantic):
    } else if (prevState.focus && !this.state.focus) {
      debug('dropdown blurred')
      const { closeOnBlur } = this.props
      if (!this.isMouseDown && closeOnBlur) {
        debug('mouse is not down and closeOnBlur=true, closing')
        this.close()
      }
      ...
}
so basically if it was blured (before the click ) it basically did nothing....

Im not sure why blur is called before, probably having something to do with the container or with gridstack (like jakub suggested i think).

Anyways fixes the issue :) 
p.s. it does close on clicking outside the component, it will jsut not close if tab is clicked or something like this. no biggie
