### PR TITLE
CY-161 - Update message in login page for unauthorized error

### DIFF
--- a/backend/routes/Auth.js
+++ b/backend/routes/Auth.js
@@ -35,7 +35,7 @@ router.post('/login', (req, res) => {
     .catch((err) => {
         logger.error(err);
         if(err.error_code === 'unauthorized_error'){
-            res.status(401).send({message: err.message, error: err});
+            res.status(401).send({message: err.message || 'Invalid credentials', error: err});
         } else if (err.error_code === 'maintenance_mode_active') {
             res.status(423).send({message: 'Cloudify Manager is currently in maintenance mode', error: err});
         } else {

--- a/backend/routes/Auth.js
+++ b/backend/routes/Auth.js
@@ -35,7 +35,7 @@ router.post('/login', (req, res) => {
     .catch((err) => {
         logger.error(err);
         if(err.error_code === 'unauthorized_error'){
-            res.status(401).send({message: 'Invalid credentials', error: err});
+            res.status(401).send({message: err.message, error: err});
         } else if (err.error_code === 'maintenance_mode_active') {
             res.status(423).send({message: 'Cloudify Manager is currently in maintenance mode', error: err});
         } else {


### PR DESCRIPTION
Screenshot example:
![image](https://user-images.githubusercontent.com/5202105/37030107-fd88aa12-2139-11e8-85be-1a7b2ef1da90.png)

Possibly all of the errors generated by manager with unauthorized error:
1. API token authentication failed
2. OKTA authentication failed
3. No authentication info provided
4. Authentication failed for <User username={0}>
5. Authentication failed for {0}
6. Authentication token is invalid:\n{0}
7. Token is expired
8. No authentication info provided
9. Authentication failed for {0}
