### PR TITLE
CY-661 - Add dry-run indication in Executions widget

### DIFF
--- a/app/components/basic/form/FormDivider.js
+++ b/app/components/basic/form/FormDivider.js
@@ -61,9 +61,13 @@ export default class FormDivider extends Component {
         className: PropTypes.string
     };
 
+    static defaultProps = {
+        className: ''
+    };
+
     render() {
         return (
-            <h4 className={`ui dividing header ${this.props.className}`}>
+            <h4 className={`ui dividing header ${this.props.className}`} {..._.omit(this.props, _.keys(FormDivider.propTypes))}>
                 {this.props.children}
             </h4>
         );

--- a/widgets/common/src/DeploymentActions.js
+++ b/widgets/common/src/DeploymentActions.js
@@ -30,11 +30,13 @@ class DeploymentActions {
         });
     }
 
-    doExecute(deployment, workflow, params, force) {
+    doExecute(deployment, workflow, params, force = false, dry_run = false, queue = false) {
         return this.toolbox.getManager().doPost('/executions',null,{
             'deployment_id': deployment.id,
             'workflow_id' : workflow.name,
+            dry_run,
             force,
+            queue,
             parameters: params
         });
     }

--- a/widgets/common/src/ExecuteDeploymentModal.js
+++ b/widgets/common/src/ExecuteDeploymentModal.js
@@ -9,16 +9,16 @@ export default class ExecuteDeploymentModal extends React.Component {
     constructor(props,context) {
         super(props,context);
 
-        this.state = ExecuteDeploymentModal.initialState();
+        this.state = ExecuteDeploymentModal.initialState;
     }
 
-    static initialState = () => {
-        return {
-            errors: {},
-            loading: false,
-            force: false,
-            params: {}
-        }
+    static initialState = {
+        errors: {},
+        loading: false,
+        dryRun: false,
+        force: false,
+        queue: false,
+        params: {}
     };
 
     static propTypes = {
@@ -100,7 +100,8 @@ export default class ExecuteDeploymentModal extends React.Component {
         });
 
         const actions = new DeploymentActions(this.props.toolbox);
-        actions.doExecute(this.props.deployment, this.props.workflow, paramsJson, this.state.force).then(()=>{
+        actions.doExecute(this.props.deployment, this.props.workflow, paramsJson,
+                          this.state.force, this.state.dryRun, this.state.queue).then(()=>{
             this.setState({loading: false, errors: {}});
             this.props.onHide();
             this.props.toolbox.getEventBus().trigger('executions:refresh');
@@ -138,7 +139,7 @@ export default class ExecuteDeploymentModal extends React.Component {
     }
 
     render() {
-        let {Modal, Icon, Form, Message, ApproveButton, CancelButton} = Stage.Basic;
+        let {ApproveButton, CancelButton, Form, Header, Icon, Modal, Message} = Stage.Basic;
         let {InputsHeader} = Stage.Common;
 
         const workflow = Object.assign({},{name:'', parameters:[]}, this.props.workflow);
@@ -152,10 +153,11 @@ export default class ExecuteDeploymentModal extends React.Component {
                 <Modal.Content>
                     <Form loading={this.state.loading} errors={this.state.errors}
                           onErrorsDismiss={() => this.setState({errors: {}})}>
+
+                        <InputsHeader header="Parameters" compact />
                         {
                             _.isEmpty(workflow.parameters)
-                            ? <Message content="No parameters available for the execution" />
-                            : <InputsHeader header="Execution parameters" style={{marginTop: 0}} />
+                            && <Message content="No parameters available for the execution" />
                         }
                         {
                             _.map(workflow.parameters, (parameter, name) => {
@@ -198,10 +200,37 @@ export default class ExecuteDeploymentModal extends React.Component {
                             })
                         }
 
+                        <Form.Divider>
+                            <Header size="tiny">
+                                Actions
+                            </Header>
+                        </Form.Divider>
+
                         <Form.Field>
-                            <Form.Checkbox name='force' toggle label='force'
+                            <Form.Checkbox name='force' toggle label='Force'
+                                           help='Execute the workflow even if there is an ongoing
+                                                 execution for the given deployment.
+                                                 You cannot use this option with "Queue".'
                                            checked={this.state.force}
-                                           onChange={(event, field) => this.setState({force: field.checked})} />
+                                           onChange={(event, field) => this.setState({force: field.checked, queue: false})} />
+                        </Form.Field>
+
+                        <Form.Field>
+                            <Form.Checkbox name='dryRun' toggle label='Dry run'
+                                           help='If set, no actual operations will be performed.
+                                                 Executed tasks will be logged without side effects.
+                                                 You cannot use this option with "Queue".'
+                                           checked={this.state.dryRun}
+                                           onChange={(event, field) => this.setState({dryRun: field.checked, queue: false})} />
+                        </Form.Field>
+
+                        <Form.Field>
+                            <Form.Checkbox name='queue' toggle label='Queue'
+                                           help='If set, executions that can`t currently run will
+                                                 be queued and run automatically when possible.
+                                                 You cannot use this option with "Force" and "Dry run".'
+                                           checked={this.state.queue}
+                                           onChange={(event, field) => this.setState({queue: field.checked, force: false, dryRun: false})} />
                         </Form.Field>
                     </Form>
                 </Modal.Content>

--- a/widgets/common/src/ExecuteDeploymentModal.js
+++ b/widgets/common/src/ExecuteDeploymentModal.js
@@ -36,17 +36,27 @@ export default class ExecuteDeploymentModal extends React.Component {
                 _.get(nextProps.workflow, 'parameters', {}),
                 (parameterData) => {
                     if (!_.isUndefined(parameterData.default)) {
-                        const defaultValueString = JsonUtils.getStringValue(parameterData.default);
-                        const defaultValueType = JsonUtils.toType(parameterData.default);
-                        const castedDefaultValue = JsonUtils.getTypedValue(defaultValueString);
-                        const castedDefaultValueType = JsonUtils.toType(castedDefaultValue);
-                        if (defaultValueType !== castedDefaultValueType) {
-                            return `"${defaultValueString}"`;
+                        if (parameterData.type === 'boolean' || parameterData.type === 'integer') {
+                            return parameterData.default;
                         } else {
-                            return defaultValueString;
+                            const defaultValueString = JsonUtils.getStringValue(parameterData.default);
+                            const defaultValueType = JsonUtils.toType(parameterData.default);
+                            const castedDefaultValue = JsonUtils.getTypedValue(defaultValueString);
+                            const castedDefaultValueType = JsonUtils.toType(castedDefaultValue);
+                            if (defaultValueType !== castedDefaultValueType) {
+                                return `"${defaultValueString}"`;
+                            } else {
+                                return defaultValueString;
+                            }
                         }
                     } else {
-                        return ''
+                        if (parameterData.type === 'boolean') {
+                            return false;
+                        } else if (parameterData.type === 'integer') {
+                            return 0;
+                        } else {
+                            return '';
+                        }
                     }
                 });
             this.setState({...ExecuteDeploymentModal.initialState, params});
@@ -166,7 +176,8 @@ export default class ExecuteDeploymentModal extends React.Component {
                                 switch (parameter.type){
                                     case 'boolean':
                                         return (
-                                            <Form.Field required={this.isParamRequired(parameter)}
+                                            <Form.Field key={name}
+                                                        required={this.isParamRequired(parameter)}
                                                         help={parameter.description}>
                                                 <Form.Checkbox name={name} toggle label={name}
                                                                checked={this.state.params[name]}
@@ -175,7 +186,8 @@ export default class ExecuteDeploymentModal extends React.Component {
                                         );
                                     case 'integer':
                                         return (
-                                            <Form.Field required={this.isParamRequired(parameter)}
+                                            <Form.Field key={name}
+                                                        required={this.isParamRequired(parameter)}
                                                         label={name}
                                                         help={parameter.description}
                                                         error={!!this.state.errors[name]}>
@@ -186,7 +198,8 @@ export default class ExecuteDeploymentModal extends React.Component {
                                         );
                                     default:
                                         return (
-                                            <Form.Field required={this.isParamRequired(parameter)}
+                                            <Form.Field key={name}
+                                                        required={this.isParamRequired(parameter)}
                                                         label={name}
                                                         help={parameter.description}
                                                         error={!!this.state.errors[name]}>

--- a/widgets/common/src/InputsHeader.js
+++ b/widgets/common/src/InputsHeader.js
@@ -11,38 +11,42 @@ class InputsHeader extends React.Component {
     }
 
     static propTypes = {
+        compact: PropTypes.bool,
         header: PropTypes.string
     };
 
     static defaultProps = {
+        compact: false,
         header: 'Deployment inputs'
     };
 
     render () {
-        let {Header, List, PopupHelp} = Stage.Basic;
+        let {Form, Header, List, PopupHelp} = Stage.Basic;
 
         return (
-            <Header size="tiny" dividing {..._.omit(this.props, _.keys(InputsHeader.propTypes))}>
-                {this.props.header}
-                <Header.Subheader>
-                    See values typing details:&nbsp;
-                    <PopupHelp flowing content={
-                        <div>
-                            Values are casted to types, e.g.:
-                            <List bulleted>
-                                <List.Item><strong>[1, 2]</strong> will be casted to an array</List.Item>
-                                <List.Item><strong>524</strong> will be casted to a number</List.Item>
-                            </List>
-                            Surround value with <strong>"</strong> to explicitly declare it as a string, e.g.:
-                            <List bulleted>
-                                <List.Item><strong>{'"{"a":"b"}"'}</strong> will be send as string not an object</List.Item>
-                                <List.Item><strong>{'"true"'}</strong> will be send as string not a boolean value</List.Item>
-                            </List>
-                            Use <strong>""</strong> for an empty string.
-                        </div>
-                    } />
-                </Header.Subheader>
-            </Header>
+            <Form.Divider style={this.props.compact ? {marginTop: 0} : {}}>
+                <Header size="tiny">
+                    {this.props.header}
+                    <Header.Subheader>
+                        See values typing details:&nbsp;
+                        <PopupHelp flowing content={
+                            <div>
+                                Values are casted to types, e.g.:
+                                <List bulleted>
+                                    <List.Item><strong>[1, 2]</strong> will be casted to an array</List.Item>
+                                    <List.Item><strong>524</strong> will be casted to a number</List.Item>
+                                </List>
+                                Surround value with <strong>"</strong> to explicitly declare it as a string, e.g.:
+                                <List bulleted>
+                                    <List.Item><strong>{'"{"a":"b"}"'}</strong> will be send as string not an object</List.Item>
+                                    <List.Item><strong>{'"true"'}</strong> will be send as string not a boolean value</List.Item>
+                                </List>
+                                Use <strong>""</strong> for an empty string.
+                            </div>
+                        } />
+                    </Header.Subheader>
+                </Header>
+            </Form.Divider>
         );
     }
 }

--- a/widgets/executions/src/DryRunIcon.js
+++ b/widgets/executions/src/DryRunIcon.js
@@ -1,0 +1,37 @@
+/**
+ * Created by jakub.niezgoda on 18/10/2018.
+ */
+
+import PropTypes from 'prop-types';
+
+export default class DryRunIcon extends React.Component {
+
+    constructor(props, context){
+        super(props, context);
+    }
+
+    static propTypes = {
+        execution: PropTypes.object
+    };
+
+    static defaultProps = {
+        execution: {is_dry_run: false}
+    };
+
+    render() {
+        let {Icon, Popup} = Stage.Basic;
+        const execution = this.props.execution;
+
+        return execution.is_dry_run
+            ? <Popup wide on='hover'>
+                  <Popup.Trigger>
+                      <Icon name='clipboard check' color='green' />
+                  </Popup.Trigger>
+                  <Popup.Content>
+                      Dry Run
+                  </Popup.Content>
+              </Popup>
+            : null;
+    }
+}
+

--- a/widgets/executions/src/ExecutionsTable.js
+++ b/widgets/executions/src/ExecutionsTable.js
@@ -2,6 +2,9 @@
  * Created by kinneretzin on 20/10/2016.
  */
 
+import SystemWorkflowIcon from './SystemWorkflowIcon';
+import DryRunIcon from './DryRunIcon';
+
 export default class ExecutionsTable extends React.Component {
     constructor(props, context) {
         super(props, context);
@@ -95,7 +98,7 @@ export default class ExecutionsTable extends React.Component {
 
     render() {
         const NO_DATA_MESSAGE = 'There are no Executions available. Probably there\'s no deployment created, yet.';
-        let {CancelButton, Checkmark, CopyToClipboardButton, DataTable, ErrorMessage, HighlightText, Icon, Menu, Modal, PopupMenu} = Stage.Basic;
+        let {CancelButton, CopyToClipboardButton, DataTable, ErrorMessage, HighlightText, Icon, Menu, Modal, PopupMenu} = Stage.Basic;
         let {ExecutionStatus, ExecutionUtils, IdPopup, UpdateDetailsModal} = Stage.Common;
         const MenuAction = ExecutionsTable.MenuAction;
 
@@ -131,8 +134,8 @@ export default class ExecutionsTable extends React.Component {
                                       show={fieldsToShow.indexOf('Ended') >= 0}/>
                     <DataTable.Column label="Creator" name='created_by' width="5%"
                                       show={fieldsToShow.indexOf('Creator') >= 0}/>
-                    <DataTable.Column label="System" name="is_system_workflow" width="5%"
-                                      show={fieldsToShow.indexOf('System') >= 0}/>
+                    <DataTable.Column label="Attributes" width="5%"
+                                      show={fieldsToShow.indexOf('System') >= 0 || fieldsToShow.indexOf('Attributes') >= 0}/>
                     <DataTable.Column label="Status" width="15%"
                                       show={fieldsToShow.indexOf('Status') >= 0}/>
                     <DataTable.Column width="5%"
@@ -155,7 +158,8 @@ export default class ExecutionsTable extends React.Component {
                                     <DataTable.Data>{item.ended_at}</DataTable.Data>
                                     <DataTable.Data>{item.created_by}</DataTable.Data>
                                     <DataTable.Data className="center aligned">
-                                        <Checkmark value={item.is_system_workflow}/>
+                                        <SystemWorkflowIcon execution={item} />
+                                        <DryRunIcon execution={item} />
                                     </DataTable.Data>
                                     <DataTable.Data className="center aligned">
                                         <ExecutionStatus item={item} />

--- a/widgets/executions/src/SystemWorkflowIcon.js
+++ b/widgets/executions/src/SystemWorkflowIcon.js
@@ -1,0 +1,37 @@
+/**
+ * Created by jakub.niezgoda on 18/10/2018.
+ */
+
+import PropTypes from 'prop-types';
+
+export default class SystemWorkflowIcon extends React.Component {
+
+    constructor(props, context){
+        super(props, context);
+    }
+
+    static propTypes = {
+        execution: PropTypes.object
+    };
+
+    static defaultProps = {
+        execution: {is_system_workflow: false}
+    };
+
+    render() {
+        let {Icon, Popup} = Stage.Basic;
+        const execution = this.props.execution;
+
+        return execution.is_system_workflow
+            ? <Popup wide on='hover'>
+                  <Popup.Trigger>
+                      <Icon name='cogs' color='blue' />
+                  </Popup.Trigger>
+                  <Popup.Content>
+                      System Workflow
+                  </Popup.Content>
+              </Popup>
+            : null;
+    }
+}
+

--- a/widgets/executions/src/widget.js
+++ b/widgets/executions/src/widget.js
@@ -25,8 +25,8 @@ Stage.defineWidget({
             Stage.GenericConfig.POLLING_TIME_CONFIG(5),
             Stage.GenericConfig.PAGE_SIZE_CONFIG(),
             {id: "fieldsToShow",name: "List of fields to show in the table", placeHolder: "Select fields from the list",
-                items: ["Blueprint","Deployment","Workflow","Id","Created","Ended","Creator","System","Status","Actions"],
-                default: 'Blueprint,Deployment,Workflow,Created,Ended,Creator,System,Actions,Status', type: Stage.Basic.GenericField.MULTI_SELECT_LIST_TYPE},
+                items: ["Blueprint","Deployment","Workflow","Id","Created","Ended","Creator","Attributes","Status","Actions"],
+                default: 'Blueprint,Deployment,Workflow,Created,Ended,Creator,Attributes,Actions,Status', type: Stage.Basic.GenericField.MULTI_SELECT_LIST_TYPE},
             {id: "showSystemExecutions", name: "Show system executions", default: true, type: Stage.Basic.GenericField.BOOLEAN_TYPE},
             Stage.GenericConfig.SORT_COLUMN_CONFIG('created_at'),
             Stage.GenericConfig.SORT_ASCENDING_CONFIG(false)


### PR DESCRIPTION
# Executions widget
![image](https://user-images.githubusercontent.com/5202105/47158678-757c5f00-d2ec-11e8-9dd0-3329aab3c194.png)

## System Workflow icon
![image](https://user-images.githubusercontent.com/5202105/47158698-7f05c700-d2ec-11e8-9990-0d0621e53e53.png)

## Dry Run icon
![image](https://user-images.githubusercontent.com/5202105/47158733-90e76a00-d2ec-11e8-8e91-322835e2289a.png)

# Execute workflow modal
![image](https://user-images.githubusercontent.com/5202105/47159580-77472200-d2ee-11e8-820c-29b9188a4db1.png)

## Force
![image](https://user-images.githubusercontent.com/5202105/47159607-84fca780-d2ee-11e8-9db4-9b85c18a162e.png)

## Dry run
![image](https://user-images.githubusercontent.com/5202105/47159629-93e35a00-d2ee-11e8-9ad3-e7a1fa5151f7.png)

## Queue
![image](https://user-images.githubusercontent.com/5202105/47159650-9cd42b80-d2ee-11e8-8ab3-ab63a62bb5b0.png)
