### PR TITLE
CY-701 - Improve Logs page

### DIFF
--- a/templates/pages/logs.json
+++ b/templates/pages/logs.json
@@ -20,12 +20,12 @@
     {
       "name": "Events and logs",
       "width": 12,
-      "height": 35,
+      "height": 40,
       "definition": "events",
       "x": 0,
       "y": 10,
       "configuration": {
-        "pageSize": 10
+        "pageSize": 15
       }
     }
   ]

--- a/widgets/events/src/EventsTable.js
+++ b/widgets/events/src/EventsTable.js
@@ -41,6 +41,34 @@ export default class EventsTable extends React.Component {
         this.props.toolbox.getContext().setValue('eventId', eventId === selectedEventId ? null : eventId);
     }
 
+    getHighlightedText(text) {
+        let eventFilter = this.props.toolbox.getContext().getValue('eventFilter') || {};
+        let messageText = eventFilter.messageText;
+
+        if (!_.isEmpty(messageText)) {
+            let parts = text.split(new RegExp(`(${messageText})`, 'gi'));
+            return (
+                <span>
+                    {
+                        parts.map((part, i) =>
+                            <span key={i}
+                                  style={part.toLowerCase() === messageText.toLowerCase() ? { backgroundColor: 'yellow' } : {} }>
+                            {part}
+                            </span>
+                        )
+                    }
+                </span>
+            );
+        } else {
+            return (
+                <span>
+                    {text}
+                </span>
+            );
+        }
+
+    }
+
     render() {
         const NO_DATA_MESSAGE = 'There are no Events/Logs available. Probably there\'s no deployment created, yet.';
         let {CopyToClipboardButton, DataTable, ErrorMessage, HighlightText, Icon, Popup} = Stage.Basic;
@@ -141,7 +169,7 @@ export default class EventsTable extends React.Component {
                                                 <Popup.Trigger>
                                                     <span>
                                                         {
-                                                            _.truncate(JsonUtils.stringify(item.message, false), truncateOptions)
+                                                           this.getHighlightedText(_.truncate(JsonUtils.stringify(item.message, false), truncateOptions))
                                                         }
                                                     </span>
                                                 </Popup.Trigger>


### PR DESCRIPTION
1. Extend Logs widget to show 15 logs per page instead of 10
2. Highlight text in Message column in Events/Logs widget when text searching is on in Events filter widget
![image](https://user-images.githubusercontent.com/5202105/46950934-abb8a500-d086-11e8-9471-bef1a85ab9a5.png)
