### PR TITLE
STAGE-635 Fix error message in upload blueprint from UI - duplicate blueprint name

### DIFF
--- a/app/utils/stageUtils.js
+++ b/app/utils/stageUtils.js
@@ -56,7 +56,7 @@ export default class StageUtils {
 
             if (attributes.length > 0) {
                 if (attributes.length > 1) {
-                    sentence += " with";
+                    sentence += ' with';
                     _.each(attributes,(item, index)=> {
                         sentence += `  ${item.key}=${item.value} ${(index < attributes.length - 1) ? ' and' : ''}`;
                     })


### PR DESCRIPTION
Some of the error messages returned by Manager API includes XML parts like follows:

<Blueprint id=`hello-world` tenant=`default_tenant`> already exists on <Tenant name=`default_tenant`> or with global availability

In the stage we change the XML parts to more readable text. So now tag including more then one attribute will be changed as follow:

![image](https://user-images.githubusercontent.com/23094826/33893104-eb46fcee-df5a-11e7-934a-6307e857e9ed.png)

For tags including only one attribute the attribute name will be skipped.
