### PR TITLE
STAGE-547 - Can't create keys as secrets from the UI

### DIFF
--- a/app/styles/style.scss
+++ b/app/styles/style.scss
@@ -829,3 +829,11 @@ a.underline {
 .emptyPage {
   padding-top: 10rem;
 }
+
+.forceMaxWidth {
+  white-space: pre-wrap;       /* Since CSS 2.1 */
+  white-space: -moz-pre-wrap;  /* Mozilla, since 1999 */
+  white-space: -o-pre-wrap;    /* Opera 7 */
+  word-wrap: break-word;       /* Internet Explorer 5.5+ */
+  max-width: 500px;
+}

--- a/widgets/secrets/src/CreateModal.js
+++ b/widgets/secrets/src/CreateModal.js
@@ -91,8 +91,8 @@ export default class CreateModal extends React.Component {
                                         value={this.state.secretKey} onChange={this._handleInputChange.bind(this)}/>
                         </Form.Field>
                         <Form.Field error={this.state.errors.secretValue}>
-                            <Form.Input name='secretValue' placeholder='Secret value'
-                                        value={this.state.secretValue} onChange={this._handleInputChange.bind(this)}/>
+                            <Form.TextArea name='secretValue' placeholder='Secret value' autoHeight
+                                           value={this.state.secretValue} onChange={this._handleInputChange.bind(this)}/>
                         </Form.Field>
                     </Form>
                 </Modal.Content>

--- a/widgets/secrets/src/SecretsTable.js
+++ b/widgets/secrets/src/SecretsTable.js
@@ -91,7 +91,7 @@ export default class SecretsTable extends React.Component {
     }
 
     render() {
-        let {ErrorMessage, DataTable, Icon, Label} = Stage.Basic;
+        let {ErrorMessage, DataTable, Icon} = Stage.Basic;
         let DeleteModal = Stage.Basic.Confirm;
         let data = this.props.data;
 
@@ -125,8 +125,8 @@ export default class SecretsTable extends React.Component {
                                                 ? this.state.showSecretLoading
                                                     ? <Icon name="spinner" loading />
                                                     : <div>
-                                                        <Label>{this.state.showSecretValue}</Label>
-                                                        <Icon bordered link name="hide" title="Hide secret valeu" onClick={this._onHideSecret.bind(this)} />
+                                                        <pre className="forceMaxWidth">{this.state.showSecretValue}</pre>
+                                                        <Icon bordered link name="hide" title="Hide secret value" onClick={this._onHideSecret.bind(this)} />
                                                       </div>
                                                 : <Icon bordered link name="unhide" title="Show secret value" onClick={this._onShowSecret.bind(this, secret)} />
                                         }

--- a/widgets/secrets/src/UpdateModal.js
+++ b/widgets/secrets/src/UpdateModal.js
@@ -97,8 +97,8 @@ export default class UpdateModal extends React.Component {
                         <Form loading={this.state.loading} errors={this.state.errors}
                               onErrorsDismiss={() => this.setState({errors: {}})}>
                             <Form.Field error={this.state.errors.secretValue}>
-                                <Form.Input name='secretValue' placeholder='Secret value'
-                                            value={this.state.secretValue} onChange={this._handleInputChange.bind(this)}/>
+                                <Form.TextArea name='secretValue' placeholder='Secret value' autoHeight
+                                               value={this.state.secretValue} onChange={this._handleInputChange.bind(this)}/>
                             </Form.Field>
                         </Form>
                     </Modal.Content>


### PR DESCRIPTION
- Updated secrets widget to work properly with multi-line secrets (STAGE-547)
- Improved UI to wrap long lines in secrets table

Secrets table:
![image](https://user-images.githubusercontent.com/5202105/31897865-e562c250-b817-11e7-8516-015265e5eb6c.png)

Secret create/update modal:
![image](https://user-images.githubusercontent.com/5202105/31897894-f98e8110-b817-11e7-9a7d-5e9d30cea922.png)
