### PR TITLE
CY-708 - Deployment inputs from YAML file not properly recognized

### DIFF
--- a/app/components/basic/PopupHelp.js
+++ b/app/components/basic/PopupHelp.js
@@ -24,7 +24,7 @@ export default class PopupHelp extends React.Component {
      */
     static propTypes = {
         trigger: PropTypes.object,
-        content: PropTypes.string.isRequired
+        content: PropTypes.any.isRequired
     };
 
     static defaultProps = {

--- a/app/components/basic/PopupHelp.js
+++ b/app/components/basic/PopupHelp.js
@@ -29,11 +29,12 @@ export default class PopupHelp extends React.Component {
 
     static defaultProps = {
         trigger: (<Icon name="help circle"/>)
-    }
+    };
 
     render() {
+        let popupProps = _.omit(this.props, _.keys(PopupHelp.propTypes));
         return (
-            <Popup on={['hover', 'focus']}>
+            <Popup on={['hover', 'focus']} {...popupProps}>
                 <Popup.Trigger>
                     {this.props.trigger}
                 </Popup.Trigger>

--- a/app/components/basic/VisibilityIcon.js
+++ b/app/components/basic/VisibilityIcon.js
@@ -35,7 +35,7 @@ export default class VisibilityIcon extends Component {
         let data = _.find(consts.visibility, {name: this.props.visibility});
         return this.props.showTitle
             ? <Popup trigger={<Icon name={data.icon} color={data.color} {..._.omit(this.props, _.keys(VisibilityIcon.propTypes))}/>} content={data.title} />
-            : <Icon name={data.icon} color={data.color} {..._.omit(this.props, 'visibility')}/>;
+            : <Icon name={data.icon} color={data.color} {..._.omit(this.props, _.keys(VisibilityIcon.propTypes))}/>;
     }
 }
 

--- a/widgets/common/src/DeployBlueprintModal.js
+++ b/widgets/common/src/DeployBlueprintModal.js
@@ -83,8 +83,8 @@ class DeployBlueprintModal extends React.Component {
                 if (_.isNil(inputObj.default)) {
                     errors[inputName] = `Please provide ${inputName}`;
                 }
-            } else if (stringInputValue === DeployBlueprintModal.EMPTY_STRING) {
-                deploymentInputs[inputName] = '';
+            } else if (_.first(stringInputValue) === '"' && _.last(stringInputValue) === '"') {
+                deploymentInputs[inputName] = _.trim(stringInputValue, '"');
             } else {
                 deploymentInputs[inputName] = typedInputValue;
             }
@@ -140,6 +140,12 @@ class DeployBlueprintModal extends React.Component {
                 } else if (stringValue === '') {
                     deploymentInputs[inputName] = DeployBlueprintModal.EMPTY_STRING;
                 } else {
+                    let valueType = Stage.Common.JsonUtils.toType(inputs[inputName]);
+                    let castedValue = Stage.Common.JsonUtils.getTypedValue(stringValue);
+                    let castedValueType = Stage.Common.JsonUtils.toType(castedValue);
+                    if (valueType !== castedValueType) {
+                        stringValue = `"${stringValue}"`;
+                    }
                     deploymentInputs[inputName] = stringValue;
                 }
             });
@@ -165,7 +171,8 @@ class DeployBlueprintModal extends React.Component {
     }
 
     render() {
-        var {Modal, Icon, Form, Message, Header, ApproveButton, CancelButton, VisibilityField} = Stage.Basic;
+        let {ApproveButton, CancelButton, Form, Icon, Message, Modal, VisibilityField} = Stage.Basic;
+        let {DeploymentInputsHeader} = Stage.Common;
 
         let blueprint = Object.assign({}, DeployBlueprintModal.EMPTY_BLUEPRINT, this.props.blueprint);
         let deploymentInputs = _.sortBy(_.map(blueprint.plan.inputs, (input, name) => ({'name': name, ...input})),
@@ -193,12 +200,7 @@ class DeployBlueprintModal extends React.Component {
                             blueprint.id
                             &&
                             <Form.Divider>
-                                <Header size="tiny">
-                                    Deployment inputs
-                                    <Header.Subheader>
-                                        Use "" for an empty string
-                                    </Header.Subheader>
-                                </Header>
+                                <DeploymentInputsHeader />
                             </Form.Divider>
                         }
 

--- a/widgets/common/src/DeploymentInputsHeader.js
+++ b/widgets/common/src/DeploymentInputsHeader.js
@@ -1,0 +1,43 @@
+/**
+ * Created by jakubniezgoda on 16/10/2018.
+ */
+
+class DeploymentInputsHeader extends React.Component {
+
+    constructor(props,context) {
+        super(props,context);
+    }
+
+    render () {
+        let {Header, List, PopupHelp} = Stage.Basic;
+
+        return (
+            <Header size="tiny">
+                Deployment inputs
+                <Header.Subheader>
+                    See values typing details:&nbsp;
+                    <PopupHelp flowing content={
+                        <div>
+                            Values are casted to types, e.g.:
+                            <List bulleted>
+                                <List.Item><strong>[1, 2]</strong> will be casted to an array</List.Item>
+                                <List.Item><strong>524</strong> will be casted to a number</List.Item>
+                            </List>
+                            Surround value with <strong>"</strong> to explicitly declare it as a string, e.g.:
+                            <List bulleted>
+                                <List.Item><strong>{'"{"a":"b"}"'}</strong> will be send as string not an object</List.Item>
+                                <List.Item><strong>{'"true"'}</strong> will be send as string not a boolean value</List.Item>
+                            </List>
+                            Use <strong>""</strong> for an empty string.
+                        </div>
+                    } />
+                </Header.Subheader>
+            </Header>
+        );
+    }
+}
+
+Stage.defineCommon({
+    name: 'DeploymentInputsHeader',
+    common: DeploymentInputsHeader
+});

--- a/widgets/common/src/UpdateDeploymentModal.js
+++ b/widgets/common/src/UpdateDeploymentModal.js
@@ -76,8 +76,8 @@ class UpdateDeploymentModal extends React.Component {
                 if (_.isNil(inputObj.default)) {
                     errors[inputName] = `Please provide ${inputName}`;
                 }
-            } else if (stringInputValue === Stage.Common.DeployBlueprintModal.EMPTY_STRING) {
-                deploymentInputs[inputName] = '';
+            } else if (_.first(stringInputValue) === '"' && _.last(stringInputValue) === '"') {
+                deploymentInputs[inputName] = _.trim(stringInputValue, '"');
             } else {
                 deploymentInputs[inputName] = typedInputValue;
             }
@@ -160,8 +160,8 @@ class UpdateDeploymentModal extends React.Component {
                         // Optional input
                         deploymentInputs[inputName] = '';
                     }
-                } else if (stringValue === '') {
-                    deploymentInputs[inputName] = Stage.Common.DeployBlueprintModal.EMPTY_STRING;
+                } else if (_.first(stringValue) === '"' && _.last(stringValue) === '"') {
+                    deploymentInputs[inputName] = _.trim(stringValue, '"');
                 } else {
                     deploymentInputs[inputName] = stringValue;
                 }
@@ -194,6 +194,12 @@ class UpdateDeploymentModal extends React.Component {
                         if (stringValue === '') {
                             deploymentInputs[inputName] = Stage.Common.DeployBlueprintModal.EMPTY_STRING;
                         } else {
+                            let valueType = Stage.Common.JsonUtils.toType(deploymentInputs[inputName]);
+                            let castedValue = Stage.Common.JsonUtils.getTypedValue(stringValue);
+                            let castedValueType = Stage.Common.JsonUtils.toType(castedValue);
+                            if (valueType !== castedValueType) {
+                                stringValue = `"${stringValue}"`;
+                            }
                             deploymentInputs[inputName] = stringValue;
                         }
                     } else {
@@ -212,6 +218,7 @@ class UpdateDeploymentModal extends React.Component {
 
     render() {
         let {ApproveButton, CancelButton, Form, Header, Icon, Message, Modal, NodeInstancesFilter} = Stage.Basic;
+        let {DeploymentInputsHeader} = Stage.Common;
 
         let blueprints = Object.assign({},{items:[]}, this.state.blueprints);
         let blueprintsOptions = _.map(blueprints.items, blueprint => { return { text: blueprint.id, value: blueprint.id } });
@@ -238,12 +245,7 @@ class UpdateDeploymentModal extends React.Component {
                             this.state.blueprint.id
                             &&
                             <Form.Divider>
-                                <Header size="tiny">
-                                    Deployment inputs
-                                    <Header.Subheader>
-                                        Use "" for an empty string
-                                    </Header.Subheader>
-                                </Header>
+                                <DeploymentInputsHeader />
                             </Form.Divider>
                         }
 

--- a/widgets/deploymentButton/src/DeployModal.js
+++ b/widgets/deploymentButton/src/DeployModal.js
@@ -108,8 +108,8 @@ export default class DeployModal extends React.Component {
                 if (_.isNil(inputObj.default)) {
                     errors[inputName] = `Please provide ${inputName}`;
                 }
-            } else if (stringInputValue === Stage.Common.DeployBlueprintModal.EMPTY_STRING) {
-                deploymentInputs[inputName] = '';
+            } else if (_.first(stringInputValue) === '"' && _.last(stringInputValue) === '"') {
+                deploymentInputs[inputName] = _.trim(stringInputValue, '"');
             } else {
                 deploymentInputs[inputName] = typedInputValue;
             }
@@ -165,6 +165,12 @@ export default class DeployModal extends React.Component {
                 } else if (stringValue === '') {
                     deploymentInputs[inputName] = Stage.Common.DeployBlueprintModal.EMPTY_STRING;
                 } else {
+                    let valueType = Stage.Common.JsonUtils.toType(inputs[inputName]);
+                    let castedValue = Stage.Common.JsonUtils.getTypedValue(stringValue);
+                    let castedValueType = Stage.Common.JsonUtils.toType(castedValue);
+                    if (valueType !== castedValueType) {
+                        stringValue = `"${stringValue}"`;
+                    }
                     deploymentInputs[inputName] = stringValue;
                 }
             });
@@ -180,7 +186,8 @@ export default class DeployModal extends React.Component {
     }
 
     render() {
-        var {Modal, Icon, Form, Message, Header, ApproveButton, CancelButton, VisibilityField} = Stage.Basic;
+        let {ApproveButton, CancelButton, Form, Icon, Message, Modal, VisibilityField} = Stage.Basic;
+        let {DeploymentInputsHeader} = Stage.Common;
 
         let blueprints = Object.assign({},{items:[]}, this.props.blueprints);
         let options = _.map(blueprints.items, blueprint => { return { text: blueprint.id, value: blueprint.id } });
@@ -215,12 +222,7 @@ export default class DeployModal extends React.Component {
                             this.state.blueprint.id
                             &&
                             <Form.Divider>
-                                <Header size="tiny">
-                                    Deployment inputs
-                                    <Header.Subheader>
-                                        Use "" for an empty string
-                                    </Header.Subheader>
-                                </Header>
+                                <DeploymentInputsHeader />
                             </Form.Divider>
                         }
 


### PR DESCRIPTION
Changes log:
- added possibility to send input value as string explicitly
- improved PopupHelp to allow adding Popup specific properties
- improved description for deployment inputs in modals

![image](https://user-images.githubusercontent.com/5202105/47024122-66b57100-d161-11e8-9446-3baac8a5e778.png)
