### PR TITLE
CY-713 - Align inputs/parameters in deployment creation/update, execute workflow modals and Inputs Step in Deployment Wizard

### DIFF
--- a/app/components/basic/RevertToDefaultIcon.js
+++ b/app/components/basic/RevertToDefaultIcon.js
@@ -25,13 +25,13 @@ export default class RevertToDefaultIcon extends Component {
 
     /**
      * propTypes
-     * @property {string} value field value
-     * @property {string} defaultValue field default value
+     * @property {any} value typed field value
+     * @property {any} defaultValue typed field default value
      * @property {function} onClick function to be called on revert icon click
      */
     static propTypes = {
-        value: PropTypes.string.isRequired,
-        defaultValue: PropTypes.string.isRequired,
+        value: PropTypes.any.isRequired,
+        defaultValue: PropTypes.any.isRequired,
         onClick: PropTypes.func.isRequired,
     };
 

--- a/app/components/basic/form/Form.js
+++ b/app/components/basic/form/Form.js
@@ -5,7 +5,7 @@
 import PropTypes from 'prop-types';
 
 import React, { Component } from 'react';
-import {Form as FormSemanticUiReact, Input as FormInput, TextArea, Radio as FormRadio,
+import {Form as FormSemanticUiReact, Radio as FormRadio,
         Button as FormButton} from 'semantic-ui-react';
 import ErrorMessage from '../ErrorMessage';
 import FormField from './FormField';
@@ -97,7 +97,7 @@ export default class Form extends Component {
     /**
      * Form text area input, see [TextArea](https://react.semantic-ui.com/addons/text-area)
      */
-    static TextArea = TextArea;
+    static TextArea = FormSemanticUiReact.TextArea;
 
     /**
      * Form radio button, see [Input](https://react.semantic-ui.com/addons/radio)

--- a/app/components/basic/form/FormField.js
+++ b/app/components/basic/form/FormField.js
@@ -40,7 +40,7 @@ import { PopupHelp } from '../index';
 export default class FormField extends Component {
     /**
      * propTypes
-     * @property {boolean} [error=null] error indicator (true - field has error, false - field has no errors)
+     * @property {any} [error=false] error indicator: true - field has error, false - field has no errors (value casted to boolean by !!error)
      * @property {string} [help=''] if not empty, then help description is shown in popup on field's hover and focus
      * @property {string} [label=''] if not empty, then it's content is shown on top of field
      * @property {boolean} [required] if true and label is set, then red asterisk icon is presented near label
@@ -53,7 +53,7 @@ export default class FormField extends Component {
     };
 
     static defaultProps = {
-        error: null,
+        error: false,
         help: '',
         label: '',
         required: false
@@ -76,10 +76,9 @@ export default class FormField extends Component {
 
     getFieldWrapper(props) {
         let {children, error, label, help, ...fieldProps} = props;
-        error = (_.isBoolean(error) && error) || !_.isEmpty(error);
 
         return (
-            <Form.Field {...fieldProps} error={error}>
+            <Form.Field {...fieldProps} error={!!error}>
                 {FormField.getLabel(label, help)}
                 {children}
             </Form.Field>

--- a/widgets/common/src/DeployBlueprintModal.js
+++ b/widgets/common/src/DeployBlueprintModal.js
@@ -13,7 +13,6 @@ class DeployBlueprintModal extends React.Component {
     }
 
     static EMPTY_BLUEPRINT = {id: '', plan: {inputs: {}}};
-    static EMPTY_STRING = '""';
 
     static initialState = {
         loading: false,
@@ -55,6 +54,7 @@ class DeployBlueprintModal extends React.Component {
     }
 
     _submitDeploy() {
+        let {InputsUtils} = Stage.Common;
         let errors = {};
 
         if (!this.props.blueprint) {
@@ -65,10 +65,11 @@ class DeployBlueprintModal extends React.Component {
             errors['deploymentName']='Please provide deployment name';
         }
 
-        let deploymentInputs
-            = Stage.Common.InputsUtils.getInputsToSend(this.props.blueprint.plan.inputs,
-                                                       this.state.deploymentInputs,
-                                                       errors);
+        let inputsWithoutValue = {};
+        const deploymentInputs = InputsUtils.getInputsToSend(this.props.blueprint.plan.inputs,
+                                                             this.state.deploymentInputs,
+                                                             inputsWithoutValue);
+        InputsUtils.addErrors(inputsWithoutValue, errors);
 
         if (!_.isEmpty(errors)) {
             this.setState({errors});

--- a/widgets/common/src/DeployBlueprintModal.js
+++ b/widgets/common/src/DeployBlueprintModal.js
@@ -175,9 +175,9 @@ class DeployBlueprintModal extends React.Component {
 
                         {
                             InputsUtils.getInputFields(blueprint.plan.inputs,
-                                this._handleDeploymentInputChange.bind(this),
-                                this.state.deploymentInputs,
-                                this.state.errors)
+                                                       this._handleDeploymentInputChange.bind(this),
+                                                       this.state.deploymentInputs,
+                                                       this.state.errors)
                         }
                         <Form.Field className='skipPluginsValidationCheckbox'>
                             <Form.Checkbox toggle

--- a/widgets/common/src/InputsHeader.js
+++ b/widgets/common/src/InputsHeader.js
@@ -12,42 +12,49 @@ class InputsHeader extends React.Component {
 
     static propTypes = {
         compact: PropTypes.bool,
+        dividing: PropTypes.bool,
         header: PropTypes.string
     };
 
     static defaultProps = {
         compact: false,
+        dividing: true,
         header: 'Deployment inputs'
     };
 
     render () {
         let {Form, Header, List, PopupHelp} = Stage.Basic;
 
-        return (
-            <Form.Divider style={this.props.compact ? {marginTop: 0} : {}}>
-                <Header size="tiny">
-                    {this.props.header}
-                    <Header.Subheader>
-                        See values typing details:&nbsp;
-                        <PopupHelp flowing content={
-                            <div>
-                                Values are casted to types, e.g.:
-                                <List bulleted>
-                                    <List.Item><strong>[1, 2]</strong> will be casted to an array</List.Item>
-                                    <List.Item><strong>524</strong> will be casted to a number</List.Item>
-                                </List>
-                                Surround value with <strong>"</strong> to explicitly declare it as a string, e.g.:
-                                <List bulleted>
-                                    <List.Item><strong>{'"{"a":"b"}"'}</strong> will be send as string not an object</List.Item>
-                                    <List.Item><strong>{'"true"'}</strong> will be send as string not a boolean value</List.Item>
-                                </List>
-                                Use <strong>""</strong> for an empty string.
-                            </div>
-                        } />
-                    </Header.Subheader>
-                </Header>
-            </Form.Divider>
-        );
+        let HeaderWithDescription = () =>
+            <Header size="tiny">
+                {this.props.header}
+                <Header.Subheader>
+                    See values typing details:&nbsp;
+                    <PopupHelp flowing content={
+                        <div>
+                            Values are casted to types, e.g.:
+                            <List bulleted>
+                                <List.Item><strong>[1, 2]</strong> will be casted to an array</List.Item>
+                                <List.Item><strong>524</strong> will be casted to a number</List.Item>
+                            </List>
+                            Surround value with <strong>"</strong> to explicitly declare it as a string, e.g.:
+                            <List bulleted>
+                                <List.Item><strong>{'"{"a":"b"}"'}</strong> will be send as string not an object</List.Item>
+                                <List.Item><strong>{'"true"'}</strong> will be send as string not a boolean value</List.Item>
+                            </List>
+                            Use <strong>""</strong> for an empty string.
+                        </div>
+                    } />
+                </Header.Subheader>
+            </Header>;
+
+        return this.props.dividing
+            ?
+                <Form.Divider style={this.props.compact ? {marginTop: 0} : {}}>
+                    <HeaderWithDescription />
+                </Form.Divider>
+            :
+                <HeaderWithDescription />
     }
 }
 

--- a/widgets/common/src/InputsUtils.js
+++ b/widgets/common/src/InputsUtils.js
@@ -41,59 +41,94 @@ class InputsUtils {
 
     /* Components */
 
-    static getRevertToDefaultIcon(name, value, defaultValue, inputChangeFunction) {
+    static getRevertToDefaultIcon(name, value, defaultValue, inputChangeFunction, typedRevert = false) {
         let {RevertToDefaultIcon} = Stage.Basic;
         let {JsonUtils} = Stage.Common;
 
         const stringValue = JsonUtils.getStringValue(value);
         const typedValue = _.startsWith(stringValue, InputsUtils.STRING_VALUE_SURROUND_CHAR) &&
-                           _.endsWith(stringValue, InputsUtils.STRING_VALUE_SURROUND_CHAR)
+                           _.endsWith(stringValue, InputsUtils.STRING_VALUE_SURROUND_CHAR) &&
+                           _.size(stringValue) > 1
             ? stringValue.slice(1, -1)
             : JsonUtils.getTypedValue(value);
 
         const stringDefaultValue = InputsUtils.getInputFieldInitialValue(defaultValue);
         const typedDefaultValue = defaultValue;
 
-        const revertToDefault = () => inputChangeFunction(null, {name, value: stringDefaultValue});
+        const revertToDefault = () => inputChangeFunction(null, {name, value: typedRevert ? typedDefaultValue : stringDefaultValue});
 
+        console.error(name, value, defaultValue);
         return _.isNil(typedDefaultValue)
             ? undefined
             : <RevertToDefaultIcon value={typedValue} defaultValue={typedDefaultValue} onClick={revertToDefault} />;
     }
 
-    static getFormInputField(name, value, defaultValue, description, onChange, error) {
+    static getFormInputField(name, value, defaultValue, description, onChange, error, type) {
         let {Form} = Stage.Basic;
 
-        return (
-            <Form.Field key={name} error={error} help={description} required={_.isNil(defaultValue)} label={name}>
-                {InputsUtils.getInputField(name, value, defaultValue, onChange, error)}
-            </Form.Field>
-        );
+        switch (type) {
+            case 'boolean':
+                return (
+                    <Form.Field key={name} help={description} required={_.isNil(defaultValue)}>
+                        {InputsUtils.getInputField(name, value, defaultValue, onChange, error, type)}
+                    </Form.Field>
+                );
+            case 'integer':
+                return (
+                    <Form.Field key={name} error={error} help={description} required={_.isNil(defaultValue)} label={name}>
+                        {InputsUtils.getInputField(name, value, defaultValue, onChange, error, type)}
+                    </Form.Field>
+                );
+            default:
+                return (
+                    <Form.Field key={name} error={error} help={description} required={_.isNil(defaultValue)} label={name}>
+                        {InputsUtils.getInputField(name, value, defaultValue, onChange, error, type)}
+                    </Form.Field>
+                );
+        }
     }
 
-    static getInputField(name, value, defaultValue, onChange, error) {
+    static getInputField(name, value, defaultValue, onChange, error, type) {
         let {Form} = Stage.Basic;
 
-        return _.includes(value, '\n')
-            ?
-            <Form.Group >
-                <Form.Field width={15}>
-                    <Form.TextArea name={name} value={value} onChange={onChange} />
-                </Form.Field>
-                <Form.Field width={1} style={{textAlign: 'center'}}>
-                    {InputsUtils.getRevertToDefaultIcon(name, value, defaultValue, onChange)}
-                </Form.Field>
-            </Form.Group>
-            :
-            <Form.Input name={name} value={value} fluid error={!!error}
-                        icon={InputsUtils.getRevertToDefaultIcon(name, value, defaultValue, onChange)}
-                        onChange={onChange} />;
+        switch (type) {
+            case 'boolean':
+                return (
+                    <Form.Group>
+                        <Form.Checkbox name={name} toggle label={name} checked={value} onChange={onChange} />
+                        <Form.Field width={1}>
+                            {InputsUtils.getRevertToDefaultIcon(name, value, defaultValue, onChange, true)}
+                        </Form.Field>
+                    </Form.Group>
+                );
+
+            case 'integer':
+                return <Form.Input name={name} value={value} fluid error={!!error} type='number'
+                                   icon={InputsUtils.getRevertToDefaultIcon(name, value, defaultValue, onChange)}
+                                   onChange={onChange} />;
+
+            default:
+                return _.includes(value, '\n')
+                    ?
+                    <Form.Group >
+                        <Form.Field width={15}>
+                            <Form.TextArea name={name} value={value} onChange={onChange} />
+                        </Form.Field>
+                        <Form.Field width={1} style={{textAlign: 'center'}}>
+                            {InputsUtils.getRevertToDefaultIcon(name, value, defaultValue, onChange)}
+                        </Form.Field>
+                    </Form.Group>
+                    :
+                    <Form.Input name={name} value={value} fluid error={!!error}
+                                icon={InputsUtils.getRevertToDefaultIcon(name, value, defaultValue, onChange)}
+                                onChange={onChange} />;
+        }
     }
 
-    static getInputFields(blueprintPlanInputs, onChange, inputsState, errorsState) {
+    static getInputFields(inputs, onChange, inputsState, errorsState) {
         let enhancedInputs
             = _.sortBy(
-                _.map(blueprintPlanInputs, (input, name) => ({'name': name, ...input})),
+                _.map(inputs, (input, name) => ({'name': name, ...input})),
                 [(input => !_.isNil(input.default)), 'name']);
 
         return _.map(enhancedInputs, (input) =>
@@ -102,7 +137,8 @@ class InputsUtils {
                                           input.default,
                                           input.description,
                                           onChange,
-                                          errorsState[input.name])
+                                          errorsState[input.name],
+                                          input.type) // only valid for workflow parameters
         );
     }
 
@@ -149,7 +185,8 @@ class InputsUtils {
             if (_.isEmpty(stringInputValue) && _.isNil(inputObj.default)) {
                 inputsWithoutValues[inputName] = true;
             } else if (_.startsWith(stringInputValue, InputsUtils.STRING_VALUE_SURROUND_CHAR) &&
-                       _.endsWith(stringInputValue, InputsUtils.STRING_VALUE_SURROUND_CHAR)) {
+                       _.endsWith(stringInputValue, InputsUtils.STRING_VALUE_SURROUND_CHAR) &&
+                       _.size(stringInputValue) > 1) {
                 typedInputValue = stringInputValue.slice(1, -1);
             }
 

--- a/widgets/common/src/InputsUtils.js
+++ b/widgets/common/src/InputsUtils.js
@@ -1,0 +1,156 @@
+/**
+ * Created by jakubniezgoda on 18/10/2018.
+ */
+
+class InputsUtils {
+
+    static DEFAULT_VALUE_STRING = '';
+    static STRING_VALUE_SURROUND_CHAR = '"';
+    static EMPTY_STRING = '""';
+
+
+    /* Helper functions */
+
+    static getEnhancedStringValue(value) {
+        let {JsonUtils} = Stage.Common;
+        let stringValue = JsonUtils.getStringValue(value);
+
+        if (stringValue === '') {
+            return InputsUtils.EMPTY_STRING;
+        } else {
+            let valueType = JsonUtils.toType(value);
+            let castedValue = JsonUtils.getTypedValue(stringValue);
+            let castedValueType = JsonUtils.toType(castedValue);
+
+            if (valueType !== castedValueType) {
+                stringValue = `"${stringValue}"`;
+            }
+
+            return stringValue;
+        }
+    }
+
+    static getInputFieldInitialValue(defaultValue) {
+        if (_.isNil(defaultValue)) {
+            return InputsUtils.DEFAULT_VALUE_STRING;
+        } else {
+            return InputsUtils.getEnhancedStringValue(defaultValue);
+        }
+    }
+
+
+    /* Components */
+
+    static getRevertToDefaultIcon(name, value, defaultValue, inputChangeFunction) {
+        let {RevertToDefaultIcon} = Stage.Basic;
+        let {JsonUtils} = Stage.Common;
+
+        const valueString = _.trim(JsonUtils.getStringValue(value), InputsUtils.STRING_VALUE_SURROUND_CHAR);
+        const defaultValueString = JsonUtils.getStringValue(defaultValue);
+        const revertToDefault = () => inputChangeFunction(null, {name, value: defaultValueString});
+
+        return _.isNil(defaultValue)
+            ? undefined
+            : <RevertToDefaultIcon value={valueString}
+                                   defaultValue={defaultValueString}
+                                   onClick={revertToDefault} />;
+    }
+
+    static getFormInputField(name, value, defaultValue, description, onChange, error) {
+        let {Form} = Stage.Basic;
+
+        return (
+            <Form.Field key={name} error={error} help={description} required={_.isNil(defaultValue)} label={name}>
+                {InputsUtils.getInputField(name, value, defaultValue, onChange, error)}
+            </Form.Field>
+        );
+    }
+
+    static getInputField(name, value, defaultValue, onChange, error) {
+        let {Form} = Stage.Basic;
+
+        return (
+            <Form.Input name={name} value={value} fluid error={error}
+                        icon={InputsUtils.getRevertToDefaultIcon(name, value, defaultValue, onChange)}
+                        onChange={onChange} />
+        );
+    }
+
+    static getInputFields(blueprintPlanInputs, onChange, inputsState, errorsState) {
+        let enhancedInputs
+            = _.sortBy(
+                _.map(blueprintPlanInputs, (input, name) => ({'name': name, ...input})),
+                [(input => !_.isNil(input.default)), 'name']);
+
+        return _.map(enhancedInputs, (input) =>
+            InputsUtils.getFormInputField(input.name,
+                                          inputsState[input.name],
+                                          input.default,
+                                          input.description,
+                                          onChange,
+                                          errorsState[input.name])
+        );
+    }
+
+
+    /* Inputs for field values (string values) */
+
+    static getInputsFromPlan(blueprintPlanInputs) {
+        let deploymentInputs = {};
+
+        _.forEach(blueprintPlanInputs, (inputObj, inputName) => {
+            deploymentInputs[inputName] = InputsUtils.getInputFieldInitialValue(inputObj.default);
+        });
+
+        return deploymentInputs;
+    }
+
+    static getInputsFromYaml(blueprintPlanInputs, inputsValues, notFoundInputs) {
+        let deploymentInputs = {};
+
+        _.forEach(blueprintPlanInputs, (inputObj, inputName) => {
+            let inputValue = inputsValues[inputName];
+
+            if (_.isNil(inputValue) && _.isNil(inputObj.default)) {
+                notFoundInputs.push(inputName);
+            } else {
+                deploymentInputs[inputName] = InputsUtils.getInputFieldInitialValue(inputValue);
+            }
+        });
+
+        return deploymentInputs;
+    }
+
+
+    /* Inputs for REST API (typed values) */
+
+    static getInputsToSend(blueprintPlanInputs, inputsValues, errors, inputsWithoutValues = {}) {
+        let {JsonUtils} = Stage.Common;
+        let deploymentInputs = {};
+
+        _.forEach(blueprintPlanInputs, (inputObj, inputName) => {
+            let stringInputValue = inputsValues[inputName];
+            let typedInputValue = JsonUtils.getTypedValue(stringInputValue);
+
+            if (_.isEmpty(stringInputValue) && _.isNil(inputObj.default)) {
+                errors[inputName] = `Please provide ${inputName}`;
+                inputsWithoutValues[inputName] = true;
+            } else if (_.first(stringInputValue) === InputsUtils.STRING_VALUE_SURROUND_CHAR &&
+                _.last(stringInputValue) === InputsUtils.STRING_VALUE_SURROUND_CHAR) {
+                typedInputValue = _.trim(stringInputValue, InputsUtils.STRING_VALUE_SURROUND_CHAR);
+            }
+
+            if (!_.isEqual(typedInputValue, inputObj.default)) {
+                deploymentInputs[inputName] = typedInputValue;
+            }
+        });
+
+        return deploymentInputs;
+    }
+
+}
+
+Stage.defineCommon({
+    name: 'InputsUtils',
+    common: InputsUtils
+});

--- a/widgets/common/src/InputsUtils.js
+++ b/widgets/common/src/InputsUtils.js
@@ -174,11 +174,11 @@ class InputsUtils {
 
     /* Inputs for REST API (typed values) */
 
-    static getInputsToSend(blueprintPlanInputs, inputsValues, inputsWithoutValues) {
+    static getInputsToSend(inputs, inputsValues, inputsWithoutValues) {
         let {JsonUtils} = Stage.Common;
         let deploymentInputs = {};
 
-        _.forEach(blueprintPlanInputs, (inputObj, inputName) => {
+        _.forEach(inputs, (inputObj, inputName) => {
             let stringInputValue = inputsValues[inputName];
             let typedInputValue = JsonUtils.getTypedValue(stringInputValue);
 

--- a/widgets/common/src/UpdateDeploymentModal.js
+++ b/widgets/common/src/UpdateDeploymentModal.js
@@ -209,9 +209,9 @@ class UpdateDeploymentModal extends React.Component {
 
                         {
                             InputsUtils.getInputFields(this.state.blueprint.plan.inputs,
-                                this._handleDeploymentInputChange.bind(this),
-                                this.state.deploymentInputs,
-                                this.state.errors)
+                                                       this._handleDeploymentInputChange.bind(this),
+                                                       this.state.deploymentInputs,
+                                                       this.state.errors)
                         }
 
                         <Form.Divider>

--- a/widgets/deploymentButton/src/DeployModal.js
+++ b/widgets/deploymentButton/src/DeployModal.js
@@ -79,6 +79,7 @@ export default class DeployModal extends React.Component {
     }
 
     _submitDeploy () {
+        let {InputsUtils} = Stage.Common;
         let errors = {};
 
         if (_.isEmpty(this.state.blueprint.id)) {
@@ -89,10 +90,11 @@ export default class DeployModal extends React.Component {
             errors['deploymentName']='Please provide deployment name';
         }
 
-        let deploymentInputs
-            = Stage.Common.InputsUtils.getInputsToSend(this.state.blueprint.plan.inputs,
-                                                       this.state.deploymentInputs,
-                                                       errors);
+        let inputsWithoutValue = {};
+        const deploymentInputs = InputsUtils.getInputsToSend(this.state.blueprint.plan.inputs,
+                                                             this.state.deploymentInputs,
+                                                             inputsWithoutValue);
+        InputsUtils.addErrors(inputsWithoutValue, errors);
 
         if (!_.isEmpty(errors)) {
             this.setState({errors});

--- a/widgets/deploymentButton/src/DeployModal.js
+++ b/widgets/deploymentButton/src/DeployModal.js
@@ -196,9 +196,9 @@ export default class DeployModal extends React.Component {
 
                         {
                             InputsUtils.getInputFields(this.state.blueprint.plan.inputs,
-                                    this._handleDeploymentInputChange.bind(this),
-                                    this.state.deploymentInputs,
-                                    this.state.errors)
+                                                       this._handleDeploymentInputChange.bind(this),
+                                                       this.state.deploymentInputs,
+                                                       this.state.errors)
                         }
                         <Form.Field className='skipPluginsValidationCheckbox'>
                             <Form.Checkbox toggle

--- a/widgets/deploymentWizardButtons/src/steps/InputsStep.js
+++ b/widgets/deploymentWizardButtons/src/steps/InputsStep.js
@@ -80,11 +80,7 @@ class InputsStepContent extends Component {
                 if (!_.isUndefined(this.props.stepData[inputName])) {
                     return this.props.stepData[inputName];
                 } else {
-                    if (!_.isUndefined(inputData.default)) {
-                        return Stage.Common.JsonUtils.getStringValue(inputData.default);
-                    } else {
-                        return InputsStepContent.defaultInputValue;
-                    }
+                    return Stage.Common.InputsUtils.getInputFieldInitialValue(inputData.default);
                 }
             }
         );
@@ -103,21 +99,9 @@ class InputsStepContent extends Component {
         }
     }
 
-    getRevertToDefaultIcon(name, value, defaultValue) {
-        let {RevertToDefaultIcon} = Stage.Basic;
-        let {JsonUtils} = Stage.Common;
-
-        const valueString = JsonUtils.getStringValue(value);
-        const defaultValueString = JsonUtils.getStringValue(defaultValue);
-        const revertToDefault = () => this.handleChange(null, {name, value: defaultValueString});
-
-        return _.isNil(defaultValue)
-            ? undefined
-            : <RevertToDefaultIcon value={valueString} defaultValue={defaultValueString} onClick={revertToDefault} />;
-    }
-
     render() {
         let {Form, Table} = Stage.Basic;
+        let {InputsUtils} = Stage.Common;
 
         const inputs = _.get(this.props.wizardData, InputsStepContent.dataPath, {});
         const noInputs = _.isEmpty(inputs);
@@ -150,12 +134,13 @@ class InputsStepContent extends Component {
                                                 {this.getInputStatus(inputs[inputName].default)}
                                             </Table.Cell>
                                             <Table.Cell>
-                                                <Form.Input name={inputName} error={this.props.errors[inputName]} fluid
-                                                            icon={this.getRevertToDefaultIcon(inputName,
-                                                                                              this.props.stepData[inputName],
-                                                                                              inputs[inputName].default)}
-                                                            value={this.props.stepData[inputName]}
-                                                            onChange={this.handleChange.bind(this)}/>
+                                                {
+                                                    InputsUtils.getInputField(inputName,
+                                                                              this.props.stepData[inputName],
+                                                                              inputs[inputName].default,
+                                                                              this.handleChange.bind(this),
+                                                                              this.props.errors[inputName])
+                                                }
                                             </Table.Cell>
                                         </Table.Row>
                                     )

--- a/widgets/deploymentWizardButtons/src/steps/InputsStep.js
+++ b/widgets/deploymentWizardButtons/src/steps/InputsStep.js
@@ -21,28 +21,14 @@ class InputsStepActions extends Component {
     static dataPath = 'blueprint.inputs';
 
     onNext(id) {
-        const {DeployBlueprintModal, JsonUtils} = Stage.Common;
+        const {InputsUtils} = Stage.Common;
 
         return this.props.onLoading()
             .then(this.props.fetchData)
             .then(({stepData}) => {
-                let deploymentInputs = {};
                 let inputsWithoutValues = {};
-
-                _.forEach(_.get(this.props.wizardData, InputsStepActions.dataPath, {}), (inputObj, inputName) => {
-                    let stringInputValue = stepData[inputName];
-                    let typedInputValue = JsonUtils.getTypedValue(stringInputValue);
-
-                    if (_.isEmpty(stringInputValue)) {
-                        if (_.isNil(inputObj.default)) {
-                            inputsWithoutValues[inputName] = true;
-                        }
-                    } else if (stringInputValue === DeployBlueprintModal.EMPTY_STRING) {
-                        deploymentInputs[inputName] = '';
-                    } else if (!_.isEqual(typedInputValue, inputObj.default)) {
-                        deploymentInputs[inputName] = typedInputValue;
-                    }
-                });
+                const blueprintInputsPlan = _.get(this.props.wizardData, InputsStepActions.dataPath, {});
+                const deploymentInputs = InputsUtils.getInputsToSend(blueprintInputsPlan, stepData, inputsWithoutValues);
 
                 if (!_.isEmpty(inputsWithoutValues)) {
                     return Promise.reject({
@@ -70,7 +56,6 @@ class InputsStepContent extends Component {
 
     static propTypes = Stage.Basic.Wizard.Step.Content.propTypes;
 
-    static defaultInputValue = '';
     static dataPath = 'blueprint.inputs';
 
     componentDidMount() {
@@ -101,7 +86,7 @@ class InputsStepContent extends Component {
 
     render() {
         let {Form, Table} = Stage.Basic;
-        let {InputsUtils} = Stage.Common;
+        let {InputsUtils, InputsHeader} = Stage.Common;
 
         const inputs = _.get(this.props.wizardData, InputsStepContent.dataPath, {});
         const noInputs = _.isEmpty(inputs);
@@ -117,7 +102,7 @@ class InputsStepContent extends Component {
                             <Table.Header>
                                 <Table.Row>
                                     <Table.HeaderCell>Input</Table.HeaderCell>
-                                    <Table.HeaderCell colSpan='2'>Value (use "" for an empty string)</Table.HeaderCell>
+                                    <Table.HeaderCell colSpan='2'><InputsHeader header='Value' dividing={false} /></Table.HeaderCell>
                                 </Table.Row>
                             </Table.Header>
 


### PR DESCRIPTION
# Features
- reduced duplicated code by creating InputsUtils with helper functions for all deployment inputs and execution parameters
- grouped (required, optional) and sorted parameters in execute worklow modal
![image](https://user-images.githubusercontent.com/5202105/47219354-e2582d80-d3ae-11e8-9618-b907d438dab6.png)
- added support for multiline strings (as for now only if input has multiline default value)
![tempsnip](https://user-images.githubusercontent.com/5202105/47219523-58f52b00-d3af-11e8-968e-391f51576bf1.png)
- added revert to default value icon for execution parameters defined as booleans with default values
![tempsnip](https://user-images.githubusercontent.com/5202105/47222341-c3f63000-d3b6-11e8-9510-ca0433143269.png)


# Bug fixes
- fixed calulating Revert to Default Value icon presence (not proper in some very specific cases)