### PR TITLE
added a restore snapshot modal

### DIFF
--- a/widgets/snapshots/src/RestoreSnapshotModal.js
+++ b/widgets/snapshots/src/RestoreSnapshotModal.js
@@ -1,0 +1,129 @@
+/**
+ * Created by kinneretzin on 03/21/2017.
+ */
+
+import Actions from './actions';
+let PropTypes = React.PropTypes;
+
+export default class RestoreSnapshotModal extends React.Component {
+
+    constructor(props,context) {
+        super(props, context);
+
+        this.state = {...RestoreSnapshotModal.initialState, show: false}
+    }
+
+    static initialState = {
+        loading: false,
+        errors: {},
+        isFromTenantlessEnv : false,
+        shouldForceRestore: false,
+        newTenantName: ''
+    }
+
+    static propTypes = {
+        snapshot: PropTypes.object.isRequired,
+        toolbox: PropTypes.object.isRequired,
+    };
+
+    static defaultProps = {
+        onHide: ()=>{}
+    };
+
+    onApprove () {
+        this.refs.restoreForm.submit();
+        return false;
+    }
+
+    onDeny () {
+        this.props.onHide();
+        return true;
+    }
+
+
+    componentWillUpdate(prevProps, prevState) {
+        if (!prevState.show && this.state.show) {
+            this.setState(RestoreSnapshotModal.initialState);
+        }
+    }
+
+    _submitRestore() {
+        let errors = {};
+
+        if (this.state.isFromTenantlessEnv && _.isEmpty(this.state.newTenantName)) {
+            errors["newTenantName"]="Please provide a new tenant name";
+        }
+
+        if (!_.isEmpty(errors)) {
+            this.setState({errors});
+            return false;
+        }
+
+        // Disable the form
+        this.setState({loading: true});
+
+        var actions = new Actions(this.props.toolbox);
+        actions.doRestore(this.props.snapshot,this.state.shouldForceRestore,this.state.newTenantName).then(()=>{
+            this.setState({loading: false});
+            this.props.toolbox.refresh();
+            this.props.toolbox.getEventBus().trigger('snapshots:refresh');
+            this.props.onHide();
+        }).catch((err)=>{
+            this.setState({errors: {error: err.message}, loading: false});
+        });
+    }
+
+    _handleFieldChange(proxy, field) {
+        this.setState(Stage.Basic.Form.fieldNameValue(field));
+    }
+
+    render() {
+        var {Modal, Button, Icon, Form} = Stage.Basic;
+
+        return (
+            <Modal show={this.props.show} onDeny={this.onDeny.bind(this)} onApprove={this.onApprove.bind(this)} loading={this.state.loading}>
+                <Modal.Header>
+                    <Icon name="undo"/> Restore snapshot
+                </Modal.Header>
+
+                <Modal.Body>
+                    <Form onSubmit={this._submitRestore.bind(this)} errors={this.state.errors} ref="restoreForm">
+
+                        <Form.Field>
+                            <Form.Checkbox toggle
+                                           label="Is Snapshot from a tenant-less environment?"
+                                           name='isFromTenantlessEnv'
+                                           checked={this.state.isFromTenantlessEnv}
+                                           onChange={this._handleFieldChange.bind(this)}/>
+                        </Form.Field>
+
+
+                        {
+                            this.state.isFromTenantlessEnv &&
+                            <Form.Field error={this.state.errors.newTenantName}>
+                                <Form.Input  placeholder="Enter new tenant name for this snapshot to be restored to"
+                                             name='newTenantName'
+                                             required
+                                             value={this.state.newTenantName}
+                                             onChange={this._handleFieldChange.bind(this)}/>
+                            </Form.Field>
+                        }
+                        <Form.Field>
+                            <Form.Checkbox toggle
+                                           label="Force restore even if manager is non-empty? (It will delete all data)"
+                                           name='shouldForceRestore'
+                                           checked={this.state.shouldForceRestore}
+                                           onChange={this._handleFieldChange.bind(this)}/>
+                        </Form.Field>
+
+                    </Form>
+                </Modal.Body>
+
+                <Modal.Footer>
+                    <Modal.Cancel/>
+                    <Modal.Approve label="Restore" icon="undo" className="green"/>
+                </Modal.Footer>
+            </Modal>
+        );
+    }
+};

--- a/widgets/snapshots/src/SnapshotsTable.js
+++ b/widgets/snapshots/src/SnapshotsTable.js
@@ -3,6 +3,7 @@
  */
 import UploadModal from './UploadSnapshotModal';
 import CreateModal from './CreateSnapshotModal';
+import RestoreModal from './RestoreSnapshotModal.js';
 
 import Actions from './actions';
 
@@ -12,7 +13,9 @@ export default class extends React.Component {
         super(props,context);
 
         this.state = {
-            confirmDelete: false
+            confirmDelete: false,
+            showRestore: false,
+            item: {}
         }
     }
 
@@ -39,11 +42,9 @@ export default class extends React.Component {
     _restoreSnapshot(item,event) {
         event.stopPropagation();
 
-        var actions = new Actions(this.props.toolbox);
-        actions.doRestore(item).then(()=>{
-            this.props.toolbox.refresh();
-        }).catch((err)=>{
-            this.setState({error:err.message});
+        this.setState({
+            showRestore: true,
+            item: item
         });
     }
 
@@ -137,6 +138,11 @@ export default class extends React.Component {
                     </DataTable.Action>
 
                 </DataTable>
+
+                <RestoreModal show={this.state.showRestore}
+                              onHide={()=>this.setState({showRestore : false})}
+                              toolbox={this.props.toolbox}
+                              snapshot={this.state.item}/>
 
                 <Confirm title='Are you sure you want to remove this snapshot?'
                          show={this.state.confirmDelete}

--- a/widgets/snapshots/src/actions.js
+++ b/widgets/snapshots/src/actions.js
@@ -13,8 +13,9 @@ export default class {
 
     }
 
-    doRestore(snapshot) {
-        return this.toolbox.getManager().doPost(`/snapshots/${snapshot.id}/restore`,null,{force: false, recreate_deployments_envs: false});
+    doRestore(snapshot,shouldForceRestore,newTenantName) {
+        return this.toolbox.getManager().doPost(`/snapshots/${snapshot.id}/restore`,null,
+            {force: shouldForceRestore, recreate_deployments_envs: false, tenant_name: newTenantName});
     }
 
     doUpload(snapshotUrl, snapshotId, file) {

--- a/widgets/userManagement/src/UsersTable.js
+++ b/widgets/userManagement/src/UsersTable.js
@@ -125,7 +125,7 @@ export default class UsersTable extends React.Component {
 
                     <DataTable.Column label="Username" name="username" width="32%" />
                     <DataTable.Column label="Last login" name="last_login_at" width="18%" />
-                    <DataTable.Column label="Role" name="role" width="15%" />
+                    <DataTable.Column label="Role" width="15%" />
                     <DataTable.Column label="Is active" name="active" width="10%" />
                     <DataTable.Column label="# Groups" width="10%" />
                     <DataTable.Column label="# Tenants" width="10%" />


### PR DESCRIPTION
two actions are there - is from tenant less env = need to state a new tenant name to restore to, and should use force - to restore over existing non-empty manager


Also as part of this bug i fixed STAGE-212 - error when trying to sort by role (it doesnt exist in the backend)