### PR TITLE
STAGE-188 - WhiteLabel allow changing login title and text

### DIFF
--- a/app/components/Login.js
+++ b/app/components/Login.js
@@ -52,7 +52,7 @@ export default class Login extends Component {
                         isHeaderTextPresent &&
                         <div className="loginHeader">
                             {loginPageHeader && <h2>{loginPageHeader}</h2>}
-                            {loginPageText && <span>{loginPageText}</span>}
+                            {loginPageText && <p>{loginPageText}</p>}
                         </div>
                     }
 

--- a/app/styles/style.scss
+++ b/app/styles/style.scss
@@ -246,7 +246,7 @@ a:hover {
   top: 0;
   bottom: 0;
 
-  .configManagerContainer, .loginContainer,.maintenanceContainer {
+  .configManagerContainer, .loginContainer, .maintenanceContainer {
     margin: auto;
     width: 400px;
     height: 170px;
@@ -257,9 +257,13 @@ a:hover {
     bottom: 0;
   }
 
-  .loginContainer .loginHeader {
-    text-align: center;
-    margin-bottom: 30px;
+  .loginContainer {
+    display: table;
+
+    .loginHeader {
+      text-align: center;
+      margin-bottom: 30px;
+    }
   }
 
   .maintenanceContainer {

--- a/conf/app.json
+++ b/conf/app.json
@@ -10,7 +10,7 @@
     "logoUrl": "/app/images/Cloudify-icon.png",
     "mainColor": "black",
     "pagesLocation": "",
-    "headerTextColor": "white"
+    "headerTextColor": "white",
     "loginPageHeader": "",
     "loginPageText": ""
   },


### PR DESCRIPTION
Implemented possibility to change login title and text using app.json configuration file (STAGE-188)

How it looks like:
![login](https://cloud.githubusercontent.com/assets/5202105/24555109/34762b82-1630-11e7-9c86-b38c8ece9336.PNG)

Code in app.json:
`
   "whiteLabel": {
     "enabled": false,
     "logoUrl": "",
     "mainColor": "",
     "pagesLocation": "",
     "headerTextColor": "",
     "loginPageHeader": "Header",
     "loginPageText": "Text"
   }
`
