### PR TITLE
CY-1010 - RBAC fetching is not stateless

### DIFF
--- a/app/actions/app.js
+++ b/app/actions/app.js
@@ -38,15 +38,13 @@ export function intialPageLoad() {
                     return Promise.reject(NO_TENANTS_ERR);
                 }
             })
-            .then(() => {
-                return dispatch(getUserData());
-            })
+            .then(() => dispatch(getRBACConfig()))
+            .then(() => dispatch(getUserData()))
             .then(() => {
                 return Promise.all([
                     dispatch(loadTemplates()),
                     dispatch(loadTours()),
                     dispatch(loadWidgetDefinitions()),
-                    dispatch(getRBACConfig()),
                     dispatch(getClientConfig()),
                     dispatch(getStatus()),
                     dispatch(getVersion())

--- a/app/components/basic/form/InputFile.js
+++ b/app/components/basic/form/InputFile.js
@@ -142,7 +142,7 @@ export default class InputFile extends Component {
             this.props.showInput
             ?
                 <React.Fragment>
-                    <Input type="text" readOnly='true' value={this.state.value} title={this.state.title}
+                    <Input readOnly value={this.state.value} title={this.state.title}
                            name={'fileName' + this.props.name} placeholder={this.props.placeholder}
                            onClick={this._openFileSelection.bind(this)} disabled={this.props.disabled} action>
                         <input />

--- a/backend/handler/AuthHandler.js
+++ b/backend/handler/AuthHandler.js
@@ -45,9 +45,13 @@ class AuthHandler {
         })
     }
 
+    static isRbacInCache() {
+        return !_.isEmpty(authorizationCache);
+    }
+
     static getRBAC() {
-        if (_.isEmpty(authorizationCache)) {
-            logger.error('No RBAC data in cache. Have you tried to get cached RBAC before getting Manager config?');
+        if (!AuthHandler.isRbacInCache()) {
+            logger.error('No RBAC data in cache.');
         }
 
         return authorizationCache;

--- a/backend/routes/Auth.js
+++ b/backend/routes/Auth.js
@@ -80,7 +80,16 @@ router.post('/logout', passport.authenticate('token', {session: false}), (req, r
 });
 
 router.get('/RBAC', passport.authenticate('token', {session: false}), (req, res) => {
-    res.send(AuthHandler.getRBAC());
+    if (AuthHandler.isRbacInCache()) {
+        res.send(AuthHandler.getRBAC());
+    } else {
+        AuthHandler.getAndCacheConfig(req.headers['authentication-token'])
+            .then((config) => res.send(config.authorization))
+            .catch((err) => {
+                logger.error(err);
+                res.status(500).send({message: 'Failed to get RBAC configuration', error: err});
+            });
+    }
 });
 
 module.exports = router;

--- a/backend/routes/ServerProxy.js
+++ b/backend/routes/ServerProxy.js
@@ -46,7 +46,7 @@ async function proxyRequest(req,res,next) {
         timeout = config.app.proxy.timeouts.blueprintUpload;
     }
     //if is a maintenance status fetch then update RBAC cache if empty
-    else if(!!req.query.su.match(/^\/maintenance$/) &&  req.method === 'GET' && !AuthHandler.isRbacInCache()) {
+    else if (!!req.query.su.match(/^\/maintenance$/) &&  req.method === 'GET' && !AuthHandler.isRbacInCache()) {
         await AuthHandler.getAndCacheConfig(req.headers['authentication-token']);
     }
 


### PR DESCRIPTION
Improved RBAC fetching logic to allow refetching RBAC on the fly when it is not in cache.
Cache check is done during maintenance status fetching from client-side. When RBAC is not in cache, then it is fetched from manager.