### PR TITLE
(work-in-progress) CY-373 - Drilldown pages don't work after page name change or parent page name change or page removal

### DIFF
--- a/app/actions/widgets.js
+++ b/app/actions/widgets.js
@@ -101,7 +101,7 @@ export function addWidgetDrilldownPage(widgetId,drillDownName,drillDownPageId) {
 
 }
 
-export function drillDownToPage(widget,defaultTemplate,widgetDefinitions,drilldownContext,drilldownPageName,location) {
+export function drillDownToPage(widget,defaultTemplate,widgetDefinitions,location,drilldownContext,drilldownPageName) {
 
     return function (dispatch, getState) {
         var isPageEditMode = _.get(getState().templateManagement, 'isPageEditMode');
@@ -111,7 +111,7 @@ export function drillDownToPage(widget,defaultTemplate,widgetDefinitions,drilldo
 
         let currentPage = _.replace(location.pathname, /.*\/page\//, '');
         let newPageId = _.snakeCase(currentPage + ' ' + defaultTemplate.name);
-        let isDrilldownPagePresent = _.find(getState().pages, {'id': newPageId});
+        let isDrilldownPagePresent = !!_.find(getState().pages, {'id': newPageId});
 
         if (!isDrilldownPagePresent) {
             dispatch(createDrilldownPage(newPageId,defaultTemplate.name));

--- a/app/actions/widgets.js
+++ b/app/actions/widgets.js
@@ -101,7 +101,7 @@ export function addWidgetDrilldownPage(widgetId,drillDownName,drillDownPageId) {
 
 }
 
-export function drillDownToPage(widget,defaultTemplate,widgetDefinitions,drilldownContext,drilldownPageName) {
+export function drillDownToPage(widget,defaultTemplate,widgetDefinitions,drilldownContext,drilldownPageName,location) {
 
     return function (dispatch, getState) {
         var isPageEditMode = _.get(getState().templateManagement, 'isPageEditMode');
@@ -109,11 +109,11 @@ export function drillDownToPage(widget,defaultTemplate,widgetDefinitions,drilldo
             return dispatch(drillDownWarning(true));
         }
 
-        var pageId = widget.drillDownPages[defaultTemplate.name];
-        if (!pageId) {
-            var currentPage = _.replace(window.location.pathname, /.*\/page\//, '');
-            var newPageId = _.snakeCase(currentPage + ' ' + defaultTemplate.name);
+        let currentPage = _.replace(location.pathname, /.*\/page\//, '');
+        let newPageId = _.snakeCase(currentPage + ' ' + defaultTemplate.name);
+        let isDrilldownPagePresent = _.find(getState().pages, {'id': newPageId});
 
+        if (!isDrilldownPagePresent) {
             dispatch(createDrilldownPage(newPageId,defaultTemplate.name));
             _.each(defaultTemplate.widgets,(widget)=>{
                 var widgetDefinition = _.find(widgetDefinitions,{id:widget.definition});
@@ -121,10 +121,9 @@ export function drillDownToPage(widget,defaultTemplate,widgetDefinitions,drilldo
             });
 
             dispatch(addWidgetDrilldownPage(widget.id,defaultTemplate.name,newPageId));
-            pageId = newPageId;
         }
 
-        dispatch(selectPage(pageId,true,drilldownContext,drilldownPageName));
+        dispatch(selectPage(newPageId,true,drilldownContext,drilldownPageName));
     }
 }
 

--- a/app/containers/Page.js
+++ b/app/containers/Page.js
@@ -78,7 +78,7 @@ const mapDispatchToProps = (dispatch, ownProps) => {
                 drilldownContext.push({pageName: pagesList[i].name, context: pagesList[i].context});
             }
             dispatch(setDrilldownContext(drilldownContext));
-            dispatch(selectPage(page.id,page.isDrillDown,page.context,page.name));
+            dispatch(selectPage(page.id, page.isDrillDown, page.context, page.isDrillDown ? page.name : null));
         },
         onPageRemoved: (page) => {
             dispatch(removePage(page.id));

--- a/app/reducers/pageReducer.js
+++ b/app/reducers/pageReducer.js
@@ -83,10 +83,28 @@ const pages = (state = [], action) => {
                 })
             });
         case types.REMOVE_PAGE:
-            var removeIndex = _.findIndex(state,{id:action.pageId});
+            let pageToBeRemoved = _.find(state, (page) => page.id === action.pageId);
+
+            // get children and grandchildren (drill down pages and drill down pages of drill down pages) if they exist
+            let childrenOfPageToBeRemoved = [];
+            let grandChildrenOfPageToBeRemoved = [];
+            if (!_.isEmpty(pageToBeRemoved.children)) {
+                childrenOfPageToBeRemoved = _.filter(state, (page) => _.includes(pageToBeRemoved.children, page.id));
+                if (!_.isEmpty(childrenOfPageToBeRemoved)) {
+                    grandChildrenOfPageToBeRemoved
+                        = _.flatten(_.map(childrenOfPageToBeRemoved, (child) => child.children
+                            ? _.filter(state, (page) => _.includes(child.children, page.id))
+                            : [])
+                        );
+                }
+            }
+            let pagesToBeRemoved = [pageToBeRemoved, ...childrenOfPageToBeRemoved, ...grandChildrenOfPageToBeRemoved];
+
+            // create new list of pages
+            let newState = _.difference(state, pagesToBeRemoved);
+
             return [
-                ...state.slice(0,removeIndex),
-                ...state.slice(removeIndex+1)
+                ...newState
             ];
         case types.RENAME_PAGE:
         case types.UPDATE_PAGE_DESCRIPTION:

--- a/app/utils/Toolbox.js
+++ b/app/utils/Toolbox.js
@@ -37,8 +37,8 @@ class Toolbox {
         this._widgetsConfig = state.config.widgets;
     }
 
-    drillDown(widget,defaultTemplate,drilldownContext,drilldownPageName) {
-        this.store.dispatch(drillDownToPage(widget,this.templates.pagesDef[defaultTemplate],this.widgetDefinitions,drilldownContext,drilldownPageName));
+    drillDown(widget,defaultTemplate,drilldownContext,drilldownPageName,location) {
+        this.store.dispatch(drillDownToPage(widget,this.templates.pagesDef[defaultTemplate],this.widgetDefinitions,drilldownContext,drilldownPageName,location));
     }
 
     goToHomePage() {

--- a/app/utils/Toolbox.js
+++ b/app/utils/Toolbox.js
@@ -37,8 +37,8 @@ class Toolbox {
         this._widgetsConfig = state.config.widgets;
     }
 
-    drillDown(widget,defaultTemplate,drilldownContext,drilldownPageName,location) {
-        this.store.dispatch(drillDownToPage(widget,this.templates.pagesDef[defaultTemplate],this.widgetDefinitions,drilldownContext,drilldownPageName,location));
+    drillDown(widget,defaultTemplate,location,drilldownContext,drilldownPageName) {
+        this.store.dispatch(drillDownToPage(widget,this.templates.pagesDef[defaultTemplate],this.widgetDefinitions,location,drilldownContext,drilldownPageName));
     }
 
     goToHomePage() {

--- a/widgets/blueprints/src/BlueprintsList.js
+++ b/widgets/blueprints/src/BlueprintsList.js
@@ -31,8 +31,7 @@ class BlueprintListWithRouter extends React.Component {
 
     _selectBlueprint (item){
         if (this.props.widget.configuration.clickToDrillDown) {
-            this.props.toolbox.drillDown(this.props.widget, 'blueprint', {blueprintId: item.id},
-                                         item.id, this.props.location);
+            this.props.toolbox.drillDown(this.props.widget, 'blueprint', this.props.location, {blueprintId: item.id}, item.id);
         } else {
             var oldSelectedBlueprintId = this.props.toolbox.getContext().getValue('blueprintId');
             this.props.toolbox.getContext().setValue('blueprintId',item.id === oldSelectedBlueprintId ? null : item.id);

--- a/widgets/blueprints/src/BlueprintsList.js
+++ b/widgets/blueprints/src/BlueprintsList.js
@@ -2,10 +2,14 @@
  * Created by kinneretzin on 02/10/2016.
  */
 
+import {withRouter} from 'react-router-dom';
+
 import BlueprintsTable from './BlueprintsTable';
 import BlueprintsCatalog from './BlueprintsCatalog';
 
-export default class BlueprintList extends React.Component {
+export default withRouter(props => <BlueprintListWithRouter {...props}/>);
+
+class BlueprintListWithRouter extends React.Component {
 
     constructor(props,context) {
         super(props,context);
@@ -27,7 +31,8 @@ export default class BlueprintList extends React.Component {
 
     _selectBlueprint (item){
         if (this.props.widget.configuration.clickToDrillDown) {
-            this.props.toolbox.drillDown(this.props.widget,'blueprint',{blueprintId: item.id}, item.id);
+            this.props.toolbox.drillDown(this.props.widget, 'blueprint', {blueprintId: item.id},
+                                         item.id, this.props.location);
         } else {
             var oldSelectedBlueprintId = this.props.toolbox.getContext().getValue('blueprintId');
             this.props.toolbox.getContext().setValue('blueprintId',item.id === oldSelectedBlueprintId ? null : item.id);

--- a/widgets/deployments/src/DeploymentsList.js
+++ b/widgets/deployments/src/DeploymentsList.js
@@ -40,8 +40,7 @@ class DeploymentsListWithRouter extends React.Component {
 
     _selectDeployment(item) {
         if (this.props.widget.configuration.clickToDrillDown) {
-            this.props.toolbox.drillDown(this.props.widget, 'deployment', {deploymentId: item.id},
-                                         item.id, this.props.location);
+            this.props.toolbox.drillDown(this.props.widget, 'deployment', this.props.location, {deploymentId: item.id}, item.id);
         } else {
             var oldSelectedDeploymentId = this.props.toolbox.getContext().getValue('deploymentId');
             this.props.toolbox.getContext().setValue('deploymentId',item.id === oldSelectedDeploymentId ? null : item.id);

--- a/widgets/deployments/src/DeploymentsList.js
+++ b/widgets/deployments/src/DeploymentsList.js
@@ -2,11 +2,15 @@
  * Created by kinneretzin on 18/10/2016.
  */
 
+import {withRouter} from 'react-router-dom';
+
 import MenuAction from './MenuAction';
 import DeploymentsSegment from './DeploymentsSegment';
 import DeploymentsTable from './DeploymentsTable';
 
-export default class extends React.Component {
+export default withRouter(props => <DeploymentsListWithRouter {...props}/>);
+
+class DeploymentsListWithRouter extends React.Component {
 
     constructor(props,context) {
         super(props,context);
@@ -36,7 +40,8 @@ export default class extends React.Component {
 
     _selectDeployment(item) {
         if (this.props.widget.configuration.clickToDrillDown) {
-            this.props.toolbox.drillDown(this.props.widget,'deployment',{deploymentId: item.id}, item.id);
+            this.props.toolbox.drillDown(this.props.widget, 'deployment', {deploymentId: item.id},
+                                         item.id, this.props.location);
         } else {
             var oldSelectedDeploymentId = this.props.toolbox.getContext().getValue('deploymentId');
             this.props.toolbox.getContext().setValue('deploymentId',item.id === oldSelectedDeploymentId ? null : item.id);


### PR DESCRIPTION
I've spotted today another bug related to drill down pages.
I suspect that this one can help us with *CY-343 Duplicated widgets in deployment drill-down page*.

---
**UPDATE:** 
Bug is not as simple to solve as I thought it to be at the beginning. I have extended the scope of it a bit as drill down page feature is quite messy. I need to clean it 