### PR TITLE
CY-669 - Add search filter to widgets presenting tabular data

### DIFF
--- a/app/utils/WidgetParamsHandler.js
+++ b/app/utils/WidgetParamsHandler.js
@@ -39,7 +39,7 @@ export default class WidgetParamsHandler {
         if (!_.isEmpty(userRequestedParams)) {
 
             // If user stated he wanted gridParams, then add the grid params fields
-            userRequestedParams = _.replace(userRequestedParams, 'gridParams', '_sort,_size,_offset').split(',');
+            userRequestedParams = _.replace(userRequestedParams, 'gridParams', '_sort,_size,_offset,_search').split(',');
 
             // Pick only the values that the user asked for
             params = _.pick(params, userRequestedParams);

--- a/widgets/highAvailability/src/ClusterNodesList.js
+++ b/widgets/highAvailability/src/ClusterNodesList.js
@@ -29,6 +29,7 @@ export default class ClusterNodesList extends React.Component {
                            sortColumn={this.props.widget.configuration.sortColumn}
                            sortAscending={this.props.widget.configuration.sortAscending}
                            className="nodesTable"
+                           searchable={true}
                            noDataMessage={NO_DATA_MESSAGE}>
 
                     <DataTable.Column label="Name" name="name" width="25%"/>

--- a/widgets/nodes/src/NodesTable.js
+++ b/widgets/nodes/src/NodesTable.js
@@ -60,6 +60,7 @@ export default class NodesTable extends React.Component {
                            pageSize={this.props.widget.configuration.pageSize}
                            sortColumn={this.props.widget.configuration.sortColumn}
                            sortAscending={this.props.widget.configuration.sortAscending}
+                           searchable={true}
                            selectable={true}
                            className="nodesTable"
                            noDataMessage={NO_DATA_MESSAGE}>

--- a/widgets/outputs/src/widget.js
+++ b/widgets/outputs/src/widget.js
@@ -19,7 +19,6 @@ Stage.defineWidget({
     fetchData: function(widget,toolbox) {
         let deploymentId = toolbox.getContext().getValue('deploymentId');
         let blueprintId = toolbox.getContext().getValue('blueprintId');
-        let _stringify = this._stringify;
 
         if (deploymentId) {
             let deploymentOutputsPromise = toolbox.getManager().doGet(`/deployments/${deploymentId}/outputs`);

--- a/widgets/snapshots/src/SnapshotsTable.js
+++ b/widgets/snapshots/src/SnapshotsTable.js
@@ -106,6 +106,7 @@ export default class extends React.Component {
                            sortColumn={this.props.widget.configuration.sortColumn}
                            sortAscending={this.props.widget.configuration.sortAscending}
                            selectable={true}
+                           searchable={true}
                            className="snapshotsTable"
                            noDataMessage={NO_DATA_MESSAGE}>
 

--- a/widgets/tenants/src/TenantsTable.js
+++ b/widgets/tenants/src/TenantsTable.js
@@ -122,6 +122,7 @@ export default class TenantsTable extends React.Component {
                            pageSize={this.props.widget.configuration.pageSize}
                            sortColumn={this.props.widget.configuration.sortColumn}
                            sortAscending={this.props.widget.configuration.sortAscending}
+                           searchable={true}
                            className="tenantsTable"
                            noDataMessage={NO_DATA_MESSAGE}>
 

--- a/widgets/userGroups/src/UserGroupsTable.js
+++ b/widgets/userGroups/src/UserGroupsTable.js
@@ -158,6 +158,7 @@ export default class UserGroupsTable extends React.Component {
                            pageSize={this.props.widget.configuration.pageSize}
                            sortColumn={this.props.widget.configuration.sortColumn}
                            sortAscending={this.props.widget.configuration.sortAscending}
+                           searchable={true}
                            className="userGroupsTable"
                            noDataMessage={NO_DATA_MESSAGE}>
 

--- a/widgets/userManagement/src/UsersTable.js
+++ b/widgets/userManagement/src/UsersTable.js
@@ -204,6 +204,7 @@ export default class UsersTable extends React.Component {
                            pageSize={this.props.widget.configuration.pageSize}
                            sortColumn={this.props.widget.configuration.sortColumn}
                            sortAscending={this.props.widget.configuration.sortAscending}
+                           searchable={true}
                            className={tableName}
                            noDataMessage={NO_DATA_MESSAGE}>
 


### PR DESCRIPTION
Added search filter to the following widgets:
1. Nodes
2. User Management
3. Tenant Management
4. User Groups Management
5. Snapshots
6. Cluster Nodes