### PR TITLE
CY-928 Add execution status to the Filter widget

### DIFF
--- a/templates/pages/adminDash.json
+++ b/templates/pages/adminDash.json
@@ -91,7 +91,8 @@
       "x": 0,
       "y": 10,
       "configuration": {
-        "filterByExecutions":false
+        "filterByExecutions":false,
+        "filterByExecutionsStatus":true
       }
     },
     {

--- a/templates/pages/app.json
+++ b/templates/pages/app.json
@@ -102,7 +102,8 @@
       "x": 0,
       "y": 37,
       "configuration": {
-        "filterByExecutions":false
+        "filterByExecutions":false,
+        "filterByExecutionsStatus":true
       }
     },
     {

--- a/widgets/executions/src/widget.js
+++ b/widgets/executions/src/widget.js
@@ -36,6 +36,7 @@ Stage.defineWidget({
         return {
             blueprint_id: toolbox.getContext().getValue('blueprintId'),
             deployment_id: toolbox.getContext().getValue('deploymentId'),
+            status_display: toolbox.getContext().getValue('executionStatus'),
             _include_system_workflows: (
                 widget.configuration.showSystemExecutions &&
                 !toolbox.getContext().getValue('blueprintId') &&

--- a/widgets/filter/src/Filter.js
+++ b/widgets/filter/src/Filter.js
@@ -53,7 +53,7 @@ export default class Filter extends React.Component {
         }
     }
 
-    _updateResourceValue(valueName, resourcesName, changedIdNameInResource, changedIds) {
+    _updateResourceValue(valueName, resourcesName, changedIdNameInResource, changedIds, fieldName = 'id') {
         const data = this.props.data;
         const context = this.props.toolbox.getContext();
         const allowMultipleSelection = this.props.configuration.allowMultipleSelection;
@@ -61,13 +61,13 @@ export default class Filter extends React.Component {
 
         if (!_.isEmpty(data[valueName]) && !_.isEmpty(changedIds)) {
             const selectedResources = _.filter(data[resourcesName].items,
-                (resource) => _.includes(data[valueName], resource.id));
+                (resource) => _.includes(data[valueName], resource[fieldName]));
             let selectedResourceId = _.castArray(data[valueName]);
 
             _.forEach(selectedResources, (resource) => {
                 if (!_.includes(changedIds, resource[changedIdNameInResource])) {
                     if (allowMultipleSelection) {
-                        _.pull(selectedResourceId, resource.id);
+                        _.pull(selectedResourceId, resource[fieldName]);
                     } else {
                         selectedResourceId = null
                     }
@@ -118,6 +118,8 @@ export default class Filter extends React.Component {
             this._updateResourceValue('nodeInstanceId', 'nodeInstances', 'deployment_id', deploymentIds);
             this._updateResourceValue('nodeInstanceId', 'nodeInstances', 'node_id', nodeIds);
             this._updateResourceValue('executionId', 'executions', 'blueprint_id', selectedBlueprintIds);
+            this._updateResourceValue('executionStatus', 'executions', 'blueprint_id', selectedBlueprintIds,
+                'status_display');
 
             this._updateDeplomentNodeIdValue(deploymentIds, nodeIds);
         }
@@ -134,6 +136,8 @@ export default class Filter extends React.Component {
             let nodeIds = this._updateResourceValue('nodeId', 'nodes', 'deployment_id', selectedDeploymentIds);
             this._updateResourceValue('nodeInstanceId', 'nodeInstances', 'deployment_id', selectedDeploymentIds);
             this._updateResourceValue('executionId', 'executions', 'deployment_id', selectedDeploymentIds);
+            this._updateResourceValue('executionStatus', 'executions', 'deployment_id', selectedDeploymentIds,
+                'status_display');
 
             this._updateDeplomentNodeIdValue(deploymentIds, nodeIds);
         }
@@ -243,7 +247,7 @@ export default class Filter extends React.Component {
 
         let executionStatusOptions = [];
         if (configuration.filterByExecutionsStatus) {
-            executionStatusOptions = _.map(_.sortedUniqBy(data.executionsStatuses.items, 'status_display'),
+            executionStatusOptions = _.map(_.uniqBy(data.executions.items, 'status_display'),
                 execution => ({text: execution.status_display, value: execution.status_display}));
             if (!configuration.allowMultipleSelection) {
                 executionStatusOptions.unshift(EMPTY_OPTION);

--- a/widgets/filter/src/Filter.js
+++ b/widgets/filter/src/Filter.js
@@ -168,6 +168,11 @@ export default class Filter extends React.Component {
         this.props.toolbox.getContext().setValue('executionId', executionIds);
     }
 
+    _selectExecutionStatus(proxy, field) {
+        let executionStatuses = !_.isEmpty(field.value) ? field.value : null;
+        this.props.toolbox.getContext().setValue('executionStatus', executionStatuses);
+    }
+
     _getDropdownValue(value) {
         const allowMultipleSelection = this.props.configuration.allowMultipleSelection;
 
@@ -236,6 +241,16 @@ export default class Filter extends React.Component {
         }
         let executionId = this._getDropdownValue(data.executionId);
 
+        let executionStatusOptions = [];
+        if (configuration.filterByExecutionsStatus) {
+            executionStatusOptions = _.map(_.sortedUniqBy(data.executionsStatuses.items, 'status_display'),
+                execution => ({text: execution.status_display, value: execution.status_display}));
+            if (!configuration.allowMultipleSelection) {
+                executionStatusOptions.unshift(EMPTY_OPTION);
+            }
+        }
+        let executionStatus = this._getDropdownValue(data.executionStatus);
+
         return (
             <div>
                 <ErrorMessage error={this.state.error} onDismiss={() => this.setState({error: null})} autoHide={true}/>
@@ -284,6 +299,15 @@ export default class Filter extends React.Component {
                                 <Form.Dropdown search selection placeholder="Execution" fluid
                                                value={executionId} id="executionFilterField"
                                                options={executionOptions} onChange={this._selectExecution.bind(this)}
+                                               multiple={configuration.allowMultipleSelection} />
+                            </Form.Field>
+                        }
+                        {
+                            configuration.filterByExecutionsStatus &&
+                            <Form.Field>
+                                <Form.Dropdown search selection placeholder="Execution Status" fluid
+                                               value={executionStatus} id="executionStatusFilterField"
+                                               options={executionStatusOptions} onChange={this._selectExecutionStatus.bind(this)}
                                                multiple={configuration.allowMultipleSelection} />
                             </Form.Field>
                         }

--- a/widgets/filter/src/Filter.js
+++ b/widgets/filter/src/Filter.js
@@ -50,6 +50,7 @@ export default class Filter extends React.Component {
             this.props.toolbox.getContext().setValue('nodeInstanceId', null);
             this.props.toolbox.getContext().setValue('executionId', null);
             this.props.toolbox.getContext().setValue('depNodeId', null);
+            this.props.toolbox.getContext().setValue('executionStatus', null);
         }
     }
 
@@ -62,15 +63,12 @@ export default class Filter extends React.Component {
         if (!_.isEmpty(data[valueName]) && !_.isEmpty(changedIds)) {
             const selectedResources = _.filter(data[resourcesName].items,
                 (resource) => _.includes(data[valueName], resource[fieldName]));
-            let selectedResourceId = _.castArray(data[valueName]);
+            let selectedResourceId = [];
 
             _.forEach(selectedResources, (resource) => {
-                if (!_.includes(changedIds, resource[changedIdNameInResource])) {
-                    if (allowMultipleSelection) {
-                        _.pull(selectedResourceId, resource[fieldName]);
-                    } else {
-                        selectedResourceId = null
-                    }
+                if (_.includes(changedIds, resource[changedIdNameInResource]) &&
+                    !_.includes(selectedResourceId, resource[fieldName])) {
+                    selectedResourceId.push(resource[fieldName])
                 }
             });
 
@@ -118,7 +116,7 @@ export default class Filter extends React.Component {
             this._updateResourceValue('nodeInstanceId', 'nodeInstances', 'deployment_id', deploymentIds);
             this._updateResourceValue('nodeInstanceId', 'nodeInstances', 'node_id', nodeIds);
             this._updateResourceValue('executionId', 'executions', 'blueprint_id', selectedBlueprintIds);
-            this._updateResourceValue('executionStatus', 'executions', 'blueprint_id', selectedBlueprintIds,
+            this._updateResourceValue('executionStatus', 'allExecutions', 'blueprint_id', selectedBlueprintIds,
                 'status_display');
 
             this._updateDeplomentNodeIdValue(deploymentIds, nodeIds);
@@ -136,7 +134,7 @@ export default class Filter extends React.Component {
             let nodeIds = this._updateResourceValue('nodeId', 'nodes', 'deployment_id', selectedDeploymentIds);
             this._updateResourceValue('nodeInstanceId', 'nodeInstances', 'deployment_id', selectedDeploymentIds);
             this._updateResourceValue('executionId', 'executions', 'deployment_id', selectedDeploymentIds);
-            this._updateResourceValue('executionStatus', 'executions', 'deployment_id', selectedDeploymentIds,
+            this._updateResourceValue('executionStatus', 'allExecutions', 'deployment_id', selectedDeploymentIds,
                 'status_display');
 
             this._updateDeplomentNodeIdValue(deploymentIds, nodeIds);
@@ -168,6 +166,12 @@ export default class Filter extends React.Component {
 
     _selectExecution(proxy, field) {
         let executionIds = !_.isEmpty(field.value) ? field.value : null;
+
+        if (!_.isEmpty(executionIds)) {
+            let selectedExecutionIds =  _.castArray(executionIds);
+            this._updateResourceValue('executionStatus', 'allExecutions', 'id', selectedExecutionIds,
+                'status_display');
+        }
 
         this.props.toolbox.getContext().setValue('executionId', executionIds);
     }
@@ -247,7 +251,7 @@ export default class Filter extends React.Component {
 
         let executionStatusOptions = [];
         if (configuration.filterByExecutionsStatus) {
-            executionStatusOptions = _.map(_.uniqBy(data.executions.items, 'status_display'),
+            executionStatusOptions = _.map(_.uniqBy(data.executionStatuses.items, 'status_display'),
                 execution => ({text: execution.status_display, value: execution.status_display}));
             if (!configuration.allowMultipleSelection) {
                 executionStatusOptions.unshift(EMPTY_OPTION);

--- a/widgets/filter/src/widget.js
+++ b/widgets/filter/src/widget.js
@@ -72,9 +72,6 @@ Stage.defineWidget({
             },
             executions: {
                 items: _.sortBy(data.executions.items, 'id')
-            },
-            executionsStatuses: {
-                items: _.sortBy(data.executions.items, 'status_display')
             }
         };
 
@@ -106,8 +103,8 @@ Stage.defineWidget({
 
         if (!_.isNil(executionStatus)) {
             const executionStatusArray = _.castArray(executionStatus);
-            processedData.executionsStatuses.items
-                = _.filter(processedData.executionsStatuses.items, (execution) => _.includes(executionStatusArray, execution.status_display));
+            processedData.executions.items = _.filter(processedData.executions.items,
+                (execution) => _.includes(executionStatusArray, execution.status_display));
         }
 
         return processedData;

--- a/widgets/filter/src/widget.js
+++ b/widgets/filter/src/widget.js
@@ -75,6 +75,7 @@ Stage.defineWidget({
             }
         };
 
+        processedData.allExecutions = Object.assign({}, processedData.executions);
         if (!_.isNil(blueprintId)) {
             let blueprintIdArray = _.castArray(blueprintId);
             processedData.deployments.items
@@ -101,10 +102,11 @@ Stage.defineWidget({
                 = _.filter(processedData.nodeInstances.items, (nodeInstance) => _.includes(nodeIdArray, nodeInstance.node_id));
         }
 
-        if (!_.isNil(executionStatus)) {
-            const executionStatusArray = _.castArray(executionStatus);
-            processedData.executions.items = _.filter(processedData.executions.items,
-                (execution) => _.includes(executionStatusArray, execution.status_display));
+        processedData.executionStatuses = Object.assign({}, processedData.executions);
+        if (!_.isNil(executionId)) {
+            const executionIdArray = _.castArray(executionId);
+            processedData.executionStatuses.items
+                = _.filter(processedData.executionStatuses.items, (execution) => _.includes(executionIdArray, execution.id));
         }
 
         return processedData;


### PR DESCRIPTION
Adding execution status to the Filter widget, it will be shown by default in the dashboard and it will be a dynamic list.

![screen shot 2019-01-08 at 11 52 41](https://user-images.githubusercontent.com/25413570/51191565-5a21ef80-18ed-11e9-9d07-157318aa64e0.png)

![screen shot 2019-01-08 at 11 51 55](https://user-images.githubusercontent.com/25413570/51191579-6148fd80-18ed-11e9-9aa9-b1d09eaf0a65.png)

![screen shot 2019-01-08 at 11 52 07](https://user-images.githubusercontent.com/25413570/51191780-d1f01a00-18ed-11e9-8db9-8c835d076410.png)
