### PR TITLE
CY-965 - Type hierarchy popup in nodes widget doesn't show type hierarchy

### DIFF
--- a/app/components/basic/NodesTree.js
+++ b/app/components/basic/NodesTree.js
@@ -93,7 +93,7 @@ export default class NodesTree extends Component {
         if (!_.isEmpty(this.props.children)) {
             return (
                 <Tree {...this.props} className={`nodes-tree ${this.props.className}`}>
-                    {_.compact(this.props.children)}
+                    {_.compact(_.castArray(this.props.children))}
                 </Tree>
             )
         } else {

--- a/widgets/blueprintSources/src/BlueprintSources.js
+++ b/widgets/blueprintSources/src/BlueprintSources.js
@@ -99,7 +99,7 @@ export default class BlueprintSources extends React.Component {
                                     <NodesTree.Node key='imported' style={{marginTop: '5px'}} disabled title={
                                         <Label color='pink' horizontal>
                                             Imported Blueprints
-                                            <Label.Detail>{_.size(data.importedBlueprintIds)}</Label.Detail>
+                                            <Label.Detail>({_.size(data.importedBlueprintIds)})</Label.Detail>
                                         </Label>}>
                                         {
                                             _.map(data.importedBlueprintTrees, (tree, index) =>


### PR DESCRIPTION
- Fixed type hierarchy popup in nodes widget
- Added round brackets to number of imported blueprints in Blueprint Sources widget tree.