### PR TITLE
CY-350 - When DDL's index changes Values delete- UI

### DIFF
--- a/widgets/common/src/UpdateDeploymentModal.js
+++ b/widgets/common/src/UpdateDeploymentModal.js
@@ -177,21 +177,22 @@ class UpdateDeploymentModal extends Component {
             let actions = new Stage.Common.BlueprintActions(this.props.toolbox);
             actions.doGetFullBlueprintData({id: data.value}).then((blueprint)=>{
                 let deploymentInputs = {};
-                if (_.isEqual(this.props.deployment.blueprint_id, blueprint.id)) {
-                    let typedDeploymentInputs = this.props.deployment.inputs;
-                    _.forEach(typedDeploymentInputs, (inputValue, inputName) => {
-                        let stringValue = Stage.Common.JsonUtils.getStringValue(inputValue);
+                let currentDeploymentInputs = this.props.deployment.inputs;
+
+                _.forEach(blueprint.plan.inputs, (inputObj, inputName) => {
+                    if (!_.isUndefined(currentDeploymentInputs[inputName])) {
+                        let stringValue = Stage.Common.JsonUtils.getStringValue(currentDeploymentInputs[inputName]);
 
                         if (stringValue === '') {
                             deploymentInputs[inputName] = Stage.Common.DeployBlueprintModal.EMPTY_STRING;
                         } else {
                             deploymentInputs[inputName] = stringValue;
                         }
-                    });
+                    } else {
+                        deploymentInputs[inputName] = '';
+                    }
+                });
 
-                } else {
-                    _.forEach(blueprint.plan.inputs, (inputObj, inputName) => deploymentInputs[inputName] = '');
-                }
                 this.setState({deploymentInputs, blueprint, errors: {}, loading: false});
             }).catch((err)=> {
                 this.setState({blueprint: Stage.Common.DeployBlueprintModal.EMPTY_BLUEPRINT, loading: false, errors: {error: err.message}});


### PR DESCRIPTION
When blueprint changes in Deployment Update modal then inputs which exists in both (original and selected blueprint) are filled with original value:

# Deployment Update modal (original blueprint - nodecellar)
![image](https://user-images.githubusercontent.com/5202105/40718418-2d3f08dc-6410-11e8-827e-2de1635c6016.png)

# Deployment Update modal (changed blueprint - hello-world)
![image](https://user-images.githubusercontent.com/5202105/40718434-38bd266c-6410-11e8-8b27-cfa751b0ae81.png)
