### PR TITLE
CY-895 - WSOD in UI when resource visibility is not set properly in Cloudify Manager

### DIFF
--- a/app/components/basic/ResourceVisibility.js
+++ b/app/components/basic/ResourceVisibility.js
@@ -40,7 +40,7 @@ export default class ResourceVisibility extends Component {
     }
 
     /**
-     * @property {string} visibility resource visibility - in ['private', 'tenant, 'global']
+     * @property {string} [visibility='unknown'] resource visibility - in ['private', 'tenant, 'global', 'unknown']
      * @property {func} [onSetVisibility(visibility)] function to be called when user confirm changing visibility
      * @property {array} [allowedSettingTo=['tenant']] array of visibilities the item is allowed to change to
      * @property {string} [className=''] Name of the style class to be added
@@ -49,13 +49,15 @@ export default class ResourceVisibility extends Component {
         visibility: PropTypes.oneOf([
             consts.visibility.PRIVATE.name,
             consts.visibility.TENANT.name,
-            consts.visibility.GLOBAL.name]).isRequired,
+            consts.visibility.GLOBAL.name,
+            consts.visibility.UNKNOWN.name]),
         onSetVisibility: PropTypes.func,
         allowedSettingTo: PropTypes.array,
         className: PropTypes.string
     };
 
     static defaultProps = {
+        visibility: consts.visibility.UNKNOWN.name,
         className: '',
     };
 
@@ -64,12 +66,12 @@ export default class ResourceVisibility extends Component {
         let setGlobalAllowed = _.includes(this.props.allowedSettingTo, consts.visibility.GLOBAL.name) && !_.isEqual(this.props.visibility, consts.visibility.GLOBAL.name);
         let canChangeVisibility = setGlobalAllowed || setTenantAllowed;
         const icon = <VisibilityIcon visibility={this.props.visibility}
-                                   className={this.props.className}
-                                   link={setGlobalAllowed}
-                                   onClick={e => e.stopPropagation()}
-                                   bordered
-                                   disabled={!canChangeVisibility}
-                                   showTitle={!this.state.popupOpened} />;
+                                     className={this.props.className}
+                                     link={setGlobalAllowed}
+                                     onClick={e => e.stopPropagation()}
+                                     bordered
+                                     disabled={!canChangeVisibility}
+                                     showTitle={!this.state.popupOpened} />;
 
         let popupContent =
         <div className="setVisibility">

--- a/app/components/basic/VisibilityField.js
+++ b/app/components/basic/VisibilityField.js
@@ -31,7 +31,7 @@ export default class VisibilityField extends Component {
 
 
     /**
-     * @property {string} [visibility] the current visibility, one from ['tenant', 'private', 'global'].
+     * @property {string} [visibility='unkown'] the current visibility, one from ['tenant', 'private', 'global'].
      * @property {function} [onVisibilityChange=()=>{}] the callback to be called with the new visibility
      * @property {bool} [disallowGlobal=false] should the component not allow changing the global
      * @property {bool} [allowChange=true] should the component allow changing visibility
@@ -41,7 +41,8 @@ export default class VisibilityField extends Component {
         visibility: PropTypes.oneOf([
             consts.visibility.PRIVATE.name,
             consts.visibility.TENANT.name,
-            consts.visibility.GLOBAL.name]).isRequired,
+            consts.visibility.GLOBAL.name,
+            consts.visibility.UNKNOWN.name]),
         onVisibilityChange: PropTypes.func,
         disallowGlobal: PropTypes.bool,
         allowChange: PropTypes.bool,
@@ -49,6 +50,7 @@ export default class VisibilityField extends Component {
     };
 
     static defaultProps = {
+        visibility: consts.visibility.UNKNOWN.name,
         onVisibilityChange: () => {},
         disallowGlobal: false,
         allowChange: true,

--- a/app/components/basic/VisibilityIcon.js
+++ b/app/components/basic/VisibilityIcon.js
@@ -15,24 +15,27 @@ import consts from '../../utils/consts';
 export default class VisibilityIcon extends Component {
 
     /**
-     * @property {string} visibility the current visibility, one from ['tenant', 'private', 'global'].
-     * @property {string} [showTitle] if set to true, then on hovering icon title will be shown in popup
+     * @property {string} [visibility='unknown'] the current visibility, one from ['tenant', 'private', 'global', 'unknown'].
+     * @property {string} [showTitle=true] if set to true, then on hovering icon title will be shown in popup
      */
     static propTypes = {
         visibility: PropTypes.oneOf([
             consts.visibility.PRIVATE.name,
             consts.visibility.TENANT.name,
-            consts.visibility.GLOBAL.name]).isRequired,
+            consts.visibility.GLOBAL.name,
+            consts.visibility.UNKNOWN.name]),
         showTitle: PropTypes.bool
     };
 
     static defaultProps = {
-        showTitle: true
+        showTitle: true,
+        visibility: consts.visibility.UNKNOWN.name
     };
 
     render() {
         let {Popup} = Stage.Basic;
-        let data = _.find(consts.visibility, {name: this.props.visibility});
+        let data = _.find(consts.visibility, {name: this.props.visibility}) || consts.visibility.UNKNOWN;
+
         return this.props.showTitle
             ? <Popup trigger={<Icon name={data.icon} color={data.color} {..._.omit(this.props, _.keys(VisibilityIcon.propTypes))}/>} content={data.title} />
             : <Icon name={data.icon} color={data.color} {..._.omit(this.props, _.keys(VisibilityIcon.propTypes))}/>;

--- a/app/utils/consts.js
+++ b/app/utils/consts.js
@@ -33,7 +33,8 @@ export default {
     visibility: {
         PRIVATE: {name: 'private', icon: 'lock', color: 'red', title: 'Private resource'},
         TENANT: {name: 'tenant', icon: 'user', color: 'green', title: 'Tenant resource'},
-        GLOBAL: {name: 'global', icon: 'globe', color: 'blue', title: 'Global resource'}
+        GLOBAL: {name: 'global', icon: 'globe', color: 'blue', title: 'Global resource'},
+        UNKNOWN: {name: 'unknown', icon: 'question', color: 'grey', title: 'Unknown resource visibility'},
     },
     MANAGER_RUNNING: 'running',
     MAINTENANCE_ACTIVATING: 'activating',


### PR DESCRIPTION
Blueprints, Deployments, Secrets, Plugins, Snapshots widgets shall be now secured for the case when `visibility` field is not set properly in JSON data received from Manager.

In case UI gets invalid `visibility` value, grey `?` icon will be shown as in the example below:
![image](https://user-images.githubusercontent.com/5202105/50336568-bc661b00-050e-11e9-81ec-4d1e88ac19b5.png)
