### PR TITLE
CY-722 - Allow providing a YAML file for execution parameters in Execute workflow modal

### DIFF
--- a/app/components/basic/form/InputFile.js
+++ b/app/components/basic/form/InputFile.js
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 
 import React, { Component } from 'react';
-import { Button, Input } from 'semantic-ui-react';
+import { Button, Input, Popup } from '../index';
 
 /**
  * InputFile is a component showing file input field
@@ -46,6 +46,9 @@ export default class InputFile extends Component {
      * @property {boolean} [loading=false] if set to true opening file selector will be disabled
      * @property {boolean} [disabled=false] if set to true component will be disabled
      * @property {boolean} [showInput=true] if set to false input string field will not be presented
+     * @property {boolean} [showReset=true] if set to false reset button will not be presented
+     * @property {object} [openButtonParams={}] additional parameters for open file button, props for Button component
+     * @property {string} [help=''] additional help information shown in Popup
      */
     static propTypes = {
         name: PropTypes.string,
@@ -54,7 +57,10 @@ export default class InputFile extends Component {
         onReset: PropTypes.func,
         loading: PropTypes.bool,
         disabled: PropTypes.bool,
-        showInput: PropTypes.bool
+        showInput: PropTypes.bool,
+        showReset: PropTypes.bool,
+        openButtonParams: PropTypes.object,
+        help: PropTypes.string
     };
 
     static defaultProps = {
@@ -64,8 +70,11 @@ export default class InputFile extends Component {
         onReset: () => {},
         loading: false,
         disabled: false,
-        showInput: true
-    }
+        showInput: true,
+        showReset: true,
+        openButtonParams: {},
+        help: ''
+    };
 
     _openFileSelection(e) {
         e.preventDefault();
@@ -90,6 +99,9 @@ export default class InputFile extends Component {
         var filename = fullPathFileName.split('\\').pop();
         this.setState({value: filename, title: fullPathFileName});
         this.props.onChange(this.file(), filename);
+        if (!this.props.showReset) {
+            this._resetFileSelection(e);
+        }
     }
 
     file() {
@@ -102,25 +114,48 @@ export default class InputFile extends Component {
         this.props.onChange(null, '');
     }
 
+    getOpenFolderButton() {
+        let getOpenFolderButton = () =>
+            <Button icon="folder open" onClick={this._openFileSelection.bind(this)}
+                    loading={this.props.loading} disabled={this.props.disabled} {...this.props.openButtonParams} />;
+
+        return !_.isEmpty(this.props.help)
+            ? <Popup trigger={getOpenFolderButton()} content={this.props.help} />
+            : getOpenFolderButton()
+    }
+
+    getResetFileButton() {
+        return this.props.showReset
+            ? <Button icon="remove" onClick={this._resetFileSelection.bind(this)} disabled={!this.state.value || this.props.disabled} />
+            : null
+    }
+
+    getHiddenInput() {
+        return (
+            <input type="file" name={this.props.name} hidden
+                   onChange={this._fileChanged.bind(this)} ref={this.inputRef} />
+        );
+    }
+
     render() {
         return (
             this.props.showInput
             ?
                 <React.Fragment>
                     <Input type="text" readOnly='true' value={this.state.value} title={this.state.title}
-                       name={'fileName' + this.props.name} placeholder={this.props.placeholder}
-                       onClick={this._openFileSelection.bind(this)} disabled={this.props.disabled} action>
+                           name={'fileName' + this.props.name} placeholder={this.props.placeholder}
+                           onClick={this._openFileSelection.bind(this)} disabled={this.props.disabled} action>
                         <input />
-                        <Button icon="folder open" loading={this.props.loading} onClick={this._openFileSelection.bind(this)} disabled={this.props.disabled}/>
-                        <Button icon="remove" onClick={this._resetFileSelection.bind(this)} disabled={!this.state.value || this.props.disabled}/>
+                        {this.getOpenFolderButton()}
+                        {this.getResetFileButton()}
                     </Input>
-                    <input type="file" name={this.props.name} hidden onChange={this._fileChanged.bind(this)} ref={this.inputRef} />
+                    {this.getHiddenInput()}
                 </React.Fragment>
             :
                 <React.Fragment>
-                    <Button icon="folder open" loading={this.props.loading} onClick={this._openFileSelection.bind(this)} disabled={this.props.disabled}/>
-                    <Button icon="remove" onClick={this._resetFileSelection.bind(this)} disabled={!this.state.value || this.props.disabled}/>
-                    <input type="file" name={this.props.name} hidden onChange={this._fileChanged.bind(this)} ref={this.inputRef} />
+                    {this.getOpenFolderButton()}
+                    {this.getResetFileButton()}
+                    {this.getHiddenInput()}
                 </React.Fragment>
         )
     }

--- a/widgets/common/src/UpdateDeploymentModal.js
+++ b/widgets/common/src/UpdateDeploymentModal.js
@@ -61,15 +61,18 @@ class UpdateDeploymentModal extends React.Component {
     }
 
     _submitUpdate() {
+        let {InputsUtils} = Stage.Common;
         let errors = {};
 
         if (_.isEmpty(this.state.blueprint.id)) {
             errors['blueprintName']='Please select blueprint';
         }
 
+        let inputsWithoutValue = {};
         let deploymentInputs = Stage.Common.InputsUtils.getInputsToSend(this.state.blueprint.plan.inputs,
                                                                         this.state.deploymentInputs,
-                                                                        errors);
+                                                                        inputsWithoutValue);
+        InputsUtils.addErrors(inputsWithoutValue, errors);
 
         if (!_.isEmpty(errors)) {
             this.setState({errors});
@@ -113,28 +116,20 @@ class UpdateDeploymentModal extends React.Component {
     }
 
     _handleYamlFileChange(file) {
-        let {FileActions, InputsUtils} = Stage.Common;
-        let blueprintPlanInputs = this.state.blueprint.plan.inputs;
-
         if (!file) {
-            let deploymentInputs = InputsUtils.getInputsFromPlan(blueprintPlanInputs);
-            this.setState({errors: {}, deploymentInputs});
             return;
         }
 
-        this.setState({fileLoading: true});
+        let {FileActions, InputsUtils} = Stage.Common;
         let actions = new FileActions(this.props.toolbox);
-        actions.doGetYamlFileContent(file).then((inputs) => {
-            let notFoundInputs = [];
-            let deploymentInputs = InputsUtils.getInputsFromYaml(blueprintPlanInputs, inputs, notFoundInputs);
+        this.setState({fileLoading: true});
 
-            if (_.isEmpty(notFoundInputs)) {
-                this.setState({errors: {}, deploymentInputs, fileLoading: false});
-            } else {
-                this.setState({errors: {yamlFile: `Mandatory input(s) (${notFoundInputs}) not provided in YAML file.`}, fileLoading: false});
-            }
-        }).catch((err)=>{
-            this.setState({errors: {yamlFile: err.message}, fileLoading: false});
+        actions.doGetYamlFileContent(file).then((yamlInputs) => {
+            let deploymentInputs = InputsUtils.getUpdatedInputs(this.state.blueprint.plan.inputs, this.state.deploymentInputs, yamlInputs);
+            this.setState({errors: {}, deploymentInputs, fileLoading: false});
+        }).catch((err) => {
+            const errorMessage = `Loading values from YAML file failed: ${_.isString(err) ? err : err.message}`;
+            this.setState({errors: {yamlFile: errorMessage}, fileLoading: false});
         });
     }
 
@@ -163,7 +158,7 @@ class UpdateDeploymentModal extends React.Component {
 
     render() {
         let {ApproveButton, CancelButton, Form, Header, Icon, Message, Modal, NodeInstancesFilter} = Stage.Basic;
-        let {InputsHeader, InputsUtils} = Stage.Common;
+        let {InputsHeader, InputsUtils, YamlFileButton} = Stage.Common;
 
         let blueprints = Object.assign({},{items:[]}, this.state.blueprints);
         let blueprintsOptions = _.map(blueprints.items, blueprint => { return { text: blueprint.id, value: blueprint.id } });
@@ -184,27 +179,20 @@ class UpdateDeploymentModal extends React.Component {
                         </Form.Field>
 
                         {
-                            this.state.blueprint.id
-                            &&
-                            <InputsHeader />
-                        }
-
-                        {
                             this.state.blueprint.id &&
-                            (
-                                _.isEmpty(this.state.blueprint.plan.inputs)
-                                    ?
+                            <React.Fragment>
+                                {
+                                    !_.isEmpty(this.state.blueprint.plan.inputs) &&
+                                    <YamlFileButton onChange={this._handleYamlFileChange.bind(this)}
+                                                    dataType="deployment's inputs"
+                                                    fileLoading={this.state.fileLoading}/>
+                                }
+                                <InputsHeader/>
+                                {
+                                    _.isEmpty(this.state.blueprint.plan.inputs) &&
                                     <Message content="No inputs available for the selected blueprint"/>
-                                    :
-
-                                    <Form.Field error={this.state.errors.yamlFile} label='YAML file'
-                                                help='Provide YAML file with all deployments inputs
-                                                      to automatically fill in the form.'>
-                                        <Form.File name="yamlFile" ref="yamlFile"
-                                                   onChange={this._handleYamlFileChange.bind(this)} loading={this.state.fileLoading}
-                                                   disabled={this.state.fileLoading} />
-                                    </Form.Field>
-                            )
+                                }
+                            </React.Fragment>
                         }
 
                         {

--- a/widgets/common/src/YamlFileButton.js
+++ b/widgets/common/src/YamlFileButton.js
@@ -1,0 +1,41 @@
+/**
+ * Created by jakubniezgoda on 05/07/2018.
+ */
+
+import PropTypes from 'prop-types';
+
+class YamlFileButton extends React.Component {
+
+    constructor(props,context) {
+        super(props,context);
+    }
+
+    static propTypes = {
+        dataType: PropTypes.string,
+        fileLoading: PropTypes.bool,
+        onChange: PropTypes.func,
+    };
+
+    static defaultProps = {
+        dataType: 'values',
+        fileLoading: false,
+        onChange: _.noop
+    };
+
+    render () {
+        let {Form} = Stage.Basic;
+
+        return (
+            <Form.File name='yamlFile' showInput={false} showReset={false}
+                       openButtonParams={{className: 'rightFloated', content: 'Load Values', labelPosition: 'left'}}
+                       onChange={this.props.onChange}
+                       help={`You can provide YAML file with ${this.props.dataType} to automatically fill in the form.`}
+                       loading={this.props.fileLoading} disabled={this.props.fileLoading} />
+        );
+    }
+}
+
+Stage.defineCommon({
+    name: 'YamlFileButton',
+    common: YamlFileButton
+});


### PR DESCRIPTION
# Changelog
- Unified YAML file provider look-and-feel and internal behaviour across all places of existence - ExecuteDeploymentModal, UpdateDeploymentModal, DeployModal and DeployBlueprintModal.
- Removed YAML file input field, created simple button on the right side of Inputs/Parameters header in all 4 modals
- Allowed providing YAML file with not all mandatory fields (before you must have provided YAML with all mandatory fields present, now you can load partial YAMLs one-by-one)
- Updating only fields with values provided in YAML (before all fields were updated, so values not provided in YAML were resetted)

# Execute Workflow
![image](https://user-images.githubusercontent.com/5202105/48205457-8d378800-e36c-11e8-92ec-529eacadf705.png)

# Update Deployment
![image](https://user-images.githubusercontent.com/5202105/48205491-9fb1c180-e36c-11e8-9a0b-64b6b455a692.png)

# Create Deployment
![image](https://user-images.githubusercontent.com/5202105/48205547-b3f5be80-e36c-11e8-92e4-8da1cd65811f.png)
