### PR TITLE
STAGE-228-When in a tenant with many deployments, UI can't fetch some of the data

### DIFF
--- a/widgets/deploymentNum/src/widget.js
+++ b/widgets/deploymentNum/src/widget.js
@@ -14,7 +14,7 @@ Stage.defineWidget({
     initialConfiguration: [
         Stage.GenericConfig.POLLING_TIME_CONFIG(5)
     ],
-    fetchUrl: '[manager]/deployments?_include=id',
+    fetchUrl: '[manager]/deployments?_include=id&_size=1',
 
     render: function(widget,data,error,toolbox) {
         if (_.isEmpty(data)) {

--- a/widgets/pluginsNum/src/widget.js
+++ b/widgets/pluginsNum/src/widget.js
@@ -14,7 +14,7 @@ Stage.defineWidget({
     initialConfiguration: [
         Stage.GenericConfig.POLLING_TIME_CONFIG(5)
     ],
-    fetchUrl: '[manager]/plugins?_include=id',
+    fetchUrl: '[manager]/plugins?_include=id&_size=1',
 
     render: function(widget,data,error,toolbox) {
         if (_.isEmpty(data)) {

--- a/widgets/serversNum/src/widget.js
+++ b/widgets/serversNum/src/widget.js
@@ -14,7 +14,7 @@ Stage.defineWidget({
     initialConfiguration: [
         Stage.GenericConfig.POLLING_TIME_CONFIG(5)
     ],
-    fetchUrl: '[manager]/node-instances?_include=id',
+    fetchUrl: '[manager]/node-instances?_include=id&_size=1',
 
     render: function(widget,data,error,toolbox) {
         if (_.isEmpty(data)) {


### PR DESCRIPTION
Fixed max fetch size reached for deployments (for blueprint - count םf deployments). Also fetching page size 1 for deployment,server and plugin number widget , becasue we only need to total cound anyways

I also added some protective code to WidgetDynamicContent to attempt to prevent another bug, but i couldnt reproduce it atm.