### PR TITLE
STAGE-184 - Blueprint and deployment action buttons widgets improvements

### DIFF
--- a/widgets/blueprintActionButtons/src/BlueprintActionButtons.js
+++ b/widgets/blueprintActionButtons/src/BlueprintActionButtons.js
@@ -15,7 +15,6 @@ export default class BlueprintActionButtons extends React.Component {
         this.state = {
             showModal: false,
             modalType: '',
-            blueprint: BlueprintActionButtons.EMPTY_BLUEPRINT,
             loading: false,
             error: null
         }
@@ -37,7 +36,7 @@ export default class BlueprintActionButtons extends React.Component {
         this.props.toolbox.loading(true);
         this.setState({loading: true});
         let actions = new Stage.Common.BlueprintActions(this.props.toolbox);
-        actions.doDeleteById(this.props.blueprintId).then(()=> {
+        actions.doDelete(this.props.blueprint).then(()=> {
             this.props.toolbox.getEventBus().trigger('blueprints:refresh');
             this.setState({loading: false, error: null});
             this._hideModal();
@@ -50,28 +49,11 @@ export default class BlueprintActionButtons extends React.Component {
         return false;
     }
 
-    componentWillReceiveProps(nextProps) {
-        if (!_.isEmpty(nextProps.blueprintId) && nextProps.blueprintId !== this.props.blueprintId) {
-            this.props.toolbox.loading(true);
-            this.setState({loading: true});
-            let actions = new Stage.Common.BlueprintActions(this.props.toolbox);
-            actions.doGetFullBlueprintDataById(nextProps.blueprintId).then((blueprint) => {
-                this.props.toolbox.loading(false);
-                this.setState({loading: false, error: null, blueprint});
-            }).catch((err) => {
-                this.props.toolbox.loading(false);
-                this.setState({loading: false, error: err.message, blueprint: BlueprintActionButtons.EMPTY_BLUEPRINT});
-            });
-        } else if (nextProps.data !== this.props.data) {
-            this.setState({blueprint: nextProps.data});
-        }
-    }
-
     render() {
         let {ErrorMessage, Button, Confirm} = Stage.Basic;
         let {DeployBlueprintModal} = Stage.Common;
 
-        let blueprintId = this.props.blueprintId;
+        let blueprintId = this.props.blueprint.id;
 
         return (
             <div>
@@ -86,7 +68,7 @@ export default class BlueprintActionButtons extends React.Component {
                         content="Delete blueprint"/>
 
                 <DeployBlueprintModal show={this._isShowModal(BlueprintActionButtons.DEPLOY_ACTION)}
-                                      blueprint={this.state.blueprint}
+                                      blueprint={this.props.blueprint}
                                       onHide={this._hideModal.bind(this)}
                                       toolbox={this.props.toolbox}/>
 

--- a/widgets/blueprintActionButtons/src/widget.js
+++ b/widgets/blueprintActionButtons/src/widget.js
@@ -19,17 +19,26 @@ Stage.defineWidget({
         let blueprintId = toolbox.getContext().getValue('blueprintId');
 
         if (!_.isEmpty(blueprintId)) {
+            toolbox.loading(true);
             return toolbox.getManager().doGet(`/blueprints/${blueprintId}`)
-                .then(blueprint => Promise.resolve(blueprint));
+                .then(blueprint => {
+                    toolbox.loading(false);
+                    return Promise.resolve(blueprint);
+                });
         }
 
         return Promise.resolve(BlueprintActionButtons.EMPTY_BLUEPRINT);
     },
 
-    render: function(widget,data,error,toolbox) {
+    fetchParams: function(widget, toolbox) {
         let blueprintId = toolbox.getContext().getValue('blueprintId');
+
+        return {blueprint_id: blueprintId};
+    },
+
+    render: function(widget,data,error,toolbox) {
         return (
-            <BlueprintActionButtons blueprintId={blueprintId} data={data} widget={widget} toolbox={toolbox} />
+            <BlueprintActionButtons blueprint={data} widget={widget} toolbox={toolbox} />
         );
     }
 });

--- a/widgets/common/src/BlueprintActions.js
+++ b/widgets/common/src/BlueprintActions.js
@@ -11,16 +11,8 @@ class BlueprintActions {
         return this.toolbox.getManager().doGet(`/blueprints/${blueprint.id}`);
     }
 
-    doGetFullBlueprintDataById(blueprintId) {
-        return this.doGetFullBlueprintData({id: blueprintId});
-    }
-
     doDelete(blueprint) {
         return this.toolbox.getManager().doDelete(`/blueprints/${blueprint.id}`);
-    }
-
-    doDeleteById(blueprintId) {
-        return this.doDelete({id: blueprintId});
     }
 
     doDeploy(blueprint, deploymentId, inputs) {

--- a/widgets/common/src/DeploymentActions.js
+++ b/widgets/common/src/DeploymentActions.js
@@ -11,16 +11,8 @@ class DeploymentActions {
         return this.toolbox.getManager().doGet(`/deployments/${deployment.id}`);
     }
 
-    doGetById(deploymentId) {
-        return this.doGet({id: deploymentId});
-    }
-
     doDelete(deployment) {
         return this.toolbox.getManager().doDelete(`/deployments/${deployment.id}`);
-    }
-
-    doDeleteById(deploymentId) {
-        return this.doDelete({id: deploymentId});
     }
 
     doCancel(execution,action) {

--- a/widgets/common/src/ExecuteDeploymentModal.js
+++ b/widgets/common/src/ExecuteDeploymentModal.js
@@ -90,7 +90,8 @@ export default class ExecuteDeploymentModal extends React.Component {
                                 return (
                                     <Form.Field key={name}>
                                         <label title={parameter.description || name }>{name}</label>
-                                        <input name='executeInput' data-name={name} type="text" defaultValue={parameter.default}/>
+                                        <input name='executeInput' data-name={name} type="text"
+                                               defaultValue={Stage.Common.JsonUtils.stringify(parameter.default)}/>
                                     </Form.Field>
                                 );
                             })

--- a/widgets/common/src/JsonUtils.js
+++ b/widgets/common/src/JsonUtils.js
@@ -3,7 +3,7 @@
  */
 
 class JsonUtils {
-    static stringify(value, indented) {
+    static stringify(value, indented = false) {
         let stringifiedValue = '';
 
         try {

--- a/widgets/deploymentActionButtons/src/DeploymentActionButtons.js
+++ b/widgets/deploymentActionButtons/src/DeploymentActionButtons.js
@@ -17,7 +17,6 @@ export default class DeploymentActionButtons extends React.Component {
         this.state = {
             showModal: false,
             modalType: '',
-            deployment: DeploymentActionButtons.EMPTY_DEPLOYMENT,
             workflow: DeploymentActionButtons.EMPTY_WORKFLOW,
             loading: false,
             error: null
@@ -28,7 +27,7 @@ export default class DeploymentActionButtons extends React.Component {
         this.props.toolbox.loading(true);
         this.setState({loading: true});
         let actions = new Stage.Common.DeploymentActions(this.props.toolbox);
-        actions.doDeleteById(this.props.deploymentId).then(() => {
+        actions.doDelete(this.props.deployment).then(() => {
             this.setState({loading: false, error: null});
             this._hideModal();
             this.props.toolbox.loading(false);
@@ -57,27 +56,10 @@ export default class DeploymentActionButtons extends React.Component {
         return this.state.modalType === type && this.state.showModal;
     }
 
-    componentWillReceiveProps(nextProps) {
-        if (!_.isEmpty(nextProps.deploymentId) && nextProps.deploymentId !== this.props.deploymentId) {
-            this.props.toolbox.loading(true);
-            this.setState({loading: true});
-            let actions = new Stage.Common.DeploymentActions(this.props.toolbox);
-            actions.doGetById(nextProps.deploymentId).then((deployment) => {
-                this.props.toolbox.loading(false);
-                this.setState({loading: false, error: null, deployment});
-            }).catch((err) => {
-                this.props.toolbox.loading(false);
-                this.setState({loading: false, error: err.message, deployment: DeploymentActionButtons.EMPTY_DEPLOYMENT});
-            });
-        } else if (nextProps.data !== this.props.data) {
-            this.setState({deployment: nextProps.data});
-        }
-    }
-
     render() {
         let {ErrorMessage, Button, Confirm, PopupMenu, Popup, Menu} = Stage.Basic;
         let {ExecuteDeploymentModal, UpdateDeploymentModal} = Stage.Common;
-        let deploymentId = this.props.deploymentId;
+        let deploymentId = this.props.deployment.id;
 
         return (
             <div>
@@ -91,7 +73,7 @@ export default class DeploymentActionButtons extends React.Component {
                     
                     <Menu vertical>
                         {
-                            _.map(this.state.deployment.workflows, (workflow) =>
+                            _.map(this.props.deployment.workflows, (workflow) =>
                                 <Menu.Item name={_.capitalize(_.lowerCase(workflow.name))} key={workflow.name}
                                            onClick={this._showExecuteWorkflowModal.bind(this, workflow)} />
                             )
@@ -114,14 +96,14 @@ export default class DeploymentActionButtons extends React.Component {
 
                 <ExecuteDeploymentModal
                     show={this._isShowModal(DeploymentActionButtons.WORKFLOW_ACTION)}
-                    deployment={this.state.deployment}
+                    deployment={this.props.deployment}
                     workflow={this.state.workflow}
                     onHide={this._hideModal.bind(this)}
                     toolbox={this.props.toolbox}/>
 
                 <UpdateDeploymentModal
                     show={this._isShowModal(DeploymentActionButtons.EDIT_ACTION)}
-                    deployment={this.state.deployment}
+                    deployment={this.props.deployment}
                     onHide={this._hideModal.bind(this)}
                     toolbox={this.props.toolbox}/>
 

--- a/widgets/deploymentActionButtons/src/widget.js
+++ b/widgets/deploymentActionButtons/src/widget.js
@@ -19,17 +19,26 @@ Stage.defineWidget({
         let deploymentId = toolbox.getContext().getValue('deploymentId');
 
         if (!_.isEmpty(deploymentId)) {
+            toolbox.loading(true);
             return toolbox.getManager().doGet(`/deployments/${deploymentId}`)
-                .then(deployment => Promise.resolve(deployment));
+                .then(deployment => {
+                    toolbox.loading(false);
+                    return Promise.resolve(deployment);
+                });
         }
 
         return Promise.resolve(DeploymentActionButtons.EMPTY_DEPLOYMENT);
     },
 
-    render: function(widget,data,error,toolbox) {
+    fetchParams: function(widget, toolbox) {
         let deploymentId = toolbox.getContext().getValue('deploymentId');
+
+        return {deployment_id: deploymentId};
+    },
+
+    render: function(widget,data,error,toolbox) {
         return (
-            <DeploymentActionButtons deploymentId={deploymentId} data={data} widget={widget} toolbox={toolbox} />
+            <DeploymentActionButtons deployment={data} widget={widget} toolbox={toolbox} />
         );
     }
 


### PR DESCRIPTION
Improved blueprint and deployment action buttons widgets:
- buttons disabling and widget loading information - buttons are disabled when blueprintId/deploymentId is not set in context or data (blueprint/deployment) is being fetched
- data fetching - data (blueprint/deployment) is fetched just before widget is mounted and when props are changed (e.g. context)