### PR TITLE
STAGE-528 - Change the message the graph widgets show when a deployment hasn't been selected yet

### DIFF
--- a/app/reducers/widgetDataReducer.js
+++ b/app/reducers/widgetDataReducer.js
@@ -22,11 +22,11 @@ const widgetData = (state=[], action) => {
             } else {
                 return state.map( (w) => {
                     if (w.id === action.widgetId) {
-                        return Object.assign(w,{
+                        return {...w, ...{
                             loading:true,
                             canceled: false,
                             error: null
-                        })
+                        }}
                     }
                     return w
                 });
@@ -35,24 +35,24 @@ const widgetData = (state=[], action) => {
         case types.WIDGET_FETCH_ERROR:
             return state.map( (w) => {
                 if (w.id === action.widgetId) {
-                    return Object.assign(w,{
+                    return {...w, ...{
                         loading:false,
                         error: action.error,
                         canceled: false
-                    })
+                    }}
                 }
                 return w
             });
         case types.WIDGET_FETCH_RES:
             return state.map( (w) => {
                 if (w.id === action.widgetId) {
-                    return Object.assign(w,{
+                    return {...w, ...{
                         loading:false,
                         data: action.data,
                         recievedAt: action.recievedAt,
                         error: null,
                         canceled: false
-                    })
+                    }}
                 }
                 return w
             });
@@ -60,11 +60,11 @@ const widgetData = (state=[], action) => {
         case types.WIDGET_FETCH_CANCELED:
             return state.map( (w) => {
                 if (w.id === action.widgetId) {
-                    return Object.assign(w,{
+                    return {...w, ...{
                         loading:false,
                         error: null,
                         canceled: true
-                    })
+                    }}
                 }
                 return w
             });

--- a/widgets/graph/src/widget.js
+++ b/widgets/graph/src/widget.js
@@ -144,11 +144,11 @@ Stage.defineWidget({
     },
 
     _isEmptyResponse: function(widget, data) {
-        return _.isEqual(_.get(data, 'state', ''), widget.definition.EMPTY_RESPONSE_STATE);
+        return data.state === widget.definition.EMPTY_RESPONSE_STATE;
     },
 
     _isWidgetNotConfigured: function(widget, data) {
-        return _.isEqual(_.get(data, 'state', ''), widget.definition.UNCONFIGURED_STATE);
+        return data.state === widget.definition.UNCONFIGURED_STATE;
     },
 
     fetchParams: function(widget, toolbox) {


### PR DESCRIPTION
- Changed (reverted actually) the message in graph widget shown when a deployment hasn't been selected yet:
![image](https://user-images.githubusercontent.com/5202105/31993572-e3add0aa-b97d-11e7-8caf-4e9b6ca9877a.png)
- Fixed data fetching reducer to create new data object instead of modfing existing which cause widget not refreshed.