### PR TITLE
Fixed non-admin template to redirect to System Resources page on click on Number of Plugins widget

### DIFF
--- a/templates/pages/app.json
+++ b/templates/pages/app.json
@@ -29,7 +29,10 @@
       "height": 8,
       "definition": "pluginsNum",
       "x": 4,
-      "y": 0
+      "y": 0,
+      "configuration":{
+        "page": "system_resources"
+      }
     },
     {
       "name": "Number of nodes",


### PR DESCRIPTION
As https://github.com/cloudify-cosmo/cloudify-stage/pull/578 was not merged and probably will not be soon, I have created separate PR for the CY-352 fix.