### PR TITLE
CY-370 & CY-367 - Deployment Inputs handling

### DIFF
--- a/widgets/common/src/DeployBlueprintModal.js
+++ b/widgets/common/src/DeployBlueprintModal.js
@@ -14,6 +14,7 @@ class DeployBlueprintModal extends React.Component {
 
     static DEPLOYMENT_INPUT_CLASSNAME = 'deploymentInput';
     static EMPTY_BLUEPRINT = {id: '', plan: {inputs: {}}};
+    static EMPTY_STRING = '""';
 
     static initialState = {
         loading: false,
@@ -65,7 +66,6 @@ class DeployBlueprintModal extends React.Component {
 
     _submitDeploy() {
         let errors = {};
-        const EMPTY_STRING = '""';
 
         if (!this.props.blueprint) {
             errors['error'] = 'Blueprint not selected';
@@ -77,15 +77,13 @@ class DeployBlueprintModal extends React.Component {
 
         let deploymentInputs = {};
         _.forEach(this.props.blueprint.plan.inputs, (inputObj, inputName) => {
-            let inputValue = this.state.deploymentInputs[inputName];
-            if (_.isEmpty(inputValue)) {
-                if (_.isNil(inputObj.default)) {
-                    errors[inputName] = `Please provide ${inputName}`;
-                }
-            } else if (inputValue === EMPTY_STRING) {
-                deploymentInputs[inputName] = '';
+            let stringInputValue = this.state.deploymentInputs[inputName];
+            let typedInputValue = Stage.Common.JsonUtils.getTypedValue(stringInputValue);
+
+            if (_.isEmpty(stringInputValue) && _.isNil(inputObj.default)) {
+                errors[inputName] = `Please provide ${inputName}`;
             } else {
-                deploymentInputs[inputName] = inputValue;
+                deploymentInputs[inputName] = typedInputValue;
             }
         });
 
@@ -125,13 +123,12 @@ class DeployBlueprintModal extends React.Component {
             let deploymentInputs = {};
 
             _.forEach(blueprintPlanInputs, (inputObj, inputName) => {
-                let inputValue = _.isString(inputs[inputName]) ? inputs[inputName] : JSON.stringify(inputs[inputName]);
-                if (_.isEmpty(inputValue)) {
-                    if (_.isNil(inputObj.default)) {
-                        notFoundInputs.push(inputName);
-                    }
+                let stringValue = Stage.Common.JsonUtils.getStringValue(inputs[inputName])
+
+                if (_.isEmpty(stringValue) && _.isNil(inputObj.default)) {
+                    notFoundInputs.push(inputName);
                 } else {
-                    deploymentInputs[inputName] = inputValue;
+                    deploymentInputs[inputName] = stringValue;
                 }
             });
 

--- a/widgets/common/src/JsonUtils.js
+++ b/widgets/common/src/JsonUtils.js
@@ -4,15 +4,13 @@
 
 class JsonUtils {
     static stringify(value, indented = false, ignoreEmpty = false) {
-        if (!ignoreEmpty && _.isEmpty(value)) {
+        if (!ignoreEmpty && value === '') {
             return '';
         }
 
         let stringifiedValue = value;
-        try {
+        if (JsonUtils.toType(value) === 'object' || JsonUtils.toType(value) === 'array') {
             stringifiedValue = JSON.stringify(value, null, indented ? 2 : 0);
-        } catch (e) {
-            console.error(`Cannot parse value '${value}'. `, e);
         }
 
         return _.trim(stringifiedValue, '"');
@@ -28,6 +26,60 @@ class JsonUtils {
         }
     }
 
+    static toType(obj) {
+        return ({}).toString.call(obj).match(/\s([a-zA-Z]+)/)[1].toLowerCase();
+    }
+
+    static getStringValue(value) {
+        let ret = null;
+
+        switch (JsonUtils.toType(value)) {
+            case 'array':
+            case 'object':
+                ret = JSON.stringify(value);
+                break;
+            case 'boolean':
+            case 'string':
+            case 'number':
+            default:
+                ret = String(value);
+                break;
+        }
+
+        return ret;
+    }
+
+    static getTypedValue(value) {
+        let initialType = JsonUtils.toType(value);
+
+        if (initialType === 'string') {
+            // Boolean
+            if (value === 'true') {
+                return true;
+            } else if (value === 'false') {
+                return false;
+            }
+
+            // Number
+            let numericValue = Number(value);
+            if (!isNaN(numericValue)) {
+                return numericValue;
+            }
+
+            // Object or Array
+            let jsonValue = null;
+            try {
+                jsonValue = JSON.parse(value);
+            } catch (e) {
+                return value;
+            }
+
+            return jsonValue;
+
+        } else {
+            return value;
+        }
+    }
 }
 
 Stage.defineCommon({

--- a/widgets/deploymentButton/src/DeployModal.js
+++ b/widgets/deploymentButton/src/DeployModal.js
@@ -97,7 +97,6 @@ export default class DeployModal extends React.Component {
 
     _submitDeploy () {
         let errors = {};
-        const EMPTY_STRING = '""';
 
         if (_.isEmpty(this.state.blueprint.id)) {
             errors['blueprintName']='Please select blueprint from the list';
@@ -109,15 +108,13 @@ export default class DeployModal extends React.Component {
 
         let deploymentInputs = {};
         _.forEach(this.state.blueprint.plan.inputs, (inputObj, inputName) => {
-            let inputValue = this.state.deploymentInputs[inputName];
-            if (_.isEmpty(inputValue)) {
-                if (_.isNil(inputObj.default)) {
-                    errors[inputName] = `Please provide ${inputName}`;
-                }
-            } else if (inputValue === EMPTY_STRING) {
-                deploymentInputs[inputName] = '';
+            let stringInputValue = this.state.deploymentInputs[inputName];
+            let typedInputValue = Stage.Common.JsonUtils.getTypedValue(stringInputValue);
+
+            if (_.isEmpty(stringInputValue) && _.isNil(inputObj.default)) {
+                errors[inputName] = `Please provide ${inputName}`;
             } else {
-                deploymentInputs[inputName] = inputValue;
+                deploymentInputs[inputName] = typedInputValue;
             }
         });
 
@@ -157,13 +154,12 @@ export default class DeployModal extends React.Component {
             let deploymentInputs = {};
 
             _.forEach(blueprintPlanInputs, (inputObj, inputName) => {
-                let inputValue = _.isString(inputs[inputName]) ? inputs[inputName] : JSON.stringify(inputs[inputName]);
-                if (_.isEmpty(inputValue)) {
-                    if (_.isNil(inputObj.default)) {
-                        notFoundInputs.push(inputName);
-                    }
+                let stringValue = Stage.Common.JsonUtils.getStringValue(inputs[inputName])
+
+                if (_.isEmpty(stringValue) && _.isNil(inputObj.default)) {
+                    notFoundInputs.push(inputName);
                 } else {
-                    deploymentInputs[inputName] = inputValue;
+                    deploymentInputs[inputName] = stringValue;
                 }
             });
 

--- a/widgets/inputs/src/InputsTable.js
+++ b/widgets/inputs/src/InputsTable.js
@@ -63,11 +63,14 @@ export default class extends React.Component {
                                     </Header>
                                 </DataTable.Data>
                                 <DataTable.Data>
-                                    {input.value &&
+                                    {!_.isNil(input.value) &&
                                         <Popup position='top left' wide>
-                                            <Popup.Trigger><span>{JsonUtils.stringify(input.value, false)}</span></Popup.Trigger>
-                                            <HighlightText
-                                                className='json'>{JsonUtils.stringify(input.value, true)}</HighlightText>
+                                            <Popup.Trigger>
+                                                <span>{JsonUtils.getStringValue(input.value)}</span>
+                                            </Popup.Trigger>
+                                            <HighlightText className='json'>
+                                                {JsonUtils.stringify(input.value, true)}
+                                            </HighlightText>
                                         </Popup>
                                     }
                                 </DataTable.Data>

--- a/widgets/outputs/src/OutputsTable.js
+++ b/widgets/outputs/src/OutputsTable.js
@@ -60,9 +60,12 @@ export default class extends React.Component {
                                 <DataTable.Data>
                                     {output.value &&
                                         <Popup position='top left' wide>
-                                            <Popup.Trigger><span>{JsonUtils.stringify(output.value, false)}</span></Popup.Trigger>
-                                            <HighlightText
-                                                className='json'>{JsonUtils.stringify(output.value, true)}</HighlightText>
+                                            <Popup.Trigger>
+                                                <span>{JsonUtils.getStringValue(output.value)}</span>
+                                            </Popup.Trigger>
+                                            <HighlightText className='json'>
+                                                {JsonUtils.stringify(output.value, true)}
+                                            </HighlightText>
                                         </Popup>
                                     }
                                 </DataTable.Data>


### PR DESCRIPTION
- Fixed *CLI and GUI don't parse blueprint input files consistently regarding empty strings* (CY-367)
- Fixed *Deployment inputs: only strings supported (dict & list should also be available)* (CY-370)
- Updated Inputs, Outputs widgets and Deployment Creation modals.
