### PR TITLE
Cloudify image builder fix

### DIFF
--- a/backend/handler/WidgetHandler.js
+++ b/backend/handler/WidgetHandler.js
@@ -272,6 +272,7 @@ module.exports = (function() {
         try {
             logger.info('Setting up user widgets directory:', userWidgetsFolder);
             mkdirp.sync(userWidgetsFolder);
+            BackendHandler.initWidgetBackends(userWidgetsFolder, builtInWidgetsFolder);
         } catch (e) {
             logger.error('Could not set up directory, error was:', e);
             process.exit(1);

--- a/backend/server.js
+++ b/backend/server.js
@@ -36,7 +36,6 @@ var GitHub = require('./routes/GitHub');
 var Style = require('./routes/Style');
 var Widgets = require('./routes/Widgets');
 var Templates = require('./routes/Templates');
-var BackendHandler = require('./handler/BackendHandler');
 var WidgetBackend = require('./routes/WidgetBackend');
 var File = require('./routes/File');
 var WidgetHandler = require('./handler/WidgetHandler');
@@ -123,6 +122,5 @@ app.use(function(err, req, res, next) {
     res.status(err.status || 404).send({message: message || err});
 });
 
-BackendHandler.initWidgetBackends();
 WidgetHandler.init();
 TemplateHandler.init();

--- a/webpack.config-prod.js
+++ b/webpack.config-prod.js
@@ -39,10 +39,6 @@ module.exports = {
             { from: 'templates',
                 to: 'templates'}
         ]),
-        new CopyWebpackPlugin([
-            { from: 'userData',
-                to: 'userData'}
-        ]),
         new HtmlWebpackPlugin({
             template: 'app/index.tmpl.html',
             inject: 'body',


### PR DESCRIPTION
- Fixed widget backend handler to have user widgets folders ready before starting initialization
- Fixed widget backend handler to scan for backend.js files in built-in and user widgets folder
- Removed coping of userData folder in production build