### PR TITLE
STAGE-230 Deployment Action buttons distorted

### DIFF
--- a/app/components/basic/Popup.js
+++ b/app/components/basic/Popup.js
@@ -29,7 +29,7 @@ export default class PopupWrapper extends Component {
 
         React.Children.forEach(this.props.children, function (child) {
             if (child.type && child.type.name === "Wrapper") {
-                trigger = <div>{child.props.children}</div>;
+                trigger = <span>{child.props.children}</span>;
                 children = _.without(props.children, child);
             }
         });

--- a/app/components/basic/PopupMenu.js
+++ b/app/components/basic/PopupMenu.js
@@ -17,14 +17,21 @@ export default class PopupMenu extends Component {
 
     static propTypes = {
         className: PropTypes.string,
-        children: PropTypes.any.isRequired
+        children: PropTypes.any.isRequired,
+        positioning: PropTypes.string,
+        offset: PropTypes.number
     };
+
+    static defaultProps = {
+        positioning: "bottom right",
+        offset: 12
+    }
 
     render () {
         let trigger = <Icon link name="content" className={this.props.className} onClick={(e)=>{e.stopPropagation();}}/>;
 
         return (
-            <Popup trigger={trigger} on='click' positioning="bottom right" className="popupMenu" offset={12}
+            <Popup trigger={trigger} on='click' positioning={this.props.positioning} className="popupMenu" offset={this.props.offset}
                    open={this.state.opened}
                    onClose={()=>this.setState({opened: false})}
                    onOpen={()=>this.setState({opened: true})}

--- a/widgets/deploymentActionButtons/src/DeploymentActionButtons.js
+++ b/widgets/deploymentActionButtons/src/DeploymentActionButtons.js
@@ -71,7 +71,7 @@ export default class DeploymentActionButtons extends React.Component {
             <div>
                 <ErrorMessage error={this.state.error}/>
 
-                <PopupMenu className="workflowAction" disabled={_.isEmpty(deploymentId) || this.state.loading}>
+                <PopupMenu className="workflowAction" positioning="bottom center" offset={0}>
                     <Popup.Trigger>
                         <Button className="labeled icon" color="teal" icon="content"
                                 disabled={_.isEmpty(deploymentId) || this.state.loading} content="Execute workflow" />


### PR DESCRIPTION
Apparently popup menu created a div around the trigger instead of a span, it made the first button take the entire row.
Fixed popup menu trigger using div and catching the entire row. Also passed some props to popup menu for customization