### PR TITLE
E2E stabilization - workaround for dropdown and reset pages modal classname fix

### DIFF
--- a/e2e/nightwatch.json
+++ b/e2e/nightwatch.json
@@ -30,7 +30,12 @@
             "end_session_on_fail" : true,
             "desiredCapabilities": {
                 "browserName": "chrome",
-                "marionette": true
+                "marionette": true,
+                "chromeOptions": {
+                    "args": [
+                        "window-size=1600,1600"
+                    ]
+                }
             },
             "globals" : {
                 "usePathResolutionForResources": false,

--- a/e2e/pages/page.js
+++ b/e2e/pages/page.js
@@ -69,7 +69,7 @@ module.exports = {
                 firstWidgetName: '.widget:first-child h5.header span',
                 firstWidgetRemoveIcon: '.widget:first-child .widgetEditButtons i.remove.link.icon.small',
                 firstWidgetConfigureIcon: '.widget:first-child .widgetEditButtons .editWidgetIcon',
-                firstWidgetResizeHandle: '.widget:first-child .ui-resizable-handle',
+                firstWidgetResizeHandle: '.widget:first-child .react-resizable-handle',
                 testWidgetContent: '.widget.testWidgetWidget .widgetContent .statistic .label'
             },
             props: {
@@ -140,10 +140,10 @@ module.exports = {
             }
         },
         resetPagesConfirmModal: {
-            selector: '.resetPagesModal',
+            selector: '.modal',
             elements: {
-                yesButton: '.ui.button.ok',
-                noButton: '.ui.button.cancel'
+                yesButton: '.ui.button.primary',
+                noButton: '.ui.button'
             }
         },
 


### PR DESCRIPTION
- Implemented ugly workaround for *STAGE-653 - Dropdown not works on the bottom of the page* to unblock E2E tests
- Fixed invalid class names for reset pages modal in E2E tests

It should unblock E2E testing, but this is not a solution for *STAGE-653*.