### PR TITLE
CY-939 - Update widget documentation configuration in cloudify-stage for 4.5.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4602,7 +4602,7 @@
     "data-uri-to-buffer": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-1.2.0.tgz",
-      "integrity": "sha1-dxY+qcINhkG0cH6PGKvfmnjzSDU=",
+      "integrity": "sha512-vKQ9DTQPN1FLYiiEEOQ6IBGFqvjCa5rSK3cWMy/Nespm5d/x3dGFT9UBZnkLxCwua/IXBi2TYnwTEpsOvhC4UQ==",
       "dev": true
     },
     "date-now": {
@@ -6712,7 +6712,7 @@
     "file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha1-VTp7hEb/b2hDWcRF8eN6BdrMM90=",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
       "dev": true
     },
     "filename-regex": {
@@ -8141,7 +8141,7 @@
         },
         "commander": {
           "version": "0.6.1",
-          "resolved": "http://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
           "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY="
         },
         "cookie": {
@@ -8161,7 +8161,7 @@
         },
         "express": {
           "version": "3.0.6",
-          "resolved": "http://registry.npmjs.org/express/-/express-3.0.6.tgz",
+          "resolved": "https://registry.npmjs.org/express/-/express-3.0.6.tgz",
           "integrity": "sha1-0nT8uGi5V4i/SvYhaNddE/132LQ=",
           "requires": {
             "buffer-crc32": "0.1.1",
@@ -8189,12 +8189,12 @@
         },
         "mime": {
           "version": "1.2.6",
-          "resolved": "http://registry.npmjs.org/mime/-/mime-1.2.6.tgz",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.6.tgz",
           "integrity": "sha1-sfhsdowCX6h7SAdfFwnyiuryA2U="
         },
         "mkdirp": {
           "version": "0.3.3",
-          "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.3.3.tgz",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.3.tgz",
           "integrity": "sha1-WV4lHBNww6aLqyE20ONIuBBa3xM="
         },
         "range-parser": {

--- a/scripts/readmesConfig.json
+++ b/scripts/readmesConfig.json
@@ -1,5 +1,5 @@
 {
-  "linksBasePath": "https://docs.cloudify.co/staging/dev",
+  "linksBasePath": "https://docs.cloudify.co/4.5.5",
   "rawContentBasePath": "https://raw.githubusercontent.com/cloudify-cosmo/docs.getcloudify.org/master",
   "files": [
     {"widget": "agents", "link": "/content/working_with/console/widgets/agents.md"},

--- a/scripts/readmesConfig.json
+++ b/scripts/readmesConfig.json
@@ -1,6 +1,6 @@
 {
   "linksBasePath": "https://docs.cloudify.co/4.5.5",
-  "rawContentBasePath": "https://raw.githubusercontent.com/cloudify-cosmo/docs.getcloudify.org/master",
+  "rawContentBasePath": "https://raw.githubusercontent.com/cloudify-cosmo/docs.getcloudify.org/4.5.5-build",
   "files": [
     {"widget": "agents", "link": "/content/working_with/console/widgets/agents.md"},
     {"widget": "blueprintActionButtons", "link": "/content/working_with/console/widgets/blueprintActionButtons.md"},

--- a/scripts/updateReadmes.js
+++ b/scripts/updateReadmes.js
@@ -46,7 +46,7 @@ function updateTitle(widget, content) {
 
 function updateLinks(widget, content) {
     return new Promise((resolve, reject) => {
-        const linkRegex = /(\[.*?\])\(\s*(.*?)\s*\)/gm;
+        const linkRegex = /(\[.*?\])\(\s*(?!http)(.*?)\s*\)/gm;
 
         log(widget, 'Updating markdown links:');
         logChange(widget, 'markdown links', content.match(linkRegex));

--- a/widgets/agents/README.md
+++ b/widgets/agents/README.md
@@ -7,16 +7,16 @@ Displays the following information about a specific agent:
 * **Node** - Node ID associated with agent
 * **System** - agent host operation system
 * **Version** - agent version
-* **Install Method** - agent installation method (one of described [here](https://docs.cloudify.co/staging/dev/install_maintain/agents/installation))
+* **Install Method** - agent installation method (one of described [here](https://docs.cloudify.co/4.5.5/install_maintain/agents/installation))
 
-![agents-management](https://docs.cloudify.co/staging/dev/images/ui/widgets/agents-management.png)
+![agents-management](https://docs.cloudify.co/4.5.5/images/ui/widgets/agents-management.png)
 
 By clicking buttons above the table you can execute the following operations:
 
 * `Install` - executes `install_new_agents` workflow on selected deployment. Allows to define Manager IP, Manager Certificate, stop old agents and filter by node(s), node instance(s) and install method(s).  
 * `Validate` - executes `validate_agents` workflow on selected deployment. Allows to filter by node(s), node instance(s) and install method(s).
 
-You can find more about agents [here](https://docs.cloudify.co/staging/dev/install_maintain/agents/index.html).
+You can find more about agents [here](https://docs.cloudify.co/4.5.5/install_maintain/agents/index.html).
 
 
 #### Widget Settings

--- a/widgets/blueprintActionButtons/README.md
+++ b/widgets/blueprintActionButtons/README.md
@@ -5,7 +5,7 @@ The action buttons need to receive the id of the desired blueprint. This can be 
 * By placing the buttons in a blueprint’s drill-down page, meaning the blueprint has been selected before entering the page, and its id is included in the page’s context. 
 * By adding to the page a widget allowing to select blueprints, such as the resources filter or the blueprints list.  
 
-![blueprint-actions](https://docs.cloudify.co/staging/dev/images/ui/widgets/blueprint-action-buttons.png)
+![blueprint-actions](https://docs.cloudify.co/4.5.5/images/ui/widgets/blueprint-action-buttons.png)
 
 #### Widget Settings
 None

--- a/widgets/blueprintCatalog/README.md
+++ b/widgets/blueprintCatalog/README.md
@@ -5,7 +5,7 @@ By default, the widget presents the blueprints under cloudify-examples repositor
 You can filter the presented blueprints by creating a filter query in the widget’s settings.  
 You can and should enter Github credentials for fetching data, as the defaults used by the widgets can reach the restricted query limit of GitHub (~50) . These parameters are pulled from secrets) as the github-username and github-password keys. These parameters are a must if you want to configure the widget to access private repositories.
 
-![blueprints-catalog](https://docs.cloudify.co/staging/dev/images/ui/widgets/blueprints-catalog.png)
+![blueprints-catalog](https://docs.cloudify.co/4.5.5/images/ui/widgets/blueprints-catalog.png)
 
 #### Widget Settings
 * `Blueprint Examples URL` - Specifies the json file from which the Cloudify examples URLs are being read

--- a/widgets/blueprintInfo/README.md
+++ b/widgets/blueprintInfo/README.md
@@ -9,7 +9,7 @@ Displays the following information about a specific blueprint:
 * **Creator user-name**
 * **Main blueprint file name** (as the blueprint archive can contain multiple files)
 
-![blueprint-info](https://docs.cloudify.co/staging/dev/images/ui/widgets/blueprint-info.png)
+![blueprint-info](https://docs.cloudify.co/4.5.5/images/ui/widgets/blueprint-info.png)
 
 #### Widget Settings
 * `Refresh time interval` - The time interval in which the widget’s data will be refreshed, in seconds. Default: 10 seconds

--- a/widgets/blueprintNum/README.md
+++ b/widgets/blueprintNum/README.md
@@ -2,7 +2,7 @@
 Displays the total number of blueprints in the tenant, according to the user’s permissions and the blueprints’ visibility levels. 
 The widget is clickable, and upon clicking will redirect by default to the “Local Blueprint” page. You can set the widget’s configuration to lead to a different page. 
 
-![number_of_blueprints](https://docs.cloudify.co/staging/dev/images/ui/widgets/num_of_blueprints.png)
+![number_of_blueprints](https://docs.cloudify.co/4.5.5/images/ui/widgets/num_of_blueprints.png)
 
 #### Widget Settings
 * `Refresh time interval` - The time interval in which the widget’s data will be refreshed, in seconds. Default: 10 seconds.

--- a/widgets/blueprintSources/README.md
+++ b/widgets/blueprintSources/README.md
@@ -1,7 +1,9 @@
 ### Blueprint Sources
-Displays all the source files in a blueprint package in tree view, adjacent to the code. When you click an item in the tree, its code is displayed in the code panel. You can also open the file in full mode by clicking on the gray box presenting its name in the top right corner of the widget. 
+Displays all the source files in a blueprint package in tree view, adjacent to the code. When you click an item in the tree, its code is displayed in the code panel. You can also open the file in full mode by clicking on the gray box presenting its name in the top right corner of the widget.
 
-![blueprint-sources](https://docs.cloudify.co/staging/dev/images/ui/widgets/blueprint-sources.png)
+If blueprint imports another blueprint, then all imported blueprint will be listed under **Imported blueprints** node in tree view.  
+
+![blueprint-sources](https://docs.cloudify.co/4.5.5/images/ui/widgets/blueprint-sources.png)
 
 #### Widget Settings
 * `Content pane initial width in %` - sets the default size of the source part of the window in percent of screen width. Default: 65%. 

--- a/widgets/blueprintUploadButton/README.md
+++ b/widgets/blueprintUploadButton/README.md
@@ -1,7 +1,7 @@
 ### Blueprint upload button
 This Button allows uploading a blueprint to the manager. Clicking on it opens a dialog for providing the following details:
 
-* **Blueprint visibility** - represented by a colourful icon, and can be set by clicking on it. See [resource’s visibility](https://docs.cloudify.co/staging/dev/working_with/manager/resource-visibility). Default: tenant
+* **Blueprint visibility** - represented by a colourful icon, and can be set by clicking on it. See [resource’s visibility](https://docs.cloudify.co/4.5.5/working_with/manager/resource-visibility). Default: tenant
 * **Blueprint archive path** (local or URL) 
 * **Name** to identify the blueprint on the manager (“Blueprint name”).
 * **Main .yaml file in the blueprint archive** (“Blueprint filename”). Default: blueprint.yaml

--- a/widgets/blueprints/README.md
+++ b/widgets/blueprints/README.md
@@ -11,7 +11,7 @@ Displays all the blueprints on the tenant, according to the user’s permissions
 * **Main blueprint file name** (as the blueprint archive can contain multiple files)
 * **Number of deployments derived from the blueprint**
 
-![blueprints-list](https://docs.cloudify.co/staging/dev/images/ui/widgets/blueprints-list.png)
+![blueprints-list](https://docs.cloudify.co/4.5.5/images/ui/widgets/blueprints-list.png)
 
 #### Widget Settings
 * `Refresh time interval` - The time interval in which the widget’s data will be refreshed, in seconds. Default: 10 seconds

--- a/widgets/buttonLink/README.md
+++ b/widgets/buttonLink/README.md
@@ -1,7 +1,7 @@
 ### Button link
 Opens the specified URL in a separate tab. You can define the label that appears on the button
 
-![button-link](https://docs.cloudify.co/staging/dev/images/ui/widgets/button-link.png)
+![button-link](https://docs.cloudify.co/4.5.5/images/ui/widgets/button-link.png)
 
 #### Widget Settings 
 * `Button label` - The text to appear on the button

--- a/widgets/composerLink/README.md
+++ b/widgets/composerLink/README.md
@@ -1,9 +1,9 @@
 ### Composer link
 Opens the Cloudify Composer, which allows creating blueprints with a graphical drag-and-drop tool. The Composer comes as part of the Cloudify Premium edition, and is only available for users with certain roles. 
 
-For more information regarding the Composer, see [Cloudify Composer](https://docs.cloudify.co/staging/dev/developer/composer/index.html).
+For more information regarding the Composer, see [Cloudify Composer](https://docs.cloudify.co/4.5.5/developer/composer/index.html).
 
-![Composer-link](https://docs.cloudify.co/staging/dev/images/ui/widgets/composer-link.png)
+![Composer-link](https://docs.cloudify.co/4.5.5/images/ui/widgets/composer-link.png)
 
 #### Widget Settings
 None

--- a/widgets/deploymentActionButtons/README.md
+++ b/widgets/deploymentActionButtons/README.md
@@ -4,7 +4,7 @@ Buttons which allow running workflows of a specific deployment, updating it or d
 * By placing the deployment action buttons in the deployments drill-down page, meaning the deployment has been selected before entering the page, and its id is included in the page’s context. 
 * By adding to the page a widget allowing to select deployments, such as the resources filter or the blueprint deployments
  
-![deployment-action-buttons.png](https://docs.cloudify.co/staging/dev/images/ui/widgets/deployment-action-buttons.png)
+![deployment-action-buttons.png](https://docs.cloudify.co/4.5.5/images/ui/widgets/deployment-action-buttons.png)
 
 #### Widget Settings
 None

--- a/widgets/deploymentButton/README.md
+++ b/widgets/deploymentButton/README.md
@@ -1,7 +1,7 @@
 ### Create deployment button
 Allows creating a deployment of a chosen blueprint. After choosing a name for the deployment, the desired blueprint and the visibility of the deployment (private/tenant), a screen will open, allowing to specify values for the inputs required by the chosen blueprint. 
 
-![create_deployment_button](https://docs.cloudify.co/staging/dev/images/ui/widgets/create_deployment_button.png)
+![create_deployment_button](https://docs.cloudify.co/4.5.5/images/ui/widgets/create_deployment_button.png)
 
 
 #### Widget Settings

--- a/widgets/deploymentNum/README.md
+++ b/widgets/deploymentNum/README.md
@@ -2,7 +2,7 @@
 Displays the total number of deployments in the tenant, according to the user’s permissions and the blueprints’ visibility levels. 
 The widget is clickable, and upon clicking will redirect by default to the “Deployments” page. You can set the widget’s configuration to lead to a different page. 
 
-![number_of_deployments](https://docs.cloudify.co/staging/dev/images/ui/widgets/num_of_deployments.png)
+![number_of_deployments](https://docs.cloudify.co/4.5.5/images/ui/widgets/num_of_deployments.png)
 
 #### Widget Settings
 * `Refresh time interval` - The time interval in which the widget’s data will be refreshed, in seconds. Default: 10 seconds.

--- a/widgets/deploymentWizardButtons/README.md
+++ b/widgets/deploymentWizardButtons/README.md
@@ -1,21 +1,21 @@
 ### Deployment wizard buttons
 Allows installing a deployment of a Hello World example or chosen blueprint. 
 
-![deployment_wizard_buttons](https://docs.cloudify.co/staging/dev/images/ui/widgets/deployment_wizard_buttons.png)
+![deployment_wizard_buttons](https://docs.cloudify.co/4.5.5/images/ui/widgets/deployment_wizard_buttons.png)
 
 After clicking on one of the buttons user is guided step by step through the process from selecting blueprint, through providing necessary data - plugins, secrets and inputs, to running install workflow.
 
 Details about the steps in wizard are described below.
 
 ##### Infrastructure step (only in Hello World Wizard)
-![hw_wizard_0](https://docs.cloudify.co/staging/dev/images/ui/widgets/deployment_wizard_buttons_hw_wizard_0.png)
+![hw_wizard_0](https://docs.cloudify.co/4.5.5/images/ui/widgets/deployment_wizard_buttons_hw_wizard_0.png)
 
 In the first step Hello World blueprint is already selected from Cloudify blueprint examples. You just need to select the type of the infrastracture you want to deploy that example on.
 
 Click `Next` button to go the next step.
 
 ##### Blueprint step (only in Deployment Wizard)
-![deployment_wizard_0](https://docs.cloudify.co/staging/dev/images/ui/widgets/deployment_wizard_buttons_deployment_wizard_0.png)
+![deployment_wizard_0](https://docs.cloudify.co/4.5.5/images/ui/widgets/deployment_wizard_buttons_deployment_wizard_0.png)
 
 In the first step you need to provide blueprint package (either by URL or local archive file), set blueprint name and choose the YAML file from the blueprint package. 
 
@@ -26,7 +26,7 @@ Click `Next` button to go the next step.
 ##### Plugins step 
 In this step you see list of plugins detected in blueprint's YAML file imports section. 
 
-![wizard_plugins_step](https://docs.cloudify.co/staging/dev/images/ui/widgets/deployment_wizard_buttons_hw_wizard_plugins.png)
+![wizard_plugins_step](https://docs.cloudify.co/4.5.5/images/ui/widgets/deployment_wizard_buttons_hw_wizard_plugins.png)
 
 Some of them may be automatically installed, for some of them you will need to provide wagon and plugin YAML files. You can also add your plugin if it was not detected.
 
@@ -35,7 +35,7 @@ Hover over icon in `Action` column to see details and check if you need to provi
 ##### Secrets step 
 In this step you see list of secrets detected in blueprint's YAML file. 
 
-![wizard_secrets_step](https://docs.cloudify.co/staging/dev/images/ui/widgets/deployment_wizard_buttons_hw_wizard_secrets.png)
+![wizard_secrets_step](https://docs.cloudify.co/4.5.5/images/ui/widgets/deployment_wizard_buttons_hw_wizard_secrets.png)
 
 Some of them may already be set, for some of them you will need to provide values.
 
@@ -44,27 +44,29 @@ Hover over icon in `Action` column to see details and check if you need to provi
 ##### Inputs step 
 In this step you see list of blueprint inputs. 
 
-![wizard_inputs_step](https://docs.cloudify.co/staging/dev/images/ui/widgets/deployment_wizard_buttons_hw_wizard_inputs.png)
+![wizard_inputs_step](https://docs.cloudify.co/4.5.5/images/ui/widgets/deployment_wizard_buttons_hw_wizard_inputs.png)
 
-If input has default value you won't need to provide it. You need to set values only for inputs which does not have default values.
+If input has default value you won't need to provide it. You need to set values only for inputs which does not have default values. You can use `Load Values` button to fill in the values from YAML file.
 
 Hover over icon in `Action` column to see details and check if you need to provide value for the input. Click `Back` or `Next` button to navigate between steps.
 
 ##### Confirm step 
 In this step you see list of task to be performed during installation process. 
 
-![wizard_confirm_step](https://docs.cloudify.co/staging/dev/images/ui/widgets/deployment_wizard_buttons_hw_wizard_confirm.png)
+You can also modify deployment name, which is automatically set using blueprint name and index suffix. 
 
-Click `Install` to start resources installation procedure or click `Back` button to go to the previous steps.
+![wizard_confirm_step](https://docs.cloudify.co/4.5.5/images/ui/widgets/deployment_wizard_buttons_hw_wizard_confirm.png)
+
+Click `Install` to start resources installation procedure or click `Back` button to go to the previous steps. Deployment name availability is verified upon clicking on `Install` button.
 
 ##### Install step 
 In this step you see list of ongoing tasks and its status. 
 
-![wizard_install_step](https://docs.cloudify.co/staging/dev/images/ui/widgets/deployment_wizard_buttons_hw_wizard_install.png)
+![wizard_install_step](https://docs.cloudify.co/4.5.5/images/ui/widgets/deployment_wizard_buttons_hw_wizard_install.png)
 
-When deployment installation starts successfuly you can perform additional actions - install another blueprint or go to deployment page.
+When deployment installation starts successfully you can perform additional actions - install another blueprint or go to deployment page.
 
-When something go wrong you will be able to see error message and you start over the procedure.
+When something goes wrong you will be able to see error message and you start over the procedure.
 
 #### Widget Settings
 * `Show Hello World Wizard button` - if set then Hello World Wizard button will be shown

--- a/widgets/deployments/README.md
+++ b/widgets/deployments/README.md
@@ -1,7 +1,7 @@
 ### Blueprint deployments
-Displays the list of the deployments in the current tenant, according to the user’s permissions. The data can be displayed as a table or list. In the case of a list view, the status of each deployment is also displayed. For information about deployment status, [click here](https://docs.cloudify.co/staging/dev/working_with/console/deployments-page)
+Displays the list of the deployments in the current tenant, according to the user’s permissions. The data can be displayed as a table or list. In the case of a list view, the status of each deployment is also displayed. For information about deployment status, [click here](https://docs.cloudify.co/4.5.5/working_with/console/deployments-page)
 
-![blueprint-deployments](https://docs.cloudify.co/staging/dev/images/ui/widgets/blueprint-deployments.png)
+![blueprint-deployments](https://docs.cloudify.co/4.5.5/images/ui/widgets/blueprint-deployments.png)
 
 #### Widget Settings
 * `Refresh time interval` - The time interval in which the widget’s data will be refreshed, in seconds. Default: 10 seconds

--- a/widgets/events/README.md
+++ b/widgets/events/README.md
@@ -1,7 +1,16 @@
 ### Events and Logs
-Displays the logs and events of all the executions in the current tenant, according to the user’s permissions. You can configure the fields that are displayed and can choose to indicate in colors success and failure messages.
+Displays the logs and events of all the executions in the current tenant, according to the user’s permissions. 
 
-![events-logs](https://docs.cloudify.co/staging/dev/images/ui/widgets/events-logs-2.png)
+You can configure the fields that are displayed and can choose to indicate in colors success and failure messages.
+
+You can sort events/logs by Timestamp (default), Blueprint, Deployment, Node Id, Node Instance Id, Workflow, Operation and Type.
+
+![events-logs](https://docs.cloudify.co/4.5.5/images/ui/widgets/events-logs-2.png)
+
+Sometimes error logs may contain additional information about error cause. This will be indicated by ![error-cause-icon](https://docs.cloudify.co/4.5.5/images/ui/icons/error-cause-icon.png) icon in the Message column. When you click on this icon you will see detailed information about the error:
+
+![error-cause-modal](https://docs.cloudify.co/4.5.5/images/ui/widgets/events-logs-error-cause-modal.png)
+
 
 #### Widget Settings
 * `Refresh time interval` - The time interval in which the widget’s data will be refreshed, in seconds. Default: 2 seconds
@@ -17,7 +26,7 @@ Displays the logs and events of all the executions in the current tenant, accord
    * Operation
    * Message
    
-You can also choose to add the field “Type”, which will present the log level in case of a log, and event type in case of an event. 
+You can also choose to add the field "Type", which will present the log level in case of a log, and event type in case of an event. 
 
 * `Color message based on type` - when marked as “on”, successful events will be coloured in blue, and failures in red. Default: On
 

--- a/widgets/eventsFilter/README.md
+++ b/widgets/eventsFilter/README.md
@@ -6,10 +6,11 @@ Displays a filter pane for events and logs. The following filtering options are 
 You can also specify your log level by typing in text. Multiselection available. 
 * **Log Levels** - predefined log levels: Debug, Info, Warning. Error, Critical. 
 You can also specify your log level by typing in text. Multiselection available. 
+* **Operation** - part of log/event operation
 * **Message Text** - part of log/event message
 * **Time Range** - time range to get log/events
 
-![events-logs-filter](https://docs.cloudify.co/staging/dev/images/ui/widgets/events-logs-filter.png)
+![events-logs-filter](https://docs.cloudify.co/4.5.5/images/ui/widgets/events-logs-filter.png)
 
 #### Widget Settings
 None

--- a/widgets/executionNum/README.md
+++ b/widgets/executionNum/README.md
@@ -1,7 +1,7 @@
 ### Number of running executions
 Displays the total number of executions which are currently running, i.e, in one of the following statuses: 'pending', 'started', 'cancelling', 'force_cancelling', according to the user’s permissions.
 
-![number_of_running_executions](https://docs.cloudify.co/staging/dev/images/ui/widgets/num_of_running_executions.png)
+![number_of_running_executions](https://docs.cloudify.co/4.5.5/images/ui/widgets/num_of_running_executions.png)
 
 #### Widget Settings
 * `Refresh time interval` - The time interval in which the widget’s data will be refreshed, in seconds. Default: 10 seconds.

--- a/widgets/executions/README.md
+++ b/widgets/executions/README.md
@@ -1,19 +1,25 @@
 ### Executions
 
-Displays data about the executions in the current tenant, according to the user’s permissions. By default, the presented details include the blueprint and deployment of the execution, name of the workflow, the time that it was created and ended, execution creator, its status and actions menu.
+Displays data about the executions in the current tenant, according to the user’s permissions. By default, the presented details include the blueprint and deployment of the execution, name of the workflow, the time that it was created and ended, execution creator, execution attributes, its status and actions menu.
 
-In the actions menu on the right side of the execution row (click ![List icon](https://docs.cloudify.co/staging/dev/images/ui/list-icon.png) to open) you can perform additional actions on the execution:
+In **Attributes** column you can see one of these icons:
+
+* ![Dry Run icon](https://docs.cloudify.co/4.5.5/images/ui/icons/dry-run-icon.png) - **Dry Run** 
+* ![System Workflow icon](https://docs.cloudify.co/4.5.5/images/ui/icons/system-workflow-icon.png) - **System Workflow**
+
+In the actions menu on the right side of the execution row (click ![List icon](https://docs.cloudify.co/4.5.5/images/ui/icons/list-icon.png) to open) you can perform additional actions on the execution:
 
 * `Show Execution Parameters` - shows details in modal window about execution parameters,    
 * `Show Update Details` - shows details in modal window about blueprint and inputs change (available only for 'update' executions),
 * `Show Error Details` - shows error details in modal window (available only for failed executions), 
+* `Resume` - resume the execution (available only for cancelled or failed executions)
 * `Cancel` - cancels the execution (available only for active executions),
 * `Force Cancel` - enforces cancellation of the execution (available only for active executions), 
 * `Kill Cancel` - the process executing the workflow is forcefully stopped, even if it is stuck or unresponsive.
  
- For details about cancelling executions, see [cancelling workflow executions](https://docs.cloudify.co/staging/dev/working_with/workflows/cancelling-execution)
+ For details about cancelling executions, see [cancelling workflow executions](https://docs.cloudify.co/4.5.5/working_with/workflows/cancelling-execution)
 
-![executions](https://docs.cloudify.co/staging/dev/images/ui/widgets/executions.png)
+![executions](https://docs.cloudify.co/4.5.5/images/ui/widgets/executions.png)
 
 #### Widget Settings
 * `Refresh time interval` - The time interval in which the widget’s data will be refreshed, in seconds. Default: 5 seconds

--- a/widgets/filter/README.md
+++ b/widgets/filter/README.md
@@ -3,7 +3,7 @@
 This widget provides the ability to filter the data presented in other widgets on the page according to a specific resource. 
 By default, the widget allows filtering by blueprint, deployment and execution, and you can also add fields to filter by node or node instance, by configuring the widget’s settings. 
 
-![resource-filter](https://docs.cloudify.co/staging/dev/images/ui/widgets/resource_filter.png)
+![resource-filter](https://docs.cloudify.co/4.5.5/images/ui/widgets/resource_filter.png)
 
 
 #### Widget Settings 

--- a/widgets/graph/README.md
+++ b/widgets/graph/README.md
@@ -9,20 +9,20 @@ You must also provide the Blueprint, Deployment, Node and Node instance IDs, eit
 
 #### Widget Settings
 * `Refresh Time Interval` - The time interval in which the widget’s data will be refreshed, in seconds. Default : 5 seconds
-* `Node filter` - Use this filter to choose the node instances you want to present the data of. Make sure this are node for which data is indeed collected. You can set Deployment ID and Node instance ID in page context with the [Resource Filter](https://docs.cloudify.co/staging/dev#resource-filter)
-    ![Node filter configuration](https://docs.cloudify.co/staging/dev/images/ui/widgets/resource_filter.png)
+* `Node filter` - Use this filter to choose the node instances you want to present the data of. Make sure this are node for which data is indeed collected. You can set Deployment ID and Node instance ID in page context with the [Resource Filter](https://docs.cloudify.co/4.5.5#resource-filter)
+    ![Node filter configuration](https://docs.cloudify.co/4.5.5/images/ui/widgets/resource_filter.png)
 * `Charts Table` - Table containing definition of up to 5 charts. 
-    ![Charts Table configuration](https://docs.cloudify.co/staging/dev/images/ui/widgets/deployment-metric-graph-configuration-charts-table.png)
+    ![Charts Table configuration](https://docs.cloudify.co/4.5.5/images/ui/widgets/deployment-metric-graph-configuration-charts-table.png)
     
     You can define the following parameters:
-    * `Metric` - The specific Diamond metric you want the widget to display. This parameter is mandatory. For more information about these metrics, see the [Diamond documentation](https://docs.cloudify.co/staging/devhttp://diamond.readthedocs.io/en/latest/). The available options are dynamically fetched from InfluxDB filtered by `Node filter` parameter.    
+    * `Metric` - The specific Diamond metric you want the widget to display. This parameter is mandatory. For more information about these metrics, see the [Diamond documentation](http://diamond.readthedocs.io/en/latest/). The available options are dynamically fetched from InfluxDB filtered by `Node filter` parameter.    
     * `Label` - The label to be displayed for the specific chart (the label will be displayed at the bottom of the chart). Parameter is optional. When not specified, then metric name will be taken as chart label.
      
-* `Time range and resolution` - Enables you to specify the timeframe of the metrics to be displayed. For details of the configuration see [Time filter widget](https://docs.cloudify.co/staging/dev#time-filter).
+* `Time range and resolution` - Enables you to specify the timeframe of the metrics to be displayed. For details of the configuration see [Time filter widget](https://docs.cloudify.co/4.5.5#time-filter).
     
 * `Custom Influx Query` - By default, the query is based on deployment ID, metric name, time filter and resolution. It is possible to define your own query, which will then be used to fetch data. 
 
-    ![Charts Table configuration](https://docs.cloudify.co/staging/dev/images/ui/widgets/deployment-metric-graph-configuration-custom-influx-query.png)
+    ![Charts Table configuration](https://docs.cloudify.co/4.5.5/images/ui/widgets/deployment-metric-graph-configuration-custom-influx-query.png)
     
     Query (`select  from  where `) consists of the following parameters:
     * `SELECT` - Defines part of query added just after SELECT keyword. Example: `mean(value)`
@@ -34,12 +34,12 @@ You must also provide the Blueprint, Deployment, Node and Node instance IDs, eit
 
 * multi-metric with line charts
 
-![multi-metric example with line charts](https://docs.cloudify.co/staging/dev/images/ui/widgets/deployment-metric-graph.png)
+![multi-metric example with line charts](https://docs.cloudify.co/4.5.5/images/ui/widgets/deployment-metric-graph.png)
 
 * multi-metric with bar charts
 
-![multi-metric example with bar charts](https://docs.cloudify.co/staging/dev/images/ui/widgets/deployment-metric-graph-1.png)
+![multi-metric example with bar charts](https://docs.cloudify.co/4.5.5/images/ui/widgets/deployment-metric-graph-1.png)
 
 * single-metric with area chart
 
-![single-metric example with area chart](https://docs.cloudify.co/staging/dev/images/ui/widgets/deployment-metric-graph-2.png)
+![single-metric example with area chart](https://docs.cloudify.co/4.5.5/images/ui/widgets/deployment-metric-graph-2.png)

--- a/widgets/highAvailability/README.md
+++ b/widgets/highAvailability/README.md
@@ -2,7 +2,7 @@
 
 Displays the Manager’s High-Availability status. If a cluster architecture is configured on the manager, this widget will show the cluster-connected nodes. There is no click-through actions available from this widget, as all Cluster management actions should be performed from the Cloudify CLI / REST API. 
 
-![list-nodes-in-cluster-2](https://docs.cloudify.co/staging/dev/images/ui/widgets/list-nodes-in-cluster-2.png)      
+![list-nodes-in-cluster-2](https://docs.cloudify.co/4.5.5/images/ui/widgets/list-nodes-in-cluster-2.png)      
     
 #### Widget Settings
 * `Refresh time interval` - The time interval in which the widget’s data will be refreshed, in seconds. Default: 30 seconds

--- a/widgets/inputs/README.md
+++ b/widgets/inputs/README.md
@@ -7,7 +7,7 @@ Presents the names and values of the inputs of a specific deployment. The deploy
 
 If only a blueprint was selected, the widget will present the default values for the inputs, defined in the blueprint itself. 
 
-![deployment-inputs](https://docs.cloudify.co/staging/dev/images/ui/widgets/deployment-inputs.png)
+![deployment-inputs](https://docs.cloudify.co/4.5.5/images/ui/widgets/deployment-inputs.png)
 
 #### Widget Settings
 * `Refresh time interval` - The time interval in which the widget’s data will be refreshed, in seconds. Default: 30 seconds

--- a/widgets/maintenanceModeButton/README.md
+++ b/widgets/maintenanceModeButton/README.md
@@ -5,9 +5,9 @@ This Button allows to activate Maintenance Mode.
 Maintenance Mode can only be activated by `admin` users.
 
 
-More about Maintenance Mode you can find [here](https://docs.cloudify.co/staging/dev/working_with/manager/maintenance-mode).
+More about Maintenance Mode you can find [here](https://docs.cloudify.co/4.5.5/working_with/manager/maintenance-mode).
 
-![maintenance-mode-button](https://docs.cloudify.co/staging/dev/images/ui/widgets/maintenance-mode-button.png)
+![maintenance-mode-button](https://docs.cloudify.co/4.5.5/images/ui/widgets/maintenance-mode-button.png)
 
 #### Widget Settings
 None

--- a/widgets/managers/README.md
+++ b/widgets/managers/README.md
@@ -1,0 +1,33 @@
+### Cloudify Managers Management
+
+Displays the list of the deployments created using [Cloudify Manager of Managers plugin](https://github.com/Cloudify-PS/manager-of-managers) in the current tenant, according to the user’s permissions. The data is displayed in a table.
+
+![managers](https://docs.cloudify.co/4.5.5/images/ui/widgets/managers.png)
+
+##### Presented data
+
+You can see IP addresses, names 
+and status of all managers in the cluster. 
+
+Detailed status about specific is presented after hovering the status icon:
+
+![managers](https://docs.cloudify.co/4.5.5/images/ui/widgets/managers-widget-manager-status.png)
+ 
+##### User actions
+
+You can perform the following actions:
+
+* **Open Console** (![Open Console icon](https://docs.cloudify.co/4.5.5/images/ui/icons/open-console-icon.png)) of master (leader) nodes
+* **Refresh Status** (![Refresh Status icon](https://docs.cloudify.co/4.5.5/images/ui/icons/refresh-status-icon.png)) of all nodes in the cluster 
+* **Execute Workflow** (![Execute Workflow icon](https://docs.cloudify.co/4.5.5/images/ui/icons/execute-workflow-icon.png)) on master (leader) nodes 
+
+You can also refresh status or execute any workflow available on the Cloudify Manager of Managers deployment on multiple managers using bulk operations. To do so, select deployments using checkboxes in the left column and click one of the buttons above the table - **Refresh Status** or **Execute Workflow**.
+
+#### Widget Settings
+* `Refresh time interval` - The time interval in which the widget’s data will be refreshed, in seconds. Default: 10 seconds
+* `List of fields to show in the table` - You can choose which fields to present. By default, all of these fields are presented:
+   * Deployment
+   * IP
+   * Last Execution
+   * Status
+   * Actions

--- a/widgets/nodes/README.md
+++ b/widgets/nodes/README.md
@@ -3,9 +3,9 @@ Displays a list of the existing nodes in the current tenant, according to the us
 
 The nodes are listed by name. When you select a node, either by clicking its name in the table or by clicking it in the Topology pane, additional data about the node’s instances is displayed: The instances names, statuses, relationships and runtime properties. 
 
-Node type hierarchy can be shown by hovering over type hierarchy icon (![type-hierarchy-icon](https://docs.cloudify.co/staging/dev/images/ui/type-hierarchy-icon.png)).
+Node type hierarchy can be shown by hovering over type hierarchy icon (![type-hierarchy-icon](https://docs.cloudify.co/4.5.5/images/ui/icons/type-hierarchy-icon.png)).
 
-![nodes-list](https://docs.cloudify.co/staging/dev/images/ui/widgets/nodes-list-2.png)
+![nodes-list](https://docs.cloudify.co/4.5.5/images/ui/widgets/nodes-list-2.png)
 
 #### Widget Settings
 * `Refresh time interval` - The time interval in which the widget’s data will be refreshed, in seconds. Default: 10 seconds

--- a/widgets/nodesComputeNum/README.md
+++ b/widgets/nodesComputeNum/README.md
@@ -1,0 +1,7 @@
+### Number of compute nodes
+Displays the total number of compute nodes created on the tenant, according to the user’s permissions.
+
+![number_of_compute_nodes](https://docs.cloudify.co/4.5.5/images/ui/widgets/num_of_compute_nodes.png)
+
+#### Widget Settings 
+* `Refresh time interval` - The time interval in which the widget’s data will be refreshed, in seconds. Default: 30 seconds.

--- a/widgets/nodesStats/README.md
+++ b/widgets/nodesStats/README.md
@@ -1,7 +1,7 @@
 ### Nodes Statistics
 Displays the number of node instances, according to their status. 
 
-![node-statistics](https://docs.cloudify.co/staging/dev/images/ui/widgets/node-statistics.png)
+![node-statistics](https://docs.cloudify.co/4.5.5/images/ui/widgets/node-statistics.png)
 
 #### Widget Settings
 * `Refresh time interval` - The time interval in which the widget’s data will be refreshed, in seconds. Default: 10 seconds

--- a/widgets/onlyMyResources/README.md
+++ b/widgets/onlyMyResources/README.md
@@ -1,7 +1,7 @@
 ### Only my resources
 Shows a toggle allowing to filter only resources created by the logged in user. The supported resources are blueprints, deployments, plugins and snapshots. 
 
-![only-my-resources](https://docs.cloudify.co/staging/dev/images/ui/widgets/only_my_resources.png)
+![only-my-resources](https://docs.cloudify.co/4.5.5/images/ui/widgets/only_my_resources.png)
 
 #### Widget Settings
 None

--- a/widgets/outputs/README.md
+++ b/widgets/outputs/README.md
@@ -1,13 +1,18 @@
 ### Deployment Outputs
 
-Presents the names and values of the outputs of a specific deployment. The deployment can be selected in one of the following ways: 
+Presents the names and values of the outputs and capabilities of a specific deployment. The deployment can be selected in one of the following ways: 
 
 * By placing the deployment outputs widget in the deployments drill-down page, meaning the deployment has been selected before entering the page, and its id is included in the page’s context. 
 * By adding to the page a widget allowing to select deployments, such as the resources filter or the blueprint deployments.   
 
 If only a blueprint was selected, the widget will present the default values for the outputs, defined in the blueprint itself. 
 
-![deployment-outputs](https://docs.cloudify.co/staging/dev/images/ui/widgets/deployment-outputs.png)
+![deployment-outputs](https://docs.cloudify.co/4.5.5/images/ui/widgets/deployment-outputs.png)
+
+Capabilities can be easily distinguished from the outputs in the table. They have the following label on the right side of the name:
+
+![deployment-capability-label](https://docs.cloudify.co/4.5.5/images/ui/widgets/deployment-capability-label.png)
 
 #### Widget Settings
 * `Refresh time interval` - The time interval in which the widget’s data will be refreshed, in seconds. Default: 10 seconds
+* `Show capabilities` - Specify if deployment capabilities should be visible in table. Default: true 

--- a/widgets/pluginUploadButton/README.md
+++ b/widgets/pluginUploadButton/README.md
@@ -1,7 +1,7 @@
 ### Plugin upload button
 Opens the plugin upload screen, from which permitted users can specify the plugin’s wagon and yaml file (URL or local files) and visibility level of the plugins they wish to upload to the current tenant. 
 
-![plugin upload button](https://docs.cloudify.co/staging/dev/images/ui/widgets/plugin_upload_button.png)
+![plugin upload button](https://docs.cloudify.co/4.5.5/images/ui/widgets/plugin_upload_button.png)
 
 #### Widget Settings
 None

--- a/widgets/plugins/README.md
+++ b/widgets/plugins/README.md
@@ -13,7 +13,7 @@ The widget displays the following information:
    
 Upon hovering over ID label a pop up with the plugin’s ID will open, allowing you to copy it to the clipboard. 
 
-![plugins-list](https://docs.cloudify.co/staging/dev/images/ui/widgets/plugins-list.png)
+![plugins-list](https://docs.cloudify.co/4.5.5/images/ui/widgets/plugins-list.png)
 
 #### Widget Settings 
 * `Refresh time interval` - The time interval in which the widget’s data will be refreshed, in seconds. Default: 30 seconds.

--- a/widgets/pluginsCatalog/README.md
+++ b/widgets/pluginsCatalog/README.md
@@ -1,7 +1,7 @@
 ### Plugins Catalog
 A widget listing all the latest releases of the officially supported Cloudify plugins, and allows uploading them to the current tenant. 
 
-![plugins_catalog](https://docs.cloudify.co/staging/dev/images/ui/widgets/plugins-catalog.png)
+![plugins_catalog](https://docs.cloudify.co/4.5.5/images/ui/widgets/plugins-catalog.png)
 
 #### Widget Settings
 * `Plugins Catalog JSON Source`  - The json file from which the widget reads the plugins list. 

--- a/widgets/pluginsNum/README.md
+++ b/widgets/pluginsNum/README.md
@@ -2,7 +2,7 @@
 Displays the total number of plugins in the tenant, according to the user’s permissions and the blueprints’ visibility levels. 
 The widget is clickable, and upon clicking will redirect by default to the "System Resources" page. You can set the widget’s configuration to lead to a different page. 
 
-![number_of_plugins](https://docs.cloudify.co/staging/dev/images/ui/widgets/num_of_plugins.png)
+![number_of_plugins](https://docs.cloudify.co/4.5.5/images/ui/widgets/num_of_plugins.png)
 
 #### Widget Settings
 * `Refresh time interval` - The time interval in which the widget’s data will be refreshed, in seconds. Default: 30 seconds.

--- a/widgets/secrets/README.md
+++ b/widgets/secrets/README.md
@@ -6,11 +6,11 @@ Displays all the secrets visible to the logged-in user in the current tenant (in
 * **Secret Value** If the secret’s value is not hidden from the logged-in user, clicking on the “eye” icon will present its value, like in the following example, in which the logged-in user is a sys admin:
 
 
-![hidden-value-admin](https://docs.cloudify.co/staging/dev/images/ui/widgets/hidden_secret_admin.png)
+![hidden-value-admin](https://docs.cloudify.co/4.5.5/images/ui/widgets/hidden_secret_admin.png)
 
 If the secret’s value is hidden and the logged-in user isn’t the secret’s creator or has admin/manager permissions in the tenant, then the same clicking will result in a red “restricted” sign, as seen here:
 
-![hidden-value-user](https://docs.cloudify.co/staging/dev/images/ui/widgets/hidden_secret_unauth_user.png)
+![hidden-value-user](https://docs.cloudify.co/4.5.5/images/ui/widgets/hidden_secret_unauth_user.png)
 
 
 * **Hidden Value** Indicates if the secret’s value is hidden of not. If the logged-in user is the secret’s creator, or has admin/manager permissions in the tenant, checking/unchecking  this field will be enabled, and will make the secret hidden/non-hidden. 
@@ -20,7 +20,7 @@ If the secret’s value is hidden and the logged-in user isn’t the secret’s 
 * **Tenant** The name of the tenant the secret belongs to (if the secret is global, it might belong to a tenant different than the current one). 
  
 The right column of the table allows permitted users (secret creator, sys admin or tenant managers) to edit the secret’s value or delete it.
-Even if the secret’s value is hidden from users, they might still be able to use the secret by providing its key in the blueprint. To better understand how secrets work in Cloudify, go to [Using the secret store](https://docs.cloudify.co/staging/dev/developer/blueprints/spec-secretstore)
+Even if the secret’s value is hidden from users, they might still be able to use the secret by providing its key in the blueprint. To better understand how secrets work in Cloudify, go to [Using the secret store](https://docs.cloudify.co/4.5.5/developer/blueprints/spec-secretstore)
 
 #### Widget Settings 
 * `Refresh time interval` - The time interval in which the widget’s data will be refreshed, in seconds. Default: 30 seconds.

--- a/widgets/serversNum/README.md
+++ b/widgets/serversNum/README.md
@@ -1,7 +1,7 @@
 ### Number of nodes
 Displays the total number of nodes created on the tenant, according to the user’s permissions.
 
-![number_of_nodes](https://docs.cloudify.co/staging/dev/images/ui/widgets/num_of_nodes.png)
+![number_of_nodes](https://docs.cloudify.co/4.5.5/images/ui/widgets/num_of_nodes.png)
 
 #### Widget Settings 
 * `Refresh time interval` - The time interval in which the widget’s data will be refreshed, in seconds. Default: 30 seconds.

--- a/widgets/snapshots/README.md
+++ b/widgets/snapshots/README.md
@@ -25,7 +25,7 @@ The widget also exposes the following operations by the buttons on the top right
 * **Create** - Create a new snapshot on the current tenant 
 * **Upload** - Upload a snapshot to the current tenant
 
-![snapshots-list](https://docs.cloudify.co/staging/dev/images/ui/widgets/snapshots-list.png)
+![snapshots-list](https://docs.cloudify.co/4.5.5/images/ui/widgets/snapshots-list.png)
 
 #### Widget Settings 
 * `Refresh time interval` - The time interval in which the widget’s data will be refreshed, in seconds. Default: 30 seconds.

--- a/widgets/tenants/README.md
+++ b/widgets/tenants/README.md
@@ -15,7 +15,7 @@ The hamburger menu on the right of every tenant allows performing the following 
 Also, using the “Add” button on the right top corner of the widget, you will be able to create new tenants. 
 
 
-![tenants-list](https://docs.cloudify.co/staging/dev/images/ui/widgets/tenants-list.png)
+![tenants-list](https://docs.cloudify.co/4.5.5/images/ui/widgets/tenants-list.png)
 
 #### Widget Settings 
 * `Refresh time interval` - The time interval in which the widget’s data will be refreshed, in seconds. Default: 30 seconds.

--- a/widgets/text/README.md
+++ b/widgets/text/README.md
@@ -1,7 +1,7 @@
 ### Text
 Displays text provided in the configuration of the widget in markdown syntax. 
 
-![text-widget](https://docs.cloudify.co/staging/dev/images/ui/widgets/text_widget_content.png)
+![text-widget](https://docs.cloudify.co/4.5.5/images/ui/widgets/text_widget_content.png)
 
 #### Widget Settings 
 * `Header` - the header to be presented as the textbox’s title
@@ -13,4 +13,4 @@ Displays text provided in the configuration of the widget in markdown syntax.
 * `Content text size (px)` - Size of the header
 * `Content text font` - Font of the header
 
-![text-widget-configuration](https://docs.cloudify.co/staging/dev/images/ui/widgets/text_widget_configuration.png)
+![text-widget-configuration](https://docs.cloudify.co/4.5.5/images/ui/widgets/text_widget_configuration.png)

--- a/widgets/timeFilter/README.md
+++ b/widgets/timeFilter/README.md
@@ -3,7 +3,7 @@ Displays a time filter for deployment metric graphs. It allows to define:
 
 * **Time range** - Enables you to choose start (`From`) and end (`To`) dates
      * by defining custom range
-         * using text input - Influx-compatible date/time is allowed. It is possible to define both absolute and relative date/time. For details, see the [Influx documentation - Date time strings](https://docs.cloudify.co/staging/devhttps://docs.influxdata.com/influxdb/v0.8/api/query_language/#date-time-strings). Examples: `now() - 15m`  or `2017-09-21 10:10`
+         * using text input - Influx-compatible date/time is allowed. It is possible to define both absolute and relative date/time. For details, see the [Influx documentation - Date time strings](https://docs.influxdata.com/influxdb/v0.8/api/query_language/#date-time-strings). Examples: `now() - 15m`  or `2017-09-21 10:10`
          * using calendar picker - You can choose date and time from the calendar/time pickers
      * by choosing predefined range - There are few predefined time ranges available. You can apply them with one click using the buttons on the left side of the filter
 
@@ -17,7 +17,7 @@ The filter provides also the following features:
 
 * **Data validation** - When you click `Apply` button time range is validated. If invalid data is provided, then appropriate input field is marked with red color and time filter window will not be closed.  
 
-![Time Filter](https://docs.cloudify.co/staging/dev/images/ui/widgets/time-filter.png)
+![Time Filter](https://docs.cloudify.co/4.5.5/images/ui/widgets/time-filter.png)
 
 #### Widget Settings 
 None

--- a/widgets/topology/README.md
+++ b/widgets/topology/README.md
@@ -5,7 +5,7 @@ The blueprint or deployment ID must be selected in one of the following ways:
 * By placing the widget in the blueprints/deployments drill-down page, meaning the blueprint/deployment has been selected before entering the page, and its id is included in the page’s context. 
 * By adding to the page a widget allowing to select blueprints or deployments, such as the resources filter, the blueprints list or the blueprint deployments.  
 
-![show-topology](https://docs.cloudify.co/staging/dev/images/ui/widgets/show-topology.png)
+![show-topology](https://docs.cloudify.co/4.5.5/images/ui/widgets/show-topology.png)
 
 When executing a `Workflow` for a `Deployment` (e.g. the `install` workflow), the topology nodes show badges that reflect the workflow execution state.
     
@@ -17,37 +17,42 @@ When executing a `Workflow` for a `Deployment` (e.g. the `install` workflow), th
 * Alerts state - The workflow execution was partially completed for this node
 * Failed state - The workflow execution failed for this node
 
-![Deployment Topology Node Badges](https://docs.cloudify.co/staging/dev/images/ui/ui-deployment-topology-badges.png)
+![Deployment Topology Node Badges](https://docs.cloudify.co/4.5.5/images/ui/widgets/topology-widget-badges.png)
+
+When you hover over the badge and the topology is displayed for specific deployment (not a blueprint), then you will see summary of node instances states related to specific node:
+
+![Deployment Topology Node Instances Details](https://docs.cloudify.co/4.5.5/images/ui/widgets/topology-widget-node-instances-details.png)
+ 
 
 #### Workflow states represented by badges
 
 * A deployment before any workflow was executed
 
-    ![Deployment Topology](https://docs.cloudify.co/staging/dev/images/ui/ui-deployment-topology-1.png)
+    ![Deployment Topology](https://docs.cloudify.co/4.5.5/images/ui/widgets/topology-widget-1.png)
 
 * A deployment with a workflow execution in progress
 
-    ![Deployment Topology Execution In Progress](https://docs.cloudify.co/staging/dev/images/ui/ui-deployment-topology-2.png)
+    ![Deployment Topology Execution In Progress](https://docs.cloudify.co/4.5.5/images/ui/widgets/topology-widget-2.png)
 
 * A deployment with a workflow execution in progress, partially completed
 
-    ![Deployment Topology Execution Partially Completed](https://docs.cloudify.co/staging/dev/images/ui/ui-deployment-topology-3.png)
+    ![Deployment Topology Execution Partially Completed](https://docs.cloudify.co/4.5.5/images/ui/widgets/topology-widget-3.png)
 
 * A deployment with a workflow execution completed successfully
 
-    ![Deployment Topology Execution Completed Successfully](https://docs.cloudify.co/staging/dev/images/ui/ui-deployment-topology-4.png)
+    ![Deployment Topology Execution Completed Successfully](https://docs.cloudify.co/4.5.5/images/ui/widgets/topology-widget-4.png)
 
 * A deployment with a workflow execution partially completed successfully with some alerts
 
-    ![Deployment Topology Execution Completed Partially Alerts](https://docs.cloudify.co/staging/dev/images/ui/ui-deployment-topology-5.png)
+    ![Deployment Topology Execution Completed Partially Alerts](https://docs.cloudify.co/4.5.5/images/ui/widgets/topology-widget-5.png)
 
 * A deployment with a workflow execution that partially failed
 
-    ![Deployment Topology Execution Completed Partially Errors](https://docs.cloudify.co/staging/dev/images/ui/ui-deployment-topology-6.png)
+    ![Deployment Topology Execution Completed Partially Errors](https://docs.cloudify.co/4.5.5/images/ui/widgets/topology-widget-6.png)
 
 * A deployment with a workflow execution that failed
 
-    ![Deployment Topology Execution Completed Errors](https://docs.cloudify.co/staging/dev/images/ui/ui-deployment-topology-7.png)
+    ![Deployment Topology Execution Completed Errors](https://docs.cloudify.co/4.5.5/images/ui/widgets/topology-widget-7.png)
 
 #### Widget Settings 
 * `Refresh time interval` - The time interval in which the widget’s data will be refreshed, in seconds. Default: 10 seconds.

--- a/widgets/userGroups/README.md
+++ b/widgets/userGroups/README.md
@@ -16,7 +16,7 @@ The hamburger menu on the right of every tenant allows performing the following 
 * **Deleting the user groups** - possible only if there are no users who are members in the groups, and the group is not assigned with any tenants. 
 Also, using the “Add” button on the right top corner of the widget, you will be able to create new user groups. 
 
-![manage-usergroups](https://docs.cloudify.co/staging/dev/images/ui/widgets/manage-usergroups.png)
+![manage-usergroups](https://docs.cloudify.co/4.5.5/images/ui/widgets/manage-usergroups.png)
 
 #### Widget Settings 
 * `Refresh time interval` - The time interval in which the widget’s data will be refreshed, in seconds. Default: 30 seconds.

--- a/widgets/userManagement/README.md
+++ b/widgets/userManagement/README.md
@@ -20,7 +20,7 @@ The hamburger menu on the right of every tenant allows performing the following 
 Also, using the “Add” button on the right top corner of the widget, you will be able to create new users.
 Please notice that if you choose to  authenticate the users in front of an external user management system, you will not be able to create or delete the users in cloudify, nor to assigned them to Cloudify user groups,  to prevent conflicts between the two systems which might cause security problems. 
 
-![manage-users](https://docs.cloudify.co/staging/dev/images/ui/widgets/manage-users.png)
+![manage-users](https://docs.cloudify.co/4.5.5/images/ui/widgets/manage-users.png)
 
 #### Widget Settings 
 * `Refresh time interval` - The time interval in which the widget’s data will be refreshed, in seconds. Default: 30 seconds.


### PR DESCRIPTION
To be merged after 4.5.5 documentation release.
`rawContentBasePath` needs to be changed then to get files from `4.5.5` branch/tag and not `master`.