### PR TITLE
CY-1039 - Invalid page size & CY-1040 - Invalid page number

### DIFF
--- a/app/components/basic/pagination/PaginationInfo.js
+++ b/app/components/basic/pagination/PaginationInfo.js
@@ -32,7 +32,7 @@ export default class PaginationInfo extends Component {
     }
 
     render() {
-        if (this.props.totalSize <= 0 && this.props.fetchSize <= 0 && this.props.currentPage == 1) {
+        if (this.props.totalSize <= 0 && this.props.fetchSize <= 0 && this.props.currentPage === 1) {
             return null;
         }
 


### PR DESCRIPTION
# CY-1039
Fixed setting page size to negative number causes WSOD and breaks all widgets from its type (CY-1039)
When user enters invalid value (not a number or integer not from range 1-500), then the following popup will be shown for 3 seconds:
![image](https://user-images.githubusercontent.com/5202105/52482270-18fdc200-2bb1-11e9-89cb-08ea4fae9cfb.png)
and page size is reset to 5.

# CY-1040
Fixed that after context change data table becomes empty when pagination is set to page higher than one (CY-1040)
When user displays tabular data on page no. X and changes context and after context change refetched data doesn't contain page no. X, then page number is changed to 1.