### PR TITLE
CY-759 - Add force flag in blueprint and plugins deletion confirmation modal

### DIFF
--- a/widgets/blueprintActionButtons/src/BlueprintActionButtons.js
+++ b/widgets/blueprintActionButtons/src/BlueprintActionButtons.js
@@ -16,7 +16,8 @@ export default class BlueprintActionButtons extends React.Component {
             showModal: false,
             modalType: '',
             loading: false,
-            error: null
+            error: null,
+            force: false
         }
     }
 
@@ -27,7 +28,7 @@ export default class BlueprintActionButtons extends React.Component {
     }
 
     _showModal(type) {
-        this.setState({modalType: type, showModal: true});
+        this.setState({modalType: type, showModal: true, force: false});
     }
 
     _hideModal() {
@@ -38,11 +39,15 @@ export default class BlueprintActionButtons extends React.Component {
         return this.state.modalType === type && this.state.showModal;
     }
 
+    _handleForceChange(event, field) {
+        this.setState(Stage.Basic.Form.fieldNameValue(field));
+    }
+
     _deleteBlueprint() {
         this.props.toolbox.loading(true);
         this.setState({loading: true});
         let actions = new Stage.Common.BlueprintActions(this.props.toolbox);
-        actions.doDelete(this.props.blueprint).then(()=> {
+        actions.doDelete(this.props.blueprint, this.state.force).then(()=> {
             this.props.toolbox.getEventBus().trigger('blueprints:refresh');
             this.setState({loading: false, error: null});
             this._hideModal();
@@ -60,8 +65,8 @@ export default class BlueprintActionButtons extends React.Component {
     }
 
     render() {
-        let {ErrorMessage, Button, Confirm} = Stage.Basic;
-        let {DeployBlueprintModal} = Stage.Common;
+        let {ErrorMessage, Button} = Stage.Basic;
+        let {DeleteConfirm, DeployBlueprintModal} = Stage.Common;
 
         let blueprintId = this.props.blueprint.id;
 
@@ -82,10 +87,13 @@ export default class BlueprintActionButtons extends React.Component {
                                       onHide={this._hideModal.bind(this)}
                                       toolbox={this.props.toolbox}/>
 
-                <Confirm content={`Are you sure you want to remove blueprint ${blueprintId}?`}
-                         open={this._isShowModal(BlueprintActionButtons.DELETE_ACTION)}
-                         onConfirm={this._deleteBlueprint.bind(this, blueprintId)}
-                         onCancel={this._hideModal.bind(this)} className="blueprintRemoveConfirm"/>
+                <DeleteConfirm resourceName={`blueprint ${blueprintId}`}
+                               force={this.state.force}
+                               open={this._isShowModal(BlueprintActionButtons.DELETE_ACTION)}
+                               onConfirm={this._deleteBlueprint.bind(this)}
+                               onCancel={this._hideModal.bind(this)}
+                               onForceChange={this._handleForceChange.bind(this)}
+                               className="blueprintRemoveConfirm" />
 
             </div>
         );

--- a/widgets/blueprints/src/BlueprintsList.js
+++ b/widgets/blueprints/src/BlueprintsList.js
@@ -15,7 +15,9 @@ export default class BlueprintList extends React.Component {
             showUploadModal: false,
             blueprint: {},
             confirmDelete:false,
-            error: null
+            error: null,
+            force: false,
+            item: {id: ''}
         }
     }
 
@@ -47,7 +49,8 @@ export default class BlueprintList extends React.Component {
     _deleteBlueprintConfirm(item){
         this.setState({
             confirmDelete : true,
-            item: item
+            item: item,
+            force: false
         });
     }
 
@@ -59,7 +62,7 @@ export default class BlueprintList extends React.Component {
 
         var actions = new Stage.Common.BlueprintActions(this.props.toolbox);
         this.setState({confirmDelete: false});
-        actions.doDelete(this.state.item)
+        actions.doDelete(this.state.item, this.state.force)
             .then(()=> {
                 this.setState({error: null});
                 this.props.toolbox.refresh();
@@ -107,14 +110,18 @@ export default class BlueprintList extends React.Component {
         this.setState({showUploadModal: false});
     }
 
+    _handleForceChange(event, field) {
+        this.setState(Stage.Basic.Form.fieldNameValue(field));
+    }
+
     fetchGridData(fetchParams) {
         return this.props.toolbox.refresh(fetchParams);
     }
 
     render() {
         const NO_DATA_MESSAGE = 'There are no Blueprints available. Click "Upload" to add Blueprints.';
-        let {Button, Confirm, ErrorMessage} = Stage.Basic;
-        let {DeployBlueprintModal, UploadBlueprintModal} = Stage.Common;
+        let {Button, ErrorMessage} = Stage.Basic;
+        let {DeleteConfirm, DeployBlueprintModal, UploadBlueprintModal} = Stage.Common;
 
         var shouldShowTable = this.props.widget.configuration['displayStyle'] === 'table';
 
@@ -151,10 +158,12 @@ export default class BlueprintList extends React.Component {
 
                 }
 
-                <Confirm content='Are you sure you want to remove this blueprint?'
-                         open={this.state.confirmDelete}
-                         onConfirm={this._deleteBlueprint.bind(this)}
-                         onCancel={()=>this.setState({confirmDelete : false})} />
+                <DeleteConfirm resourceName={`blueprint ${_.get(this.state.item, 'id', '')}`}
+                               force={this.state.force}
+                               open={this.state.confirmDelete}
+                               onConfirm={this._deleteBlueprint.bind(this)}
+                               onCancel={() => this.setState({confirmDelete : false})}
+                               onForceChange={this._handleForceChange.bind(this)} />
 
                 <DeployBlueprintModal open={this.state.showDeploymentModal}
                                       blueprint={this.state.blueprint}

--- a/widgets/common/src/BlueprintActions.js
+++ b/widgets/common/src/BlueprintActions.js
@@ -15,12 +15,12 @@ class BlueprintActions {
         return this.toolbox.getManager().doGet(`/blueprints/${blueprint.id}`);
     }
 
-    doDelete(blueprint) {
-        return this.toolbox.getManager().doDelete(`/blueprints/${blueprint.id}`)
-            .then(()=>this.doDeleteImage(blueprint.id));
+    doDelete(blueprint, force = false) {
+        return this.toolbox.getManager().doDelete(`/blueprints/${blueprint.id}`, {force})
+            .then(() => this.doDeleteImage(blueprint.id));
     }
 
-    doDeploy(blueprint, deploymentId, inputs, visibility, skipPluginsValidation=false) {
+    doDeploy(blueprint, deploymentId, inputs, visibility, skipPluginsValidation = false) {
         return this.toolbox.getManager().doPut(`/deployments/${deploymentId}`, null, {
             'blueprint_id': blueprint.id,
             inputs,

--- a/widgets/common/src/DeleteConfirm.js
+++ b/widgets/common/src/DeleteConfirm.js
@@ -1,0 +1,52 @@
+/**
+ * Created by jakubniezgoda on 07/11/2018.
+ */
+
+import PropTypes from 'prop-types';
+
+class DeleteConfirm extends React.Component {
+
+    constructor(props,context) {
+        super(props,context);
+    }
+
+    static propTypes = {
+        resourceName: PropTypes.string.isRequired,
+        onConfirm: PropTypes.func.isRequired,
+        onCancel: PropTypes.func.isRequired,
+        open: PropTypes.bool.isRequired,
+        className: PropTypes.string,
+        force: PropTypes.bool,
+        onForceChange: PropTypes.func
+    };
+
+    static defaultProps = {
+        className: '',
+        force: false,
+        onForceChange: _.noop
+    };
+
+    render () {
+        let {Confirm, Form, Segment} = Stage.Basic;
+
+        return <Confirm className={this.props.className}
+                        header={`Are you sure you want to remove ${this.props.resourceName}?`}
+                        content={
+                            <Segment basic>
+                                <Form.Field>
+                                    <Form.Checkbox name='force' toggle label='Force'
+                                                   checked={this.props.force}
+                                                   onChange={this.props.onForceChange} />
+                                </Form.Field>
+                            </Segment>
+                        }
+                        open={this.props.open}
+                        onConfirm={this.props.onConfirm}
+                        onCancel={this.props.onCancel} />
+    }
+}
+
+Stage.defineCommon({
+    name: 'DeleteConfirm',
+    common: DeleteConfirm
+});

--- a/widgets/common/src/PluginActions.js
+++ b/widgets/common/src/PluginActions.js
@@ -8,8 +8,8 @@ class PluginActions {
         this.toolbox = toolbox;
     }
 
-    doDelete(plugin) {
-        return this.toolbox.getManager().doDelete(`/plugins/${plugin.id}`,null,{force:true});
+    doDelete(plugin, force = true) {
+        return this.toolbox.getManager().doDelete(`/plugins/${plugin.id}`, null, {force});
 
     }
 

--- a/widgets/plugins/src/PluginsTable.js
+++ b/widgets/plugins/src/PluginsTable.js
@@ -9,6 +9,7 @@ export default class extends React.Component {
 
         this.state = {
             error: null,
+            force: true,
             confirmDelete: false,
             showUploadModal: false,
             hoveredPlugin: false
@@ -35,7 +36,8 @@ export default class extends React.Component {
 
         this.setState({
             confirmDelete: true,
-            item: item
+            item: item,
+            force: true
         });
     }
 
@@ -55,7 +57,7 @@ export default class extends React.Component {
         }
 
         var actions = new Stage.Common.PluginActions(this.props.toolbox);
-        actions.doDelete(this.state.item)
+        actions.doDelete(this.state.item, this.state.force)
             .then(()=> {
                 this.setState({confirmDelete: false, error: null});
                 this.props.toolbox.getEventBus().trigger('plugins:refresh');
@@ -91,6 +93,10 @@ export default class extends React.Component {
         this.props.toolbox.refresh();
     }
 
+    _handleForceChange(event, field) {
+        this.setState(Stage.Basic.Form.fieldNameValue(field));
+    }
+
     componentDidMount() {
         this.props.toolbox.getEventBus().on('plugins:refresh',this._refreshData,this);
     }
@@ -105,8 +111,8 @@ export default class extends React.Component {
 
     render() {
         const NO_DATA_MESSAGE = 'There are no Plugins available. Click "Upload" to add Plugins.';
-        let {Button, Confirm, DataTable, ErrorMessage, ResourceVisibility} = Stage.Basic;
-        let {IdPopup, UploadPluginModal} = Stage.Common;
+        let {Button, DataTable, ErrorMessage, ResourceVisibility} = Stage.Basic;
+        let {DeleteConfirm, IdPopup, UploadPluginModal} = Stage.Common;
 
         return (
             <div>
@@ -168,11 +174,13 @@ export default class extends React.Component {
                 </DataTable>
 
                 <UploadPluginModal open={this.state.showUploadModal} toolbox={this.props.toolbox} onHide={this._hideUploadModal.bind(this)} />
-                
-                <Confirm content='Are you sure you want to remove this plugin?'
-                         open={this.state.confirmDelete}
-                         onConfirm={this._deletePlugin.bind(this)}
-                         onCancel={()=>this.setState({confirmDelete : false})} />
+
+                <DeleteConfirm resourceName={`plugin ${_.get(this.state.item, 'package_name', '')} v${_.get(this.state.item, 'package_version', '')}`}
+                               force={this.state.force}
+                               open={this.state.confirmDelete}
+                               onConfirm={this._deletePlugin.bind(this)}
+                               onCancel={() => this.setState({confirmDelete : false})}
+                               onForceChange={this._handleForceChange.bind(this)} />
             </div>
 
         );


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5202105/48126974-f0e58680-e282-11e8-915b-d204ab6b7afd.png)
Force flag by default is false for blueprint removal (as it was before).

![image](https://user-images.githubusercontent.com/5202105/48127032-0d81be80-e283-11e8-8c25-16c15f78697c.png)
Force flag by default is true for plugin removal (as it was before).