### PR TITLE
CY-497 - For active executions 'Invalid date' text in 'Ended at' column is shown in executions table

### DIFF
--- a/app/utils/stageUtils.js
+++ b/app/utils/stageUtils.js
@@ -30,11 +30,13 @@ export default class StageUtils {
     };
 
     static formatTimestamp(timestamp, outputPattern='DD-MM-YYYY HH:mm', inputPattern='YYYY-MM-DD HH:mm:ss') {
-        return moment.utc(timestamp, inputPattern).local().format(outputPattern);
+        let timestampMoment = moment.utc(timestamp, inputPattern).local();
+        return timestampMoment.isValid() ? timestampMoment.format(outputPattern) : '';
     }
 
     static formatLocalTimestamp(timestamp, outputPattern='DD-MM-YYYY HH:mm', inputPattern=undefined) {
-        return moment(timestamp, inputPattern).format(outputPattern);
+        let timestampMoment = moment(timestamp, inputPattern);
+        return timestampMoment.isValid() ? timestampMoment.format(outputPattern) : '';
     }
 
     /**


### PR DESCRIPTION
Added empty string when execution is running.