### PR TITLE
CY-736 - Add extended error message modal for events/logs with error_causes

### DIFF
--- a/widgets/events/src/ErrorCausesIcon.js
+++ b/widgets/events/src/ErrorCausesIcon.js
@@ -1,0 +1,43 @@
+/**
+ * Created by jakub.niezgoda on 29/10/2018.
+ */
+
+import PropTypes from 'prop-types';
+
+export default class ErrorCausesModal extends React.Component {
+
+    constructor(props, context){
+        super(props, context);
+    }
+
+    static propTypes = {
+        onClick: PropTypes.func,
+        show: PropTypes.bool
+    };
+
+    static defaultProps = {
+        onClick: _.noop,
+        show: false
+    };
+
+    render() {
+        let {Icon, Popup} = Stage.Basic;
+
+        return this.props.show
+            ?
+                <Popup on='hover'>
+                    <Popup.Trigger>
+                        <Icon.Group size='big' onClick={(e) => {e.stopPropagation(); this.props.onClick();}}>
+                            <Icon name='file text' color='red'/>
+                            <Icon corner name='zoom' color='black'/>
+                        </Icon.Group>
+                    </Popup.Trigger>
+                    <Popup.Content>
+                        Show Error Causes
+                    </Popup.Content>
+                </Popup>
+            :
+                null;
+    }
+}
+

--- a/widgets/events/src/ErrorCausesModal.js
+++ b/widgets/events/src/ErrorCausesModal.js
@@ -1,0 +1,66 @@
+/**
+ * Created by jakub.niezgoda on 29/10/2018.
+ */
+
+import PropTypes from 'prop-types';
+import React from 'react';
+
+export default class ErrorCausesModal extends React.Component {
+
+    constructor(props, context){
+        super(props, context);
+    }
+
+    static propTypes = {
+        open: PropTypes.bool,
+        onClose: PropTypes.func,
+        errorCauses: PropTypes.array
+    };
+
+    static defaultProps = {
+        open: false,
+        onClose: _.noop,
+        errorCauses: []
+    };
+
+    render() {
+        let {JsonUtils} = Stage.Common;
+        let {CancelButton, CopyToClipboardButton, Divider, Header, HighlightText, Message, Modal, Segment} = Stage.Basic;
+        const numberOfErrorCauses = _.size(this.props.errorCauses);
+
+        return numberOfErrorCauses > 0
+            ?
+                <Modal open={this.props.open} onClose={this.props.onClose}>
+                    <Modal.Header>
+                        Error Causes
+                    </Modal.Header>
+                    <Modal.Content scrolling>
+                        {
+                            _.map(this.props.errorCauses, ({message, traceback, type}, index) =>
+                                <Segment key={`errorCause_${index}`} basic>
+                                    {
+                                        numberOfErrorCauses > 1 &&
+                                        <React.Fragment>
+                                            <Header size='medium'>Error Cause #{index + 1}</Header>
+                                            <Divider/>
+                                        </React.Fragment>
+                                    }
+                                    <Header size='small'>Type</Header>
+                                    <Message info>{type}</Message>
+                                    <Header size='small'>Message</Header>
+                                    <Message error>{message}</Message>
+                                    <Header size='small'>Traceback</Header>
+                                    <HighlightText className='python'>{traceback}</HighlightText>
+                                </Segment>
+                            )
+                        }
+                    </Modal.Content>
+                    <Modal.Actions>
+                        <CopyToClipboardButton content='Copy Error Causes' text={JsonUtils.stringify(this.props.errorCauses, true)} />
+                        <CancelButton onClick={(e) => {e.stopPropagation(); this.props.onClose()}} content="Close" />
+                    </Modal.Actions>
+                </Modal>
+            :
+                null;
+    }
+}

--- a/widgets/events/src/EventsTable.js
+++ b/widgets/events/src/EventsTable.js
@@ -2,13 +2,18 @@
  * Created by kinneretzin on 20/10/2016.
  */
 
+import ErrorCausesModal from './ErrorCausesModal';
+import ErrorCausesIcon from './ErrorCausesIcon';
+
 export default class EventsTable extends React.Component {
 
     constructor(props, context) {
         super(props, context);
 
         this.state = {
-            error: null
+            error: null,
+            errorCauses: [],
+            showErrorCausesModal: false,
         };
     }
 
@@ -39,6 +44,14 @@ export default class EventsTable extends React.Component {
     _selectEvent(eventId) {
         let selectedEventId = this.props.toolbox.getContext().getValue('eventId');
         this.props.toolbox.getContext().setValue('eventId', eventId === selectedEventId ? null : eventId);
+    }
+
+    showErrorCausesModal(errorCauses) {
+        this.setState({errorCauses, showErrorCausesModal: true});
+    }
+
+    hideErrorCausesModal() {
+        this.setState({errorCauses: [], showErrorCausesModal: false});
     }
 
     getHighlightedText(text) {
@@ -73,6 +86,7 @@ export default class EventsTable extends React.Component {
         const NO_DATA_MESSAGE = 'There are no Events/Logs available. Probably there\'s no deployment created, yet.';
         let {CopyToClipboardButton, DataTable, ErrorMessage, HighlightText, Icon, Popup} = Stage.Basic;
         let {JsonUtils, EventUtils} = Stage.Common;
+        const EmptySpace = () => <span>&nbsp;&nbsp;</span>;
 
         let fieldsToShow = this.props.widget.configuration.fieldsToShow;
         let colorLogs = this.props.widget.configuration.colorLogs;
@@ -164,7 +178,8 @@ export default class EventsTable extends React.Component {
                                     <DataTable.Data>{item.workflow_id}</DataTable.Data>
                                     <DataTable.Data>{item.operation}</DataTable.Data>
                                     <DataTable.Data>
-                                        {item.message &&
+                                        {
+                                            item.message &&
                                             <Popup position='top left' hoverable wide="very">
                                                 <Popup.Trigger>
                                                     <span>
@@ -179,12 +194,18 @@ export default class EventsTable extends React.Component {
                                                 </Popup.Content>
                                             </Popup>
                                         }
+                                        {!!item.error_causes && <EmptySpace />}
+                                        <ErrorCausesIcon show={!!item.error_causes}
+                                                         onClick={this.showErrorCausesModal.bind(this, item.error_causes)} />
                                     </DataTable.Data>
                                 </DataTable.Row>
                             );
                         })
                     }
                 </DataTable>
+                <ErrorCausesModal errorCauses={this.state.errorCauses}
+                                  open={this.state.showErrorCausesModal}
+                                  onClose={this.hideErrorCausesModal.bind(this)} />
             </div>
         );
     }


### PR DESCRIPTION
# New icon to Show Error Causes in Message column
![image](https://user-images.githubusercontent.com/5202105/47713854-907b9700-dc3b-11e8-847a-ad06af91e206.png)

# New modal opened on click on Show Error Causes icon
![image](https://user-images.githubusercontent.com/5202105/47713900-a4bf9400-dc3b-11e8-8a84-c15d50693574.png)
