### PR TITLE
STAGE-209 - wrong error message to delete user

### DIFF
--- a/widgets/userManagement/src/UsersTable.js
+++ b/widgets/userManagement/src/UsersTable.js
@@ -108,6 +108,7 @@ export default class UsersTable extends React.Component {
             this.props.toolbox.loading(false);
             this.props.toolbox.refresh();
         }).catch((err)=>{
+            this._hideModal();
             this.setState({error: err.message});
             this.props.toolbox.loading(false);
         });


### PR DESCRIPTION
Confirm deletion modal was not hidden when HTTP request finished with error (in that case when user was associated with tenant). Fixed that.