### PR TITLE
CY-644 - Added 'Ignore plugin failure' option in snapshot restoration modal

### DIFF
--- a/widgets/snapshots/src/CreateSnapshotModal.js
+++ b/widgets/snapshots/src/CreateSnapshotModal.js
@@ -94,22 +94,22 @@ export default class CreateModal extends React.Component {
                         </Form.Field>
 
                         <Form.Field>
-                            <Form.Checkbox label="Include metrics stored in InfluxDB" name="includeMetrics"
+                            <Form.Checkbox toggle label="Include metrics stored in InfluxDB" name="includeMetrics"
                                            checked={this.state.includeMetrics} onChange={this._handleInputChange.bind(this)}/>
                         </Form.Field>
 
-                        <Form.Field>
-                            <Form.Checkbox label="Include agent SSH keys (including those specified in uploaded blueprints)" name="includeCredentials"
+                        <Form.Field help='Includes SSH keys specified in uploaded blueprints'>
+                            <Form.Checkbox toggle label="Include credentials" name="includeCredentials"
                                            checked={this.state.includeCredentials} onChange={this._handleInputChange.bind(this)}/>
                         </Form.Field>
 
                         <Form.Field>
-                            <Form.Checkbox label="Exclude logs" name="excludeLogs"
+                            <Form.Checkbox toggle label="Exclude logs" name="excludeLogs"
                             checked={this.state.excludeLogs} onChange={this._handleInputChange.bind(this)}/>
                         </Form.Field>
 
                         <Form.Field>
-                            <Form.Checkbox label="Exclude events" name="excludeEvents"
+                            <Form.Checkbox toggle label="Exclude events" name="excludeEvents"
                             checked={this.state.excludeEvents} onChange={this._handleInputChange.bind(this)}/>
                         </Form.Field>
 

--- a/widgets/snapshots/src/RestoreSnapshotModal.js
+++ b/widgets/snapshots/src/RestoreSnapshotModal.js
@@ -17,8 +17,9 @@ export default class RestoreSnapshotModal extends React.Component {
         loading: false,
         errors: {},
         isFromTenantlessEnv : false,
-        shouldForceRestore: false
-    }
+        shouldForceRestore: false,
+        ignorePluginFailure: false
+    };
 
     static propTypes = {
         snapshot: PropTypes.object.isRequired,
@@ -26,7 +27,7 @@ export default class RestoreSnapshotModal extends React.Component {
     };
 
     static defaultProps = {
-        onHide: ()=>{}
+        onHide: _.noop
     };
 
     onApprove () {
@@ -58,7 +59,7 @@ export default class RestoreSnapshotModal extends React.Component {
         this.setState({loading: true});
 
         var actions = new Actions(this.props.toolbox);
-        actions.doRestore(this.props.snapshot,this.state.shouldForceRestore).then(()=>{
+        actions.doRestore(this.props.snapshot, this.state.shouldForceRestore, this.state.ignorePluginFailure).then(()=>{
             this.setState({errors: {}, loading: false});
             this.props.toolbox.refresh();
             this.props.toolbox.getEventBus().trigger('snapshots:refresh');
@@ -88,7 +89,7 @@ export default class RestoreSnapshotModal extends React.Component {
 
                         <Form.Field>
                             <Form.Checkbox toggle
-                                           label="Is Snapshot from a tenant-less environment?"
+                                           label="Snapshot from a tenant-less environment"
                                            name='isFromTenantlessEnv'
                                            checked={this.state.isFromTenantlessEnv}
                                            onChange={this._handleFieldChange.bind(this)}/>
@@ -104,9 +105,16 @@ export default class RestoreSnapshotModal extends React.Component {
                         }
                         <Form.Field>
                             <Form.Checkbox toggle
-                                           label="Force restore even if manager is non-empty? (It will delete all data)"
+                                           label="Force restore even if manager is non-empty (it will delete all data)"
                                            name='shouldForceRestore'
                                            checked={this.state.shouldForceRestore}
+                                           onChange={this._handleFieldChange.bind(this)}/>
+                        </Form.Field>
+                        <Form.Field help='Ignore plugin installation failures and deployment environment creation failures due to missing plugins'>
+                            <Form.Checkbox toggle
+                                           label='Ignore plugin failures'
+                                           name='ignorePluginFailure'
+                                           checked={this.state.ignorePluginFailure}
                                            onChange={this._handleFieldChange.bind(this)}/>
                         </Form.Field>
 

--- a/widgets/snapshots/src/actions.js
+++ b/widgets/snapshots/src/actions.js
@@ -13,9 +13,13 @@ export default class {
 
     }
 
-    doRestore(snapshot,shouldForceRestore) {
-        return this.toolbox.getManager().doPost(`/snapshots/${snapshot.id}/restore`,null,
-            {force: shouldForceRestore, recreate_deployments_envs: false, tenant_name: ''});
+    doRestore(snapshot, shouldForceRestore, ignorePluginFailure = false) {
+        return this.toolbox.getManager().doPost(`/snapshots/${snapshot.id}/restore`,null, {
+            force: shouldForceRestore,
+            recreate_deployments_envs: false,
+            tenant_name: '',
+            ignore_plugin_failure: ignorePluginFailure
+        });
     }
 
     doUpload(snapshotUrl, snapshotId, file) {


### PR DESCRIPTION
# New field
![image](https://user-images.githubusercontent.com/5202105/46467703-b5acef00-c7ce-11e8-8a30-e015c845abe9.png)

# New field (hover)
![image](https://user-images.githubusercontent.com/5202105/46467715-c198b100-c7ce-11e8-8ad3-3f9f7d612f95.png)
