### PR TITLE
STAGE-641 - Test widget for backend feature testing doesn't work

### DIFF
--- a/backend/handler/ManagerHandler.js
+++ b/backend/handler/ManagerHandler.js
@@ -34,7 +34,7 @@ module.exports = (function() {
         options.timeout = timeout || config.app.proxy.timeouts[method.toLowerCase()];
 
         if (headers) {
-            options.headers = headers;
+            options.headers = _.omit(headers, 'host');
         }
 
         if (data) {


### PR DESCRIPTION
The problem occured only when connecting to UI using manager's IP and with SSL certificate.

Fixed ManagerHandler to work properly when SSL connection to manager is used. That also solves the problem with not working blueprints catalog (as there was `ManagerHandler.jsonRequest` used).