### PR TITLE
CY-1115 - Use reported_timestamp instead of timestamp in Events widget

### DIFF
--- a/widgets/events/src/widget.js
+++ b/widgets/events/src/widget.js
@@ -86,7 +86,7 @@ Stage.defineWidget({
         if (timeStart || timeEnd) {
             timeStart = timeStart?timeStart.utc().toISOString():'';
             timeEnd = timeEnd?timeEnd.utc().toISOString():'';
-            params._range = `@timestamp,${timeStart},${timeEnd}`;
+            params._range = `@reported_timestamp,${timeStart},${timeEnd}`;
         }
 
         params.type = eventFilter.type;
@@ -118,7 +118,7 @@ Stage.defineWidget({
                                             item.reported_timestamp + item.deployment_id + item.type + item.execution_id);
                 return Object.assign({}, item, {
                     id: id,
-                    timestamp: Stage.Utils.Time.formatTimestamp(item.timestamp),
+                    timestamp: Stage.Utils.Time.formatTimestamp(item.reported_timestamp, 'DD-MM-YYYY HH:mm:ss.SSS', moment.ISO_8601),
                     isSelected: id === SELECTED_EVENT_ID || (widget.configuration.showLogs && id === SELECTED_LOG_ID)
                 })
             }),


### PR DESCRIPTION
1. Changed Events widget to use reported_timestamp instead of timestamp field 
2. Extended time string format from `DD-MM-YYYY HH:mm` to `DD-MM-YYYY HH:mm:ss.SSS` to show seconds and milliseconds 
![image](https://user-images.githubusercontent.com/5202105/53637936-dca80980-3c24-11e9-8774-a70eaded41ee.png)
