### PR TITLE
CY-425 - Expose "ended_at" field in executions list

### DIFF
--- a/widgets/executions/src/ExecutionsTable.js
+++ b/widgets/executions/src/ExecutionsTable.js
@@ -89,12 +89,14 @@ export default class extends React.Component {
                                  show={fieldsToShow.indexOf('Blueprint') >= 0 && !this.props.data.blueprintId}/>
                     <DataTable.Column label="Deployment" name="deployment_id" width="15%"
                                  show={fieldsToShow.indexOf('Deployment') >= 0 && !this.props.data.deploymentId}/>
-                    <DataTable.Column label="Workflow" name="workflow_id" width="20%"
+                    <DataTable.Column label="Workflow" name="workflow_id" width="15%"
                                  show={fieldsToShow.indexOf('Workflow') >= 0}/>
-                    <DataTable.Column label="Id" name="id" width="15%"
+                    <DataTable.Column label="Id" name="id" width="10%"
                                  show={fieldsToShow.indexOf('Id') >= 0}/>
                     <DataTable.Column label="Created" name="created_at" width="10%"
                                  show={fieldsToShow.indexOf('Created') >= 0}/>
+                    <DataTable.Column label="Ended" name="ended_at" width="10%"
+                                 show={fieldsToShow.indexOf('Ended') >= 0}/>
                     <DataTable.Column label="Creator" name='created_by' width="5%"
                                       show={fieldsToShow.indexOf('Creator') >= 0}/>
                     <DataTable.Column label="IsSystem" name="is_system_workflow" width="5%"
@@ -121,6 +123,7 @@ export default class extends React.Component {
                                     <DataTable.Data>{item.workflow_id}</DataTable.Data>
                                     <DataTable.Data>{item.id}</DataTable.Data>
                                     <DataTable.Data>{item.created_at}</DataTable.Data>
+                                    <DataTable.Data>{item.ended_at}</DataTable.Data>
                                     <DataTable.Data>{item.created_by}</DataTable.Data>
                                     <DataTable.Data className="center aligned">
                                         <Checkmark value={item.is_system_workflow}/>

--- a/widgets/executions/src/widget.js
+++ b/widgets/executions/src/widget.js
@@ -24,7 +24,7 @@ Stage.defineWidget({
             Stage.GenericConfig.POLLING_TIME_CONFIG(5),
             Stage.GenericConfig.PAGE_SIZE_CONFIG(),
             {id: "fieldsToShow",name: "List of fields to show in the table", placeHolder: "Select fields from the list",
-                items: ["Blueprint","Deployment","Workflow","Id","Created","Creator","IsSystem","Params","Status"],
+                items: ["Blueprint","Deployment","Workflow","Id","Created","Ended","Creator","IsSystem","Params","Status"],
                 default: 'Blueprint,Deployment,Workflow,Created,Creator,IsSystem,Params,Status', type: Stage.Basic.GenericField.MULTI_SELECT_LIST_TYPE},
             {id: "showSystemExecutions", name: "Show system executions", default: true, type: Stage.Basic.GenericField.BOOLEAN_TYPE},
             Stage.GenericConfig.SORT_COLUMN_CONFIG('created_at'),
@@ -63,6 +63,7 @@ Stage.defineWidget({
                 return Object.assign({},item,{
                     blueprint_id: _.get(executionIdToBlueprintIdMap, item.id, item.blueprint_id),
                     created_at: Stage.Utils.formatTimestamp(item.created_at), //2016-07-20 09:10:53.103579
+                    ended_at: Stage.Utils.formatTimestamp(item.ended_at),
                     isSelected: item.id === selectedExecution
                 })
             }),


### PR DESCRIPTION
# Executions widget

## Main look
![image](https://user-images.githubusercontent.com/5202105/41718788-541d3dd4-755e-11e8-8136-b21e0a9718c3.png)

## Configuration
![image](https://user-images.githubusercontent.com/5202105/41718814-6d139f22-755e-11e8-8304-e6030dd558c6.png)

