### PR TITLE
CY-792 - Add Resume action for cancelled and failed executions in Cloudify UI

### DIFF
--- a/widgets/common/src/ExecutionActions.js
+++ b/widgets/common/src/ExecutionActions.js
@@ -15,7 +15,7 @@ class ExecutionActions {
         return this.toolbox.getManager().doGet('/executions?_include=id,status', {id: executionId});
     }
 
-    doCancel(execution, action) {
+    doAct(execution, action) {
         return this.toolbox.getManager().doPost(`/executions/${execution.id}`, null, {
             'deployment_id': execution.deployment_id,
             'action': action

--- a/widgets/common/src/ExecutionStatus.js
+++ b/widgets/common/src/ExecutionStatus.js
@@ -37,7 +37,7 @@ class ExecutionStatus extends React.Component {
 
         return this.props.showLabel
             ?
-            <Popup on={showPopup ? 'hover' : ''}>
+            <Popup on={showPopup ? 'hover' : []}>
                 <Popup.Trigger>
                     <Label {...this.props.labelProps} onClick={(e) => e.stopPropagation()}>
                         <Icon {...ExecutionUtils.getExecutionStatusIconParams(execution)} {...this.props.iconProps} />

--- a/widgets/common/src/ExecutionUtils.js
+++ b/widgets/common/src/ExecutionUtils.js
@@ -3,6 +3,10 @@
  */
 
 class ExecutionUtils {
+    /* Execution resume types */
+    static FORCE_RESUME_ACTION = 'force-resume';
+    static RESUME_ACTION = 'resume';
+
     /* Execution cancellation types */
     static CANCEL_ACTION = 'cancel';
     static FORCE_CANCEL_ACTION = 'force-cancel';

--- a/widgets/common/src/LastExecutionStatusIcon.js
+++ b/widgets/common/src/LastExecutionStatusIcon.js
@@ -18,7 +18,7 @@ export default class LastExecutionStatusIcon extends React.Component {
         execution: PropTypes.object,
         onShowLogs: PropTypes.func,
         onShowUpdateDetails: PropTypes.func,
-        onCancelExecution: PropTypes.func,
+        onActOnExecution: PropTypes.func,
         showLabel: PropTypes.bool,
         labelAttached: PropTypes.bool
     };
@@ -27,7 +27,7 @@ export default class LastExecutionStatusIcon extends React.Component {
         execution: {workflow_id: '', status: ''},
         onShowLogs: _.noop,
         onShowUpdateDetails: _.noop,
-        onCancelExecution: _.noop,
+        onActOnExecution: _.noop,
         showLabel: false,
         labelAttached: true
     };
@@ -119,9 +119,17 @@ export default class LastExecutionStatusIcon extends React.Component {
                                     <Table.Row textAlign='center'>
                                         <Table.HeaderCell colSpan={colSpan}>
                                             {
+                                                (ExecutionUtils.isCancelledExecution(execution) || ExecutionUtils.isFailedExecution(execution)) &&
+                                                <Button icon labelPosition='left' color='green'
+                                                        onClick={() => this.props.onActOnExecution(execution, ExecutionUtils.FORCE_RESUME_ACTION)}>
+                                                    <Icon name='play' />
+                                                    Resume
+                                                </Button>
+                                            }
+                                            {
                                                 (ExecutionUtils.isActiveExecution(execution) || ExecutionUtils.isWaitingExecution(execution)) &&
                                                 <Button icon labelPosition='left' color='yellow'
-                                                        onClick={() => this.props.onCancelExecution(execution, ExecutionUtils.CANCEL_ACTION)}>
+                                                        onClick={() => this.props.onActOnExecution(execution, ExecutionUtils.CANCEL_ACTION)}>
                                                     <Icon name='cancel' />
                                                     Cancel
                                                 </Button>
@@ -129,13 +137,13 @@ export default class LastExecutionStatusIcon extends React.Component {
                                             {
                                                 (ExecutionUtils.isActiveExecution(execution) || ExecutionUtils.isWaitingExecution(execution)) &&
                                                 <Button icon labelPosition='left' color='orange'
-                                                        onClick={() => this.props.onCancelExecution(execution, ExecutionUtils.FORCE_CANCEL_ACTION)}>
+                                                        onClick={() => this.props.onActOnExecution(execution, ExecutionUtils.FORCE_CANCEL_ACTION)}>
                                                     <Icon name='cancel' />
                                                     Force Cancel
                                                 </Button>
                                             }
                                             <Button icon labelPosition='left' color='red'
-                                                    onClick={() => this.props.onCancelExecution(execution, ExecutionUtils.KILL_CANCEL_ACTION)}>
+                                                    onClick={() => this.props.onActOnExecution(execution, ExecutionUtils.KILL_CANCEL_ACTION)}>
                                                 <Icon name='stop' />
                                                 Kill Cancel
                                             </Button>

--- a/widgets/deployments/src/DeploymentsList.js
+++ b/widgets/deployments/src/DeploymentsList.js
@@ -92,9 +92,9 @@ export default class DeploymentsList extends React.Component {
         });
     }
 
-    _cancelExecution(execution, action) {
+    actOnExecution(execution, action) {
         let actions = new Stage.Common.ExecutionActions(this.props.toolbox);
-        actions.doCancel(execution, action).then(() => {
+        actions.doAct(execution, action).then(() => {
             this._setError(null);
             this.props.toolbox.getEventBus().trigger('deployments:refresh');
             this.props.toolbox.getEventBus().trigger('executions:refresh');
@@ -159,7 +159,7 @@ export default class DeploymentsList extends React.Component {
                                       onShowLogs={this._showLogs.bind(this)}
                                       onShowUpdateDetails={this._showDeploymentUpdateDetailsModal.bind(this)}
                                       onMenuAction={this._showModal.bind(this)}
-                                      onCancelExecution={this._cancelExecution.bind(this)}
+                                      onActOnExecution={this.actOnExecution.bind(this)}
                                       onError={this._setError.bind(this)}
                                       onSetVisibility={this._setDeploymentVisibility.bind(this)}
                                       noDataMessage={NO_DATA_MESSAGE}
@@ -171,7 +171,7 @@ export default class DeploymentsList extends React.Component {
                                         onShowLogs={this._showLogs.bind(this)}
                                         onShowUpdateDetails={this._showDeploymentUpdateDetailsModal.bind(this)}
                                         onMenuAction={this._showModal.bind(this)}
-                                        onCancelExecution={this._cancelExecution.bind(this)}
+                                        onActOnExecution={this.actOnExecution.bind(this)}
                                         onError={this._setError.bind(this)}
                                         onSetVisibility={this._setDeploymentVisibility.bind(this)}
                                         noDataMessage={NO_DATA_MESSAGE}

--- a/widgets/deployments/src/DeploymentsSegment.js
+++ b/widgets/deployments/src/DeploymentsSegment.js
@@ -16,7 +16,7 @@ export default class DeploymentsSegment extends React.Component {
         onSelectDeployment: PropTypes.func,
         onShowLogs: PropTypes.func,
         onShowUpdateDetails: PropTypes.func,
-        onCancelExecution: PropTypes.func,
+        onActOnExecution: PropTypes.func,
         onMenuAction: PropTypes.func,
         onError: PropTypes.func,
         onSetVisibility: PropTypes.func,
@@ -30,7 +30,7 @@ export default class DeploymentsSegment extends React.Component {
         onSelectDeployment: ()=>{},
         onShowLogs: ()=>{},
         onShowUpdateDetails: ()=>{},
-        onCancelExecution: ()=>{},
+        onActOnExecution: ()=>{},
         onMenuAction: ()=>{},
         onError: ()=>{},
         onSetVisibility: ()=>{},
@@ -61,7 +61,7 @@ export default class DeploymentsSegment extends React.Component {
                                             <LastExecutionStatusIcon execution={item.lastExecution}
                                                                      onShowLogs={() => this.props.onShowLogs(item.id, item.lastExecution.id)}
                                                                      onShowUpdateDetails={this.props.onShowUpdateDetails}
-                                                                     onCancelExecution={this.props.onCancelExecution}
+                                                                     onActOnExecution={this.props.onActOnExecution}
                                                                      showLabel={this.props.showExecutionStatusLabel} />
                                             <ResourceVisibility visibility={item.visibility} className='rightFloated'
                                                                 onSetVisibility={(visibility) =>

--- a/widgets/deployments/src/DeploymentsTable.js
+++ b/widgets/deployments/src/DeploymentsTable.js
@@ -16,7 +16,7 @@ export default class extends React.Component {
         onSelectDeployment: PropTypes.func,
         onShowLogs: PropTypes.func,
         onShowUpdateDetails: PropTypes.func,
-        onCancelExecution: PropTypes.func,
+        onActOnExecution: PropTypes.func,
         onMenuAction: PropTypes.func,
         onError: PropTypes.func,
         onSetVisibility: PropTypes.func,
@@ -28,7 +28,7 @@ export default class extends React.Component {
     static defaultProps = {
         fetchData: ()=>{},
         onSelectDeployment: ()=>{},
-        onCancelExecution: ()=>{},
+        onActOnExecution: ()=>{},
         onMenuAction: ()=>{},
         onError: ()=>{},
         onSetVisibility: ()=>{},
@@ -76,7 +76,7 @@ export default class extends React.Component {
                                     <LastExecutionStatusIcon execution={item.lastExecution}
                                                              onShowLogs={() => this.props.onShowLogs(item.id, item.lastExecution.id)}
                                                              onShowUpdateDetails={this.props.onShowUpdateDetails}
-                                                             onCancelExecution={this.props.onCancelExecution}
+                                                             onActOnExecution={this.props.onActOnExecution}
                                                              showLabel={this.props.showExecutionStatusLabel}
                                                              labelAttached={false} />
                                 </DataTable.Data>

--- a/widgets/executions/src/ExecutionsTable.js
+++ b/widgets/executions/src/ExecutionsTable.js
@@ -24,6 +24,7 @@ export default class ExecutionsTable extends React.Component {
         SHOW_EXECUTION_PARAMETERS: 'execution_parameters',
         SHOW_UPDATE_DETAILS: 'update_details',
         SHOW_ERROR_DETAILS: 'error_details',
+        RESUME_EXECUTION: Stage.Common.ExecutionUtils.FORCE_RESUME_ACTION,
         CANCEL_EXECUTION: Stage.Common.ExecutionUtils.CANCEL_ACTION,
         FORCE_CANCEL_EXECUTION: Stage.Common.ExecutionUtils.FORCE_CANCEL_ACTION,
         KILL_CANCEL_EXECUTION: Stage.Common.ExecutionUtils.KILL_CANCEL_ACTION
@@ -57,9 +58,9 @@ export default class ExecutionsTable extends React.Component {
         }
     }
 
-    _cancelExecution(execution, action) {
+    actOnExecution(execution, action) {
         let actions = new Stage.Common.ExecutionActions(this.props.toolbox);
-        actions.doCancel(execution, action)
+        actions.doAct(execution, action)
             .then(() => {
                 this.setState({error: null});
                 this.props.toolbox.getEventBus().trigger('deployments:refresh');
@@ -84,10 +85,11 @@ export default class ExecutionsTable extends React.Component {
                 this.setState({execution, errorModalOpen: true, idPopupOpen: false});
                 break;
 
+            case MenuAction.RESUME_EXECUTION:
             case MenuAction.CANCEL_EXECUTION:
             case MenuAction.FORCE_CANCEL_EXECUTION:
             case MenuAction.KILL_CANCEL_EXECUTION:
-                this._cancelExecution(execution, name);
+                this.actOnExecution(execution, name);
                 break;
         }
     }
@@ -187,6 +189,13 @@ export default class ExecutionsTable extends React.Component {
                                                     <Menu.Item content='Show Error Details'
                                                                icon={<Icon name='exclamation circle' color='red' />}
                                                                name={MenuAction.SHOW_ERROR_DETAILS}
+                                                               onClick={this._actionClick.bind(this, item)} />
+                                                }
+                                                {
+                                                    (ExecutionUtils.isCancelledExecution(item) || ExecutionUtils.isFailedExecution(item)) &&
+                                                    <Menu.Item content='Resume'
+                                                               icon={<Icon name='play' color='green' />}
+                                                               name={MenuAction.RESUME_EXECUTION}
                                                                onClick={this._actionClick.bind(this, item)} />
                                                 }
                                                 {

--- a/widgets/managers/src/ManagersTable.js
+++ b/widgets/managers/src/ManagersTable.js
@@ -68,9 +68,9 @@ export default class ManagersTable extends React.Component {
         this.setState({deploymentUpdateId: null, showDeploymentUpdateDetailsModal: false});
     }
 
-    cancelExecution(execution, action) {
+    actOnExecution(execution, action) {
         let actions = new Stage.Common.ExecutionActions(this.props.toolbox);
-        actions.doCancel(execution, action).then(() => {
+        actions.doAct(execution, action).then(() => {
             this.setState({error: null});
             this.props.toolbox.getEventBus().trigger('deployments:refresh');
             this.props.toolbox.getEventBus().trigger('executions:refresh');
@@ -159,7 +159,7 @@ export default class ManagersTable extends React.Component {
                                             <LastExecutionStatusIcon execution={manager.lastExecution}
                                                                      onShowLogs={() => this.showLogs(manager.id, manager.lastExecution.id)}
                                                                      onShowUpdateDetails={this.openDeploymentUpdateDetailsModal.bind(this)}
-                                                                     onCancelExecution={this.cancelExecution.bind(this)}
+                                                                     onActOnExecution={this.actOnExecution.bind(this)}
                                                                      showLabel labelAttached={false} />
                                         </DataTable.Data>
                                         <DataTable.Data className="center aligned">


### PR DESCRIPTION
# Executions widget
![image](https://user-images.githubusercontent.com/5202105/50595583-529c2880-0ea1-11e9-9dc5-0cfd5f34f88e.png)

# Deployments widget
![image](https://user-images.githubusercontent.com/5202105/50595556-28e30180-0ea1-11e9-8a83-c5ba2d524667.png)

