### PR TITLE
CY-476 - Copy to clipboard buttons in modal windows shall be in modal footer instead of modal content

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,14 +29,57 @@ jobs:
           name: Build application
           command: npm run build
 
-      - run:
-          name: Run tests
-          command: npm run prodtest
+  test:
+    docker:
+      - image: circleci/node:8.9-stretch
+    working_directory: ~/repo
+      steps:
+        - attach_workspace:
+            at: ~/repo
+        - run:
+            name: Run tests
+            command: npm run prodtest
 
-      - run:
-          name: Check code style
-          command: npm run lint
+  check:
+    docker:
+      - image: circleci/node:8.9-stretch
+    working_directory: ~/repo
+      steps:
+        - attach_workspace:
+            at: ~/repo
+        - run:
+            name: Check code style
+            command: npm run lint
+        - run:
+            name: Check bundle size
+            command: npm run size
 
-      - run:
-          name: Check bundle size
-          command: npm run size
+  docWidgets:
+    docker:
+      - image: circleci/node:8.9-stretch
+    working_directory: ~/repo
+      steps:
+        - attach_workspace:
+            at: ~/repo
+        - run:
+            name: Generate widgets documentation
+            command: npm run docWidgets
+        - run:
+            name: Check differences
+            command: git diff --exit-code
+
+workflows:
+  version: 2
+  build-deploy:
+    jobs:
+      - build:
+
+      - test:
+          requires:
+            - build
+      - check:
+          requires:
+            - build
+      - docWidgets:
+          requires:
+            - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,57 +29,14 @@ jobs:
           name: Build application
           command: npm run build
 
-  test:
-    docker:
-      - image: circleci/node:8.9-stretch
-    working_directory: ~/repo
-      steps:
-        - attach_workspace:
-            at: ~/repo
-        - run:
-            name: Run tests
-            command: npm run prodtest
+      - run:
+          name: Run tests
+          command: npm run prodtest
 
-  check:
-    docker:
-      - image: circleci/node:8.9-stretch
-    working_directory: ~/repo
-      steps:
-        - attach_workspace:
-            at: ~/repo
-        - run:
-            name: Check code style
-            command: npm run lint
-        - run:
-            name: Check bundle size
-            command: npm run size
+      - run:
+          name: Check code style
+          command: npm run lint
 
-  docWidgets:
-    docker:
-      - image: circleci/node:8.9-stretch
-    working_directory: ~/repo
-      steps:
-        - attach_workspace:
-            at: ~/repo
-        - run:
-            name: Generate widgets documentation
-            command: npm run docWidgets
-        - run:
-            name: Check differences
-            command: git diff --exit-code
-
-workflows:
-  version: 2
-  build-deploy:
-    jobs:
-      - build:
-
-      - test:
-          requires:
-            - build
-      - check:
-          requires:
-            - build
-      - docWidgets:
-          requires:
-            - build
+      - run:
+          name: Check bundle size
+          command: npm run size

--- a/widgets/executions/src/ExecutionsTable.js
+++ b/widgets/executions/src/ExecutionsTable.js
@@ -158,11 +158,14 @@ export default class extends React.Component {
                     }
                 </DataTable>
 
-                <Modal open={this.state.executionParametersModalOpen} onClose={()=>this.setState({execution: null, executionParametersModalOpen: false})}>
+                <Modal open={this.state.executionParametersModalOpen} closeIcon
+                       onClose={()=>this.setState({execution: null, executionParametersModalOpen: false})}>
                     <Modal.Content scrolling>
                         <HighlightText className='json'>{executionParameters}</HighlightText>
-                        <CopyToClipboardButton content='Copy Parameters' text={executionParameters} className='rightFloated' />
                     </Modal.Content>
+                    <Modal.Actions>
+                        <CopyToClipboardButton content='Copy Parameters' text={executionParameters} />
+                    </Modal.Actions>
                 </Modal>
 
                 <UpdateDetailsModal open={this.state.deploymentUpdateModalOpen}
@@ -170,11 +173,14 @@ export default class extends React.Component {
                                     onClose={()=>this.setState({execution: null, deploymentUpdateId: '', deploymentUpdateModalOpen: false})}
                                     toolbox={this.props.toolbox} />
 
-                <Modal open={this.state.errorModalOpen} onClose={()=>this.setState({execution: null, errorModalOpen: false})}>
+                <Modal open={this.state.errorModalOpen} closeIcon
+                       onClose={()=>this.setState({execution: null, errorModalOpen: false})}>
                     <Modal.Content scrolling>
                         <HighlightText className='python'>{execution.error}</HighlightText>
-                        <CopyToClipboardButton content='Copy Error' text={execution.error} className='rightFloated' />
                     </Modal.Content>
+                    <Modal.Actions>
+                        <CopyToClipboardButton content='Copy Error' text={execution.error} />
+                    </Modal.Actions>
                 </Modal>
 
             </div>


### PR DESCRIPTION
# Before
![image](https://user-images.githubusercontent.com/5202105/42561702-16dfab54-84fa-11e8-8532-d84831004e22.png)

# After
![image](https://user-images.githubusercontent.com/5202105/42561710-1b567e74-84fa-11e8-8e30-6d3f86a92482.png)
