### PR TITLE
CYBL-493 - Add possibility to Kill not active executions

### DIFF
--- a/widgets/common/src/ExecutionStatus.js
+++ b/widgets/common/src/ExecutionStatus.js
@@ -4,7 +4,7 @@
 
 import PropTypes from 'prop-types';
 
-export default class ExecutionStatus extends React.Component {
+class ExecutionStatus extends React.Component {
 
     constructor(props,context) {
         super(props,context);
@@ -17,7 +17,13 @@ export default class ExecutionStatus extends React.Component {
     static propTypes = {
         item: PropTypes.object.isRequired,
         onCancelExecution: PropTypes.func.isRequired,
-        showInactiveAsLink: PropTypes.bool
+        showInactiveAsLink: PropTypes.bool,
+        displayCancelIcon: PropTypes.bool
+    };
+
+    static defaultProps = {
+        showInactiveAsLink: false,
+        displayCancelIcon: true
     };
 
     _actionClick(event, {name}) {
@@ -39,23 +45,40 @@ export default class ExecutionStatus extends React.Component {
                 <Label>
                     <Icon name="spinner" loading />
                     {executionStatusDisplay}
-                    <PopupMenu disabled={cancelClicked} icon='delete' >
-                        <Menu pointing vertical>
-                            <Menu.Item content='Cancel' name={ExecutionUtils.CANCEL_ACTION}
-                                       onClick={this._actionClick.bind(this)} />
-                            <Menu.Item content='Force Cancel' name={ExecutionUtils.FORCE_CANCEL_ACTION}
-                                       onClick={this._actionClick.bind(this)} />
-                            <Menu.Item content='Kill' name={ExecutionUtils.KILL_CANCEL_ACTION}
-                                       onClick={this._actionClick.bind(this)} />
-                        </Menu>
-                    </PopupMenu>
+                    {
+                        this.props.displayCancelIcon &&
+                        <PopupMenu disabled={cancelClicked} icon='delete' >
+                            <Menu pointing vertical>
+                                <Menu.Item content='Cancel'
+                                           icon='cancel'
+                                           name={ExecutionUtils.CANCEL_ACTION}
+                                           onClick={this._actionClick.bind(this)} />
+                                <Menu.Item content='Force Cancel'
+                                           icon={<Icon name='cancel' color='red' />}
+                                           name={ExecutionUtils.FORCE_CANCEL_ACTION}
+                                           onClick={this._actionClick.bind(this)}/>
+                                <Menu.Item content='Kill Cancel'
+                                           icon={<Icon name='stop' color='red' />}
+                                           name={ExecutionUtils.KILL_CANCEL_ACTION}
+                                           onClick={this._actionClick.bind(this)} />
+
+                            </Menu>
+                        </PopupMenu>
+                    }
                 </Label>
             )
         } else {
             let inactiveExecutionStatus
                 = this.props.showInactiveAsLink ? (<a href="javascript:void(0)">{executionStatusDisplay}</a>) : executionStatusDisplay;
             return (
-                <Label>{inactiveExecutionStatus}</Label>
+                <Label>
+                    {
+                        _.isEmpty(execution.error)
+                        ? <Icon name="check circle" color="green" inverted />
+                        : <Icon name="remove circle" color="red" link />
+                    }
+                    {inactiveExecutionStatus}
+                </Label>
             )
         }
     }

--- a/widgets/executions/src/ExecutionsTable.js
+++ b/widgets/executions/src/ExecutionsTable.js
@@ -3,7 +3,7 @@
  */
 import UpdateDetailsModal from './UpdateDetailsModal';
 
-export default class extends React.Component {
+export default class ExecutionsTable extends React.Component {
     constructor(props, context) {
         super(props, context);
 
@@ -17,6 +17,15 @@ export default class extends React.Component {
             error: null
         };
     }
+
+    static MenuAction = {
+        SHOW_EXECUTION_PARAMETERS: 'execution_parameters',
+        SHOW_UPDATE_DETAILS: 'update_details',
+        SHOW_ERROR_DETAILS: 'error_details',
+        CANCEL_EXECUTION: Stage.Common.ExecutionUtils.CANCEL_ACTION,
+        FORCE_CANCEL_EXECUTION: Stage.Common.ExecutionUtils.FORCE_CANCEL_ACTION,
+        KILL_CANCEL_EXECUTION: Stage.Common.ExecutionUtils.KILL_CANCEL_ACTION
+    };
 
     shouldComponentUpdate(nextProps, nextState) {
         return !_.isEqual(this.props.widget.configuration, nextProps.widget.configuration)
@@ -57,14 +66,39 @@ export default class extends React.Component {
             .catch((err) => {this.setState({error: err.message});});
     }
 
+    _actionClick(execution, proxy, {name}) {
+        const MenuAction = ExecutionsTable.MenuAction;
+
+        switch(name) {
+            case MenuAction.SHOW_EXECUTION_PARAMETERS:
+                this.setState({execution, executionParametersModalOpen: true, idPopupOpen: false});
+                break;
+
+            case MenuAction.SHOW_UPDATE_DETAILS:
+                this.setState({deploymentUpdateId: execution.parameters.update_id, deploymentUpdateModalOpen: true});
+                break;
+
+            case MenuAction.SHOW_ERROR_DETAILS:
+                this.setState({execution, errorModalOpen: true, idPopupOpen: false});
+                break;
+
+            case MenuAction.CANCEL_EXECUTION:
+            case MenuAction.FORCE_CANCEL_EXECUTION:
+            case MenuAction.KILL_CANCEL_EXECUTION:
+                this._cancelExecution(execution, name);
+                break;
+        }
+    }
+
     fetchGridData(fetchParams) {
         return this.props.toolbox.refresh(fetchParams);
     }
 
     render() {
         const NO_DATA_MESSAGE = 'There are no Executions available. Probably there\'s no deployment created, yet.';
-        let {Checkmark, CopyToClipboardButton, DataTable, ErrorMessage, HighlightText, Icon, Modal, Popup} = Stage.Basic;
-        let {ExecutionStatus, IdPopup} = Stage.Common;
+        let {Checkmark, CopyToClipboardButton, DataTable, ErrorMessage, HighlightText, Icon, Menu, Modal, PopupMenu} = Stage.Basic;
+        let {ExecutionStatus, ExecutionUtils, IdPopup} = Stage.Common;
+        const MenuAction = ExecutionsTable.MenuAction;
 
         let fieldsToShow = this.props.widget.configuration.fieldsToShow;
         let execution = this.state.execution || {parameters: {}};
@@ -85,25 +119,25 @@ export default class extends React.Component {
 
                     <DataTable.Column label="" width="1%" />
                     <DataTable.Column label="Blueprint" name="blueprint_id" width="15%"
-                                 show={fieldsToShow.indexOf('Blueprint') >= 0 && !this.props.data.blueprintId}/>
+                                      show={fieldsToShow.indexOf('Blueprint') >= 0 && !this.props.data.blueprintId}/>
                     <DataTable.Column label="Deployment" name="deployment_id" width="15%"
-                                 show={fieldsToShow.indexOf('Deployment') >= 0 && !this.props.data.deploymentId}/>
+                                      show={fieldsToShow.indexOf('Deployment') >= 0 && !this.props.data.deploymentId}/>
                     <DataTable.Column label="Workflow" name="workflow_id" width="15%"
-                                 show={fieldsToShow.indexOf('Workflow') >= 0}/>
+                                      show={fieldsToShow.indexOf('Workflow') >= 0}/>
                     <DataTable.Column label="Id" name="id" width="10%"
-                                 show={fieldsToShow.indexOf('Id') >= 0}/>
+                                      show={fieldsToShow.indexOf('Id') >= 0}/>
                     <DataTable.Column label="Created" name="created_at" width="10%"
-                                 show={fieldsToShow.indexOf('Created') >= 0}/>
+                                      show={fieldsToShow.indexOf('Created') >= 0}/>
                     <DataTable.Column label="Ended" name="ended_at" width="10%"
-                                 show={fieldsToShow.indexOf('Ended') >= 0}/>
+                                      show={fieldsToShow.indexOf('Ended') >= 0}/>
                     <DataTable.Column label="Creator" name='created_by' width="5%"
                                       show={fieldsToShow.indexOf('Creator') >= 0}/>
                     <DataTable.Column label="System" name="is_system_workflow" width="5%"
-                                 show={fieldsToShow.indexOf('System') >= 0}/>
-                    <DataTable.Column label="Params" name="parameters" width="5%"
-                                 show={fieldsToShow.indexOf('Params') >= 0}/>
-                    <DataTable.Column label="Status" width="10%" name="status"
-                                 show={fieldsToShow.indexOf('Status') >= 0}/>
+                                      show={fieldsToShow.indexOf('System') >= 0}/>
+                    <DataTable.Column label="Status" width="15%" name="status"
+                                      show={fieldsToShow.indexOf('Status') >= 0}/>
+                    <DataTable.Column name="actions" width="5%"
+                                      show={fieldsToShow.indexOf('Actions') >= 0}/>
 
                     {
                         this.props.data.items.map((item)=>{
@@ -125,32 +159,50 @@ export default class extends React.Component {
                                         <Checkmark value={item.is_system_workflow}/>
                                     </DataTable.Data>
                                     <DataTable.Data className="center aligned">
-                                        <Icon name="options" link bordered title="Execution parameters" onClick={(event)=>{event.stopPropagation();this.setState({execution: item, executionParametersModalOpen: true})}} />
-                                        {
-                                            item.workflow_id === 'update' && <Icon name="magnify" link bordered title="Update details" onClick={(event)=>{event.stopPropagation();this.setState({deploymentUpdateId: item.parameters.update_id, deploymentUpdateModalOpen: true})}} />
-                                        }
+                                        <ExecutionStatus item={item} displayCancelIcon={false} onCancelExecution={_.noop} />
                                     </DataTable.Data>
                                     <DataTable.Data className="center aligned">
-                                        {
-                                            _.isEmpty(item.error)
-                                            ?
-                                                <div>
-                                                    <Icon name="check circle" color="green" inverted />
-                                                    <ExecutionStatus item={item} showInactiveAsLink={false} onCancelExecution={this._cancelExecution.bind(this)}/>
-                                                </div>
-                                            :
-                                                <Popup position='top center'>
-                                                    <Popup.Trigger>
-                                                        <div onClick={(event)=>{event.stopPropagation();this.setState({execution: item, errorModalOpen: true})}} >
-                                                            <Icon name="remove circle" color="red" link />
-                                                            <ExecutionStatus item={item} showInactiveAsLink={true} onCancelExecution={this._cancelExecution.bind(this)} />
-                                                        </div>
-                                                    </Popup.Trigger>
-                                                    <Popup.Content>
-                                                        Click to see details
-                                                    </Popup.Content>
-                                                </Popup>
-                                        }
+
+                                        <PopupMenu className="menuAction">
+                                            <Menu pointing vertical>
+                                                <Menu.Item content='Show Execution Parameters'
+                                                           icon='options'
+                                                           name={MenuAction.SHOW_EXECUTION_PARAMETERS}
+                                                           onClick={this._actionClick.bind(this, item)} />
+                                                {
+                                                    item.workflow_id === 'update' &&
+                                                    <Menu.Item content='Show Update Details'
+                                                               icon='magnify'
+                                                               name={MenuAction.SHOW_UPDATE_DETAILS}
+                                                               onClick={this._actionClick.bind(this, item)} />
+                                                }
+                                                {
+                                                    !_.isEmpty(item.error) &&
+                                                    <Menu.Item content='Show Error Details'
+                                                               icon={<Icon name='exclamation circle' color='red' />}
+                                                               name={MenuAction.SHOW_ERROR_DETAILS}
+                                                               onClick={this._actionClick.bind(this, item)} />
+                                                }
+                                                {
+                                                    ExecutionUtils.isActiveExecution(item) &&
+                                                    <Menu.Item content='Cancel'
+                                                               icon='cancel'
+                                                               name={MenuAction.CANCEL_EXECUTION}
+                                                               onClick={this._actionClick.bind(this, item)} />
+                                                }
+                                                {
+                                                    ExecutionUtils.isActiveExecution(item) &&
+                                                    <Menu.Item content='Force Cancel'
+                                                               icon={<Icon name='cancel' color='red' />}
+                                                               name={MenuAction.FORCE_CANCEL_EXECUTION}
+                                                               onClick={this._actionClick.bind(this, item)}/>
+                                                }
+                                                <Menu.Item content='Kill Cancel'
+                                                           icon={<Icon name='stop' color='red' />}
+                                                           name={MenuAction.KILL_CANCEL_EXECUTION}
+                                                           onClick={this._actionClick.bind(this, item)} />
+                                            </Menu>
+                                        </PopupMenu>
                                     </DataTable.Data>
                                 </DataTable.Row>
                             );

--- a/widgets/executions/src/widget.js
+++ b/widgets/executions/src/widget.js
@@ -25,8 +25,8 @@ Stage.defineWidget({
             Stage.GenericConfig.POLLING_TIME_CONFIG(5),
             Stage.GenericConfig.PAGE_SIZE_CONFIG(),
             {id: "fieldsToShow",name: "List of fields to show in the table", placeHolder: "Select fields from the list",
-                items: ["Blueprint","Deployment","Workflow","Id","Created","Ended","Creator","System","Params","Status"],
-                default: 'Blueprint,Deployment,Workflow,Created,Ended,Creator,System,Params,Status', type: Stage.Basic.GenericField.MULTI_SELECT_LIST_TYPE},
+                items: ["Blueprint","Deployment","Workflow","Id","Created","Ended","Creator","System","Status","Actions"],
+                default: 'Blueprint,Deployment,Workflow,Created,Ended,Creator,System,Actions,Status', type: Stage.Basic.GenericField.MULTI_SELECT_LIST_TYPE},
             {id: "showSystemExecutions", name: "Show system executions", default: true, type: Stage.Basic.GenericField.BOOLEAN_TYPE},
             Stage.GenericConfig.SORT_COLUMN_CONFIG('created_at'),
             Stage.GenericConfig.SORT_ASCENDING_CONFIG(false)


### PR DESCRIPTION
### Changes
* Converted Params column on the right side in Executions table into Actions menu (similarly to what we already have for another widgets - Deployments, Tenant Management, ...)
* Menu content depends on the workflow type (update / not update), execution status (active / not active) and error presence

### Active execution
![image](https://user-images.githubusercontent.com/5202105/45490489-883cca80-b767-11e8-91af-f65e763d9090.png)

### Successful update execution
![image](https://user-images.githubusercontent.com/5202105/45490641-eff31580-b767-11e8-83c9-b3c0a7d2bd66.png)

### Failed execution
![image](https://user-images.githubusercontent.com/5202105/45490663-04cfa900-b768-11e8-914f-a6a3d8fc2d7e.png)
