### PR TITLE
STAGE-181 - Default timestamp sorting

### DIFF
--- a/app/components/EditWidgetModal.js
+++ b/app/components/EditWidgetModal.js
@@ -61,7 +61,7 @@ export default class EditWidgetModal extends Component {
                 <Modal.Body>
                     <div className="ui form" ref='configForm'>
                         {
-                            this.props.configDef.map((config)=>{
+                            this.props.configDef.filter((config) => !config.hidden).map((config)=>{
                                 var currValue = _.get(this.props.configuration,'['+config.id+']',config.value || config.default);
 
                                 return <GenericField key={config.id}

--- a/app/utils/widgetDefinitionsLoader.js
+++ b/app/utils/widgetDefinitionsLoader.js
@@ -120,4 +120,15 @@ class GenericConfig {
                 type: BasicComponents.GenericField.NUMBER_TYPE}
     };
 
+    static SORT_COLUMN_CONFIG = (sortColumn) => {
+        return {id: 'sortColumn',
+                default: sortColumn,
+                hidden: true}
+    };
+
+    static SORT_ASCENDING_CONFIG = (sortAscending) => {
+        return {id: 'sortAscending',
+                default: sortAscending,
+                hidden: true}
+    };
 }

--- a/widgets/blueprintCatalog/src/RepositoryTable.js
+++ b/widgets/blueprintCatalog/src/RepositoryTable.js
@@ -26,6 +26,8 @@ export default class extends React.Component {
         return (
             <DataTable fetchData={this.props.fetchData}
                        pageSize={this.props.widget.configuration.pageSize}
+                       sortColumn={this.props.widget.configuration.sortColumn}
+                       sortAscending={this.props.widget.configuration.sortAscending}
                        fetchSize={this.props.data.items.length}
                        totalSize={this.props.data.total}
                        selectable={true}>

--- a/widgets/blueprintCatalog/src/widget.js
+++ b/widgets/blueprintCatalog/src/widget.js
@@ -23,8 +23,9 @@ Stage.defineWidget({
         {id: 'username', name: 'Fetch with username', placeHolder:"Type username", default:"cloudify-examples", type: Stage.Basic.GenericField.STRING_TYPE},
         {id: 'password', name: 'Optional password', placeHolder:"Type password", default:"", type: Stage.Basic.GenericField.PASSWORD_TYPE},
         {id: "displayStyle",name: "Display style", items: [{name:'Table', value:'table'}, {name:'Catalog', value:'catalog'}],
-             default: "catalog", type: Stage.Basic.GenericField.LIST_TYPE}
-
+             default: "catalog", type: Stage.Basic.GenericField.LIST_TYPE},
+        Stage.GenericConfig.SORT_COLUMN_CONFIG('created_at'),
+        Stage.GenericConfig.SORT_ASCENDING_CONFIG(false)
     ],
 
     mapGridParams: function(gridParams) {

--- a/widgets/blueprints/src/BlueprintsTable.js
+++ b/widgets/blueprints/src/BlueprintsTable.js
@@ -30,10 +30,12 @@ export default class BlueprintsTable extends React.Component{
 
         return (
             <DataTable fetchData={this.props.fetchGridData}
-                        totalSize={this.props.data.total}
-                        pageSize={this.props.widget.configuration.pageSize}
-                        selectable={true}
-                        className="blueprintsTable">
+                       totalSize={this.props.data.total}
+                       pageSize={this.props.widget.configuration.pageSize}
+                       sortColumn={this.props.widget.configuration.sortColumn}
+                       sortAscending={this.props.widget.configuration.sortAscending}
+                       selectable={true}
+                       className="blueprintsTable">
 
                 <DataTable.Column label="Name" name="id" width="30%"/>
                 <DataTable.Column label="Created" name="created_at" width="20%"/>

--- a/widgets/blueprints/src/widget.js
+++ b/widgets/blueprints/src/widget.js
@@ -17,7 +17,9 @@ Stage.defineWidget({
         Stage.GenericConfig.PAGE_SIZE_CONFIG(),
         {id: "clickToDrillDown", name: "Should click to drilldown", default: true, type: Stage.Basic.GenericField.BOOLEAN_TYPE},
         {id: "displayStyle",name: "Display style", items: [{name:'Table', value:'table'}, {name:'Catalog', value:'catalog'}],
-            default: "table", type: Stage.Basic.GenericField.LIST_TYPE}
+            default: "table", type: Stage.Basic.GenericField.LIST_TYPE},
+        Stage.GenericConfig.SORT_COLUMN_CONFIG('created_at'),
+        Stage.GenericConfig.SORT_ASCENDING_CONFIG(false)
     ],
     fetchUrl: {
         blueprints: '[manager]/blueprints?_include=id,updated_at,created_at,description[params]',

--- a/widgets/deployments/src/DeploymentsTable.js
+++ b/widgets/deployments/src/DeploymentsTable.js
@@ -32,10 +32,12 @@ export default class extends React.Component {
 
         return (
             <DataTable fetchData={this.props.fetchData}
-                        totalSize={this.props.data.total}
-                        pageSize={this.props.widget.configuration.pageSize}
-                        selectable={true}
-                        className="deploymentTable">
+                       totalSize={this.props.data.total}
+                       pageSize={this.props.widget.configuration.pageSize}
+                       sortColumn={this.props.widget.configuration.sortColumn}
+                       sortAscending={this.props.widget.configuration.sortAscending}
+                       selectable={true}
+                       className="deploymentTable">
 
                 <DataTable.Column label="Name" name="id" width="25%"/>
                 <DataTable.Column label="Blueprint" name="blueprint_id" width="25%"/>

--- a/widgets/deployments/src/widget.js
+++ b/widgets/deployments/src/widget.js
@@ -18,7 +18,9 @@ Stage.defineWidget({
             {id: "clickToDrillDown", name: "Should click to drilldown", default: true, type: Stage.Basic.GenericField.BOOLEAN_TYPE},
             {id: "blueprintIdFilter", name: "Blueprint ID to filter by", placeHolder: "Enter the blueprint id you wish to filter by", type: Stage.Basic.GenericField.STRING_TYPE},
             {id: "displayStyle", name: "Display style", items: [{name:'Table', value:'table'}, {name:'List', value:'list'}],
-                default: "table", type: Stage.Basic.GenericField.LIST_TYPE}
+                default: "table", type: Stage.Basic.GenericField.LIST_TYPE},
+            Stage.GenericConfig.SORT_COLUMN_CONFIG('created_at'),
+            Stage.GenericConfig.SORT_ASCENDING_CONFIG(false)
         ],
     isReact: true,
 

--- a/widgets/events/src/EventsTable.js
+++ b/widgets/events/src/EventsTable.js
@@ -41,9 +41,11 @@ export default class EventsTable extends React.Component {
                 <ErrorMessage error={this.state.error}/>
 
                 <DataTable fetchData={this.fetchGridData.bind(this)}
-                       totalSize={this.props.data.total}
-                       pageSize={this.props.widget.configuration.pageSize}
-                       className="eventsTable">
+                           totalSize={this.props.data.total}
+                           pageSize={this.props.widget.configuration.pageSize}
+                           sortColumn={this.props.widget.configuration.sortColumn}
+                           sortAscending={this.props.widget.configuration.sortAscending}
+                           className="eventsTable">
 
                     <DataTable.Column label="Blueprint" name="context.blueprint_id" width="10%" show={!this.props.data.blueprintId &&
                                                                                                       !this.props.data.deploymentId &&

--- a/widgets/events/src/widget.js
+++ b/widgets/events/src/widget.js
@@ -15,7 +15,9 @@ Stage.defineWidget({
     isReact: true,
     initialConfiguration: [
         Stage.GenericConfig.POLLING_TIME_CONFIG(10),
-        Stage.GenericConfig.PAGE_SIZE_CONFIG()
+        Stage.GenericConfig.PAGE_SIZE_CONFIG(),
+        Stage.GenericConfig.SORT_COLUMN_CONFIG('timestamp'),
+        Stage.GenericConfig.SORT_ASCENDING_CONFIG(false)
     ],
 
     fetchParams: function(widget, toolbox) {

--- a/widgets/executions/src/ExecutionsTable.js
+++ b/widgets/executions/src/ExecutionsTable.js
@@ -54,10 +54,12 @@ export default class extends React.Component {
                 <ErrorMessage error={this.state.error}/>
 
                 <DataTable fetchData={this.fetchGridData.bind(this)}
-                            totalSize={this.props.data.total}
-                            pageSize={this.props.widget.configuration.pageSize}
-                            selectable={true}
-                            className="executionsTable">
+                           totalSize={this.props.data.total}
+                           pageSize={this.props.widget.configuration.pageSize}
+                           sortColumn={this.props.widget.configuration.sortColumn}
+                           sortAscending={this.props.widget.configuration.sortAscending}
+                           selectable={true}
+                           className="executionsTable">
 
                     <DataTable.Column label="Blueprint" name="blueprint_id" width="20%"
                                  show={fieldsToShow.indexOf("Blueprint") >= 0 && !this.props.data.blueprintId}/>

--- a/widgets/executions/src/widget.js
+++ b/widgets/executions/src/widget.js
@@ -20,7 +20,9 @@ Stage.defineWidget({
             {id: "fieldsToShow",name: "List of fields to show in the table", placeHolder: "Select fields from the list",
                 items: ["Blueprint","Deployment","Workflow","Id","Created","IsSystem","Params","Status"],
                 default: 'Blueprint,Deployment,Workflow,Id,Created,IsSystem,Params,Status', type: Stage.Basic.GenericField.MULTI_SELECT_LIST_TYPE},
-            {id: "showSystemExecutions", name: "Show system executions", default: true, type: Stage.Basic.GenericField.BOOLEAN_TYPE}
+            {id: "showSystemExecutions", name: "Show system executions", default: true, type: Stage.Basic.GenericField.BOOLEAN_TYPE},
+            Stage.GenericConfig.SORT_COLUMN_CONFIG('created_at'),
+            Stage.GenericConfig.SORT_ASCENDING_CONFIG(false)
         ],
 
     fetchParams: function(widget, toolbox) {

--- a/widgets/logs/src/LogsTable.js
+++ b/widgets/logs/src/LogsTable.js
@@ -40,9 +40,11 @@ export default class LogsTable extends React.Component {
                 <ErrorMessage error={this.state.error}/>
 
                 <DataTable fetchData={this.fetchGridData.bind(this)}
-                       totalSize={this.props.data.total}
-                       pageSize={this.props.widget.configuration.pageSize}
-                       className="logsTable">
+                           totalSize={this.props.data.total}
+                           pageSize={this.props.widget.configuration.pageSize}
+                           sortColumn={this.props.widget.configuration.sortColumn}
+                           sortAscending={this.props.widget.configuration.sortAscending}
+                           className="logsTable">
 
                     <DataTable.Column label="Blueprint" name="context.blueprint_id" width="10%" show={!this.props.data.blueprintId && !this.props.data.deploymentId && !this.props.data.executionId} />
                     <DataTable.Column label="Deployment" name="context.deployment_id" width="10%" show={!this.props.data.deploymentId && !this.props.data.executionId} />

--- a/widgets/logs/src/widget.js
+++ b/widgets/logs/src/widget.js
@@ -15,7 +15,9 @@ Stage.defineWidget({
     isReact: true,
     initialConfiguration: [
         Stage.GenericConfig.POLLING_TIME_CONFIG(10),
-        Stage.GenericConfig.PAGE_SIZE_CONFIG()
+        Stage.GenericConfig.PAGE_SIZE_CONFIG(),
+        Stage.GenericConfig.SORT_COLUMN_CONFIG('timestamp'),
+        Stage.GenericConfig.SORT_ASCENDING_CONFIG(false)
     ],
 
     fetchParams: function(widget, toolbox) {

--- a/widgets/nodes/src/NodesTable.js
+++ b/widgets/nodes/src/NodesTable.js
@@ -45,6 +45,8 @@ export default class NodesTable extends React.Component {
                 <DataTable fetchData={this.fetchGridData.bind(this)}
                        totalSize={this.props.data.total}
                        pageSize={this.props.widget.configuration.pageSize}
+                       sortColumn={this.props.widget.configuration.sortColumn}
+                       sortAscending={this.props.widget.configuration.sortAscending}
                        selectable={true}
                        className="nodesTable">
 

--- a/widgets/plugins/src/PluginsTable.js
+++ b/widgets/plugins/src/PluginsTable.js
@@ -80,10 +80,12 @@ export default class extends React.Component {
                 <ErrorMessage error={this.state.error}/>
 
                 <DataTable fetchData={this.fetchGridData.bind(this)}
-                            totalSize={this.props.data.total}
-                            pageSize={this.props.widget.configuration.pageSize}
-                            selectable={true}
-                            className="pluginsTable">
+                           totalSize={this.props.data.total}
+                           pageSize={this.props.widget.configuration.pageSize}
+                           sortColumn={this.props.widget.configuration.sortColumn}
+                           sortAscending={this.props.widget.configuration.sortAscending}
+                           selectable={true}
+                           className="pluginsTable">
 
                     <DataTable.Column label="Id" name="id" width="20%"/>
                     <DataTable.Column label="Package name" name="package_name" width="15%"/>

--- a/widgets/snapshots/src/SnapshotsTable.js
+++ b/widgets/snapshots/src/SnapshotsTable.js
@@ -92,10 +92,12 @@ export default class extends React.Component {
                 <ErrorMessage error={this.state.error}/>
 
                 <DataTable fetchData={this.fetchGridData.bind(this)}
-                            totalSize={this.props.data.total}
-                            pageSize={this.props.widget.configuration.pageSize}
-                            selectable={true}
-                            className="snapshotsTable">
+                           totalSize={this.props.data.total}
+                           pageSize={this.props.widget.configuration.pageSize}
+                           sortColumn={this.props.widget.configuration.sortColumn}
+                           sortAscending={this.props.widget.configuration.sortAscending}
+                           selectable={true}
+                           className="snapshotsTable">
 
                     <DataTable.Column label="Id" name="id" width="40%"/>
                     <DataTable.Column label="Created at" name="created_at" width="25%"/>

--- a/widgets/snapshots/src/widget.js
+++ b/widgets/snapshots/src/widget.js
@@ -14,7 +14,9 @@ Stage.defineWidget({
     isReact: true,
     initialConfiguration: [
         Stage.GenericConfig.POLLING_TIME_CONFIG(30),
-        Stage.GenericConfig.PAGE_SIZE_CONFIG()
+        Stage.GenericConfig.PAGE_SIZE_CONFIG(),
+        Stage.GenericConfig.SORT_COLUMN_CONFIG('created_at'),
+        Stage.GenericConfig.SORT_ASCENDING_CONFIG(false)
     ],
     fetchUrl: '[manager]/snapshots?_include=id,created_at,status[params]',
 

--- a/widgets/tenants/src/TenantsTable.js
+++ b/widgets/tenants/src/TenantsTable.js
@@ -112,6 +112,8 @@ export default class TenantsTable extends React.Component {
                 <DataTable fetchData={this.fetchGridData.bind(this)}
                            totalSize={data.total}
                            pageSize={this.props.widget.configuration.pageSize}
+                           sortColumn={this.props.widget.configuration.sortColumn}
+                           sortAscending={this.props.widget.configuration.sortAscending}
                            className="tenantsTable">
 
                     <DataTable.Column label="Name" name="name" width="30%" />

--- a/widgets/userGroups/src/UserGroupsTable.js
+++ b/widgets/userGroups/src/UserGroupsTable.js
@@ -112,6 +112,8 @@ export default class UserGroupsTable extends React.Component {
                 <DataTable fetchData={this.fetchData.bind(this)}
                            totalSize={this.props.data.total}
                            pageSize={this.props.widget.configuration.pageSize}
+                           sortColumn={this.props.widget.configuration.sortColumn}
+                           sortAscending={this.props.widget.configuration.sortAscending}
                            className="userGroupsTable">
 
                     <DataTable.Column label="Group" name="name" width="30%" />

--- a/widgets/userManagement/src/UsersTable.js
+++ b/widgets/userManagement/src/UsersTable.js
@@ -111,9 +111,11 @@ export default class UsersTable extends React.Component {
                 <ErrorMessage error={this.state.error}/>
 
                 <DataTable fetchData={this.fetchData.bind(this)}
-                       totalSize={this.props.data.total}
-                       pageSize={this.props.widget.configuration.pageSize}
-                       className="usersTable">
+                           totalSize={this.props.data.total}
+                           pageSize={this.props.widget.configuration.pageSize}
+                           sortColumn={this.props.widget.configuration.sortColumn}
+                           sortAscending={this.props.widget.configuration.sortAscending}
+                           className="usersTable">
 
                     <DataTable.Column label="Username" name="username" width="32%" />
                     <DataTable.Column label="Last login" name="last_login_at" width="18%" />


### PR DESCRIPTION
- Added default timestamp sorting for blueprints, deployments, executions, events, logs, blueprints catalog and snapshots widget (STAGE-181)
- Added possibility to create widget configurable parameter without exposing it to edit widget configuration modal
- Added sorting parameters from widgets configuration to all pagination-based uses of DataTable components

Attaching screenshot showing newly added widgets, which have default sorting set:
![capture](https://cloud.githubusercontent.com/assets/5202105/23709014/4834fb14-0418-11e7-9100-ab1a32575c83.PNG)
