### PR TITLE
CY-204 - Allow sorting fields in the logs and events table

### DIFF
--- a/widgets/events/src/EventsTable.js
+++ b/widgets/events/src/EventsTable.js
@@ -63,16 +63,16 @@ export default class EventsTable extends React.Component {
                            className="eventsTable">
 
                     <DataTable.Column label="" width="40px" show={fieldsToShow.indexOf('Icon') >= 0}/>
-                    <DataTable.Column label="Timestamp" width="10%" show={fieldsToShow.indexOf('Timestamp') >= 0}/>
-                    <DataTable.Column label="Type" show={fieldsToShow.indexOf('Type') >= 0}/>
-                    <DataTable.Column label="Blueprint" show={!this.props.data.blueprintId && !this.props.data.deploymentId &&
+                    <DataTable.Column label="Timestamp" name="timestamp" width="10%" show={fieldsToShow.indexOf('Timestamp') >= 0}/>
+                    <DataTable.Column label="Type" name="event_type" show={fieldsToShow.indexOf('Type') >= 0}/>
+                    <DataTable.Column label="Blueprint" name="blueprint_id" show={!this.props.data.blueprintId && !this.props.data.deploymentId &&
                                             !this.props.data.executionId && fieldsToShow.indexOf('Blueprint') >= 0} />
-                    <DataTable.Column label="Deployment" show={!this.props.data.deploymentId && !this.props.data.executionId &&
+                    <DataTable.Column label="Deployment" name="deployment_id" show={!this.props.data.deploymentId && !this.props.data.executionId &&
                                             fieldsToShow.indexOf('Deployment') >= 0} />
-                    <DataTable.Column label="Workflow" show={!this.props.data.executionId && fieldsToShow.indexOf('Workflow') >= 0} />
-                    <DataTable.Column label="Operation" show={fieldsToShow.indexOf('Operation') >= 0}/>
-                    <DataTable.Column label="Node Name" show={fieldsToShow.indexOf('Node Name') >= 0}/>
-                    <DataTable.Column label="Node Id" show={fieldsToShow.indexOf('Node Id') >= 0}/>
+                    <DataTable.Column label="Workflow" name="workflow_id" show={!this.props.data.executionId && fieldsToShow.indexOf('Workflow') >= 0} />
+                    <DataTable.Column label="Operation" name="operation" show={fieldsToShow.indexOf('Operation') >= 0}/>
+                    <DataTable.Column label="Node Name" name="node_name" show={fieldsToShow.indexOf('Node Name') >= 0}/>
+                    <DataTable.Column label="Node Id" name="node_instance_id" show={fieldsToShow.indexOf('Node Id') >= 0}/>
                     <DataTable.Column label="Message" show={fieldsToShow.indexOf('Message') >= 0}/>
 
                     {

--- a/widgets/eventsFilter/src/widget.js
+++ b/widgets/eventsFilter/src/widget.js
@@ -9,7 +9,7 @@ Stage.defineWidget({
     name: "Events/logs filter",
     description: 'Adds a filter section for events and logs',
     initialWidth: 12,
-    initialHeight: 6,
+    initialHeight: 7,
     color: "pink",
     showHeader: false,
     showBorder: false,


### PR DESCRIPTION
- Allow sorting fields in the logs and events table
![image](https://user-images.githubusercontent.com/5202105/37527935-8b40949a-2933-11e8-8392-77f1e1127d1d.png)
- Updated height of events and logs filter widget

