### PR TITLE
CY-645 - Implement minor improvements to Deployment Wizard

### DIFF
--- a/app/components/Widget.js
+++ b/app/components/Widget.js
@@ -75,6 +75,11 @@ export default class Widget extends Component {
         }
     }
 
+    shouldComponentUpdate(nextProps, nextState) {
+        return !_.isEqual(this.props, nextProps)
+            || !_.isEqual(this.state, nextState);
+    }
+
     render() {
 
         if (!this.props.widget.definition) {

--- a/app/components/WidgetDynamicContent.js
+++ b/app/components/WidgetDynamicContent.js
@@ -201,7 +201,11 @@ export default class WidgetDynamicContent extends Component {
     }
 
     shouldComponentUpdate(nextProps, nextState) {
-        return !_.isEqual(this.props, nextProps)
+        return !_.isEqual(this.props.widget, nextProps.widget)
+            || !_.isEqual(this.props.context, nextProps.context)
+            || !_.isEqual(this.props.manager, nextProps.manager)
+            || !_.isEqual(this.props.data, nextProps.data)
+            || !_.isEqual(this.props.pageId, nextProps.pageId)
             || !_.isEqual(this.state, nextState);
     }
 

--- a/app/components/layout/Header.js
+++ b/app/components/layout/Header.js
@@ -33,7 +33,8 @@ export default class Header extends Component {
     };
 
     shouldComponentUpdate(nextProps, nextState) {
-        return !_.isEqual(this.props.manager, nextProps.manager) || this.state != nextState;
+        return !_.isEqual(this.props.manager, nextProps.manager)
+            || !_.isEqual(this.state, nextState);
     }
 
     componentDidMount() {

--- a/app/styles/style.scss
+++ b/app/styles/style.scss
@@ -798,6 +798,10 @@ table.servicesData button.refreshButton {
   border-top: none;
 }
 
+// FIXME: Remove this when Semantic-UI-CSS 2.4.2 it's ready
+.ui.fullscreen.modal.readmeModal {
+  left: auto !important;
+}
 /* A href underscore */
 a.underline {
   text-decoration: none !important;

--- a/backend/handler/ArchiveHelper.js
+++ b/backend/handler/ArchiveHelper.js
@@ -58,7 +58,7 @@ module.exports = (function() {
             var getRequest = null;
             var onErrorFetch = function (error) {
                 reject(error);
-            }
+            };
             var onSuccessFetch = function (response) {
                 var archiveFile = _extractFilename(response.headers['content-disposition']);
 
@@ -150,7 +150,7 @@ module.exports = (function() {
 
         fs.readdir(tempDir, function (err, files) {
             if (err) {
-                logger.error(err);
+                logger.warn('Cannot remove old extracts. Error:', err);
                 return;
             }
 

--- a/widgets/deploymentWizardButtons/src/steps/InstallStep.js
+++ b/widgets/deploymentWizardButtons/src/steps/InstallStep.js
@@ -100,7 +100,7 @@ class InstallStepActions extends Component {
                     <Progress size='large' percent={percent} autoSuccess>
                         Installation started! Redirecting to deployment page in {this.state.secondsRemaining} seconds...
                     </Progress>
-                    <Button content='Cancel' icon='cancel' labelPosition='left'
+                    <Button content='Stay on this page' icon='hand paper' labelPosition='left'
                             onClick={this.cancelRedirection.bind(this)} />
                 </Wizard.Step.Actions>
             );

--- a/widgets/deploymentWizardButtons/src/steps/helpers/ResourceStatus.js
+++ b/widgets/deploymentWizardButtons/src/steps/helpers/ResourceStatus.js
@@ -21,6 +21,11 @@ export default class ResourceStatus extends Component {
         text: PropTypes.string.isRequired
     };
 
+    shouldComponentUpdate(nextProps) {
+        return this.props.status !== nextProps.status
+            || this.props.text !== nextProps.text;
+    }
+
     render() {
         let {Icon, Popup} = Stage.Basic;
 

--- a/widgets/deployments/src/widget.js
+++ b/widgets/deployments/src/widget.js
@@ -50,6 +50,11 @@ Stage.defineWidget({
 
     fetchData: function(widget,toolbox,params) {
         let deploymentData = toolbox.getManager().doGet('/deployments', params);
+        // FIXME: Improve data fetching when CY-760 is implemented.
+        // let deploymentData = toolbox.getManager().doGet('/deployments', {
+        //         _include: 'id,blueprint_id,visibility,created_at,created_by,updated_at,workflows',
+        //         ...params
+        //     });
         let deploymentIds = deploymentData.then(data => _.map(data.items, item => item.id));
 
         let nodeInstanceData = deploymentIds.then(ids =>


### PR DESCRIPTION
# CY-717 - Allow specifying a Deployment ID
- the deployment name is chosen automatically basing on the blueprint name and availability of name in CM, you can now change it:
![image](https://user-images.githubusercontent.com/5202105/50005284-267c3e80-ffaa-11e8-869f-5f424de7fd87.png)
- if you choose already existing name, you will see appropriate error message:
![image](https://user-images.githubusercontent.com/5202105/50005275-1b291300-ffaa-11e8-8261-3ffe0df3d31a.png)

# CY-716 - Add support for inputs YAML file in Inputs step
![image](https://user-images.githubusercontent.com/5202105/50005250-f59c0980-ffa9-11e8-9916-5594ca9885f5.png)

# CY-721 - Redesign automatic redirection process in Install step
![image](https://user-images.githubusercontent.com/5202105/50005783-de5e1b80-ffab-11e8-97f0-e6cf8715442c.png)

