### PR TITLE
CY-699 - Not optimal distribution of space in Deployments widget

### DIFF
--- a/widgets/deployments/src/DeploymentsSegment.js
+++ b/widgets/deployments/src/DeploymentsSegment.js
@@ -64,24 +64,21 @@ export default class DeploymentsSegment extends React.Component {
                                                                      onShowUpdateDetails={this.props.onShowUpdateDetails}
                                                                      onCancelExecution={this.props.onCancelExecution}
                                                                      showLabel={this.props.showExecutionStatusLabel} />
+                                            <ResourceVisibility visibility={item.visibility} className='rightFloated'
+                                                                onSetVisibility={(visibility) =>
+                                                                    this.props.onSetVisibility(item.id, visibility)}
+                                                                allowedSettingTo={this.props.allowedSettingTo} />
                                             {
                                                 this.props.showExecutionStatusLabel &&
                                                 <Divider hidden />
                                             }
-                                            <Header as='h3' textAlign='center'>
+                                            <Header as='h3' textAlign='center'
+                                                    style={this.props.showExecutionStatusLabel ? {} : {marginTop: 5}}>
                                                 <a href="javascript:void(0)" className="breakWord">{item.id}</a>
                                             </Header>
-
                                         </Grid.Column>
 
-                                        <Grid.Column width={1} verticalAlign='top' textAlign='right'>
-                                            <ResourceVisibility visibility={item.visibility}
-                                                                onSetVisibility={(visibility) =>
-                                                                    this.props.onSetVisibility(item.id, visibility)}
-                                                                allowedSettingTo={this.props.allowedSettingTo} />
-                                        </Grid.Column>
-
-                                        <Grid.Column width={2}>
+                                        <Grid.Column width={3}>
                                             <Header as='h5'>Blueprint</Header>
                                             <span>{item.blueprint_id}</span>
                                         </Grid.Column>


### PR DESCRIPTION
Changes:
- removed additional column for resource visibility
- moved resource visibility to be floated right in deployment name column
- moved a bit up the name of the deployment
- extended blueprint column width

![image](https://user-images.githubusercontent.com/5202105/47093582-cd05c680-d229-11e8-99bf-f1b39cf9fe50.png)
