### PR TITLE
(work-in-progress) CY-1137 - Allow non-admin users to see license and block license upload & CY-1147 - Update error handling after API changes

### DIFF
--- a/app/actions/auth.js
+++ b/app/actions/auth.js
@@ -7,7 +7,7 @@ import {clearContext} from './context';
 import {setAppError} from './app';
 import Consts from './../utils/consts';
 
-export function unauthorized(err) {
+export function showAppError(err) {
     return function (dispatch) {
         dispatch(clearContext());
         dispatch(setAppError(err));

--- a/app/actions/managers.js
+++ b/app/actions/managers.js
@@ -15,12 +15,14 @@ function requestLogin() {
     }
 }
 
-function receiveLogin(version, license) {
+function receiveLogin(username, role, version, license) {
     return {
+        type: types.RES_LOGIN,
+        username,
+        role,
         version,
         license,
         licenseRequired: !_.isNull(license),
-        type: types.RES_LOGIN,
         receivedAt: Date.now()
     }
 }
@@ -39,8 +41,8 @@ export function login (username, password, redirect) {
     return function (dispatch, getState) {
         dispatch(requestLogin());
         return Auth.login(username,password)
-            .then(({version, license}) => {
-                dispatch(receiveLogin(version, license));
+            .then(({role, version, license}) => {
+                dispatch(receiveLogin(username, role, version, license));
 
                 if(redirect){
                     window.location = redirect;

--- a/app/components/AboutModal.js
+++ b/app/components/AboutModal.js
@@ -35,7 +35,7 @@ export default class AboutModal extends Component {
         return (
             <Modal open={this.props.open} onClose={this.props.onHide}>
 
-                <Modal.Header className='mainBackgroundColor'>
+                <Modal.Header className='mainBackgroundColor' style={{padding: 0, paddingLeft: 10}}>
                     <Banner hideOnSmallScreen={false} />
                 </Modal.Header>
 

--- a/app/components/AboutModal.js
+++ b/app/components/AboutModal.js
@@ -56,7 +56,10 @@ export default class AboutModal extends Component {
                 </Modal.Content>
 
                 <Modal.Actions>
-                    <Button content='License Management' icon='key' color='yellow' onClick={this.props.onLicenseManagment} />
+                    {
+                        this.props.canLicenseManagement &&
+                        <Button content='License Management' icon='key' color='yellow' onClick={this.props.onLicenseManagment} />
+                    }
                     <CancelButton content='Close' onClick={this.props.onHide} />
                 </Modal.Actions>
             </Modal>

--- a/app/components/LicensePage.js
+++ b/app/components/LicensePage.js
@@ -24,7 +24,7 @@ function LicenseSwitchButton({isEditLicenseActive, onClick, color}) {
     )
 }
 
-function DescriptionMessage({isTrial, isEditLicenseActive, onLicenseButtonClick, status}) {
+function DescriptionMessage({canUploadLicense, isTrial, isEditLicenseActive, onLicenseButtonClick, status}) {
     const commonMessageProps = {icon: true};
 
     switch (status) {
@@ -44,34 +44,44 @@ function DescriptionMessage({isTrial, isEditLicenseActive, onLicenseButtonClick,
         case Consts.LICENSE.EXPIRED:
             return isTrial
                 ?
-                    <Message negative {...commonMessageProps}>
-                        <Icon name='clock outline' />
-                        <Message.Content>
+                <Message negative {...commonMessageProps}>
+                    <Icon name='clock outline' />
+                    <Message.Content>
+                        {
+                            canUploadLicense &&
                             <LicenseSwitchButton isEditLicenseActive={isEditLicenseActive}
                                                  onClick={onLicenseButtonClick} color='red' />
-                            <Message.Header>The trial license has expired</Message.Header>
-                            Please contact <a target='_blank' href='https://cloudify.co/contact'>Cloudify</a> to obtain a license key.
+                        }
+                        <Message.Header>The trial license has expired</Message.Header>
+                        Please contact <a target='_blank' href='https://cloudify.co/contact'>Cloudify</a> to obtain a license key.
 
-                        </Message.Content>
-                    </Message>
+                    </Message.Content>
+                </Message>
                 :
-                    <Message warning {...commonMessageProps}>
-                        <Icon name='clock outline' />
-                        <Message.Content>
+                <Message warning {...commonMessageProps}>
+                    <Icon name='clock outline' />
+                    <Message.Content>
+                        {
+                            canUploadLicense &&
                             <LicenseSwitchButton isEditLicenseActive={isEditLicenseActive}
                                                  onClick={onLicenseButtonClick} color='brown' />
-                            <Message.Header>Product license has expired</Message.Header>
-                            Please contact <a target='_blank' href='https://cloudify.co/support'>Cloudify support</a>
-                            &nbsp;to obtain a new license key.
-                        </Message.Content>
-                    </Message>;
+                        }
+
+                        <Message.Header>Product license has expired</Message.Header>
+                        Please contact <a target='_blank' href='https://cloudify.co/support'>Cloudify support</a>
+                        &nbsp;to obtain a new license key.
+                    </Message.Content>
+                </Message>;
         case Consts.LICENSE.ACTIVE:
             return (
                 <Message positive {...commonMessageProps}>
                     <Icon name='checkmark' />
                     <Message.Content>
-                        <LicenseSwitchButton isEditLicenseActive={isEditLicenseActive}
-                                             onClick={onLicenseButtonClick} color='green' />
+                        {
+                            canUploadLicense &&
+                            <LicenseSwitchButton isEditLicenseActive={isEditLicenseActive}
+                                                 onClick={onLicenseButtonClick} color='green'/>
+                        }
                         <Message.Header>License is valid</Message.Header>
                         No action required.
                     </Message.Content>
@@ -137,7 +147,7 @@ export default class LicensePage extends Component {
     }
 
     render () {
-        const {license: licenseObject, isProductOperational, onGoToApp, status} = this.props;
+        const {license: licenseObject, canUploadLicense, isProductOperational, onGoToApp, status} = this.props;
         const {license: licenseString, error, isLoading, isEditLicenseActive} = this.state;
 
         const isTrial = !_.isEmpty(licenseObject) ? licenseObject.trial : false;
@@ -149,17 +159,18 @@ export default class LicensePage extends Component {
                 <MessageContainer wide size='large' textAlign='left' loading={isLoading}>
                     <Header as='h2'><Icon name='key' /> License Management</Header>
 
-                    <DescriptionMessage isTrial={isTrial} status={status} isEditLicenseActive={isEditLicenseActive}
+                    <DescriptionMessage isTrial={isTrial} status={status} canUploadLicense={canUploadLicense}
+                                        isEditLicenseActive={isEditLicenseActive}
                                         onLicenseButtonClick={this.onLicenseButtonClick} />
 
                     <Segment>
                         {
-                            isEditLicenseActive
-                            ?
+                            canUploadLicense && isEditLicenseActive
+                                ?
                                 <UploadLicense error={error} isLoading={isLoading} license={licenseString}
-                                            onChange={this.onLicenseEdit} onErrorDismiss={this.onErrorDismiss}
-                                            onUpload={this.onLicenseUpload} />
-                            :
+                                               onChange={this.onLicenseEdit} onErrorDismiss={this.onErrorDismiss}
+                                               onUpload={this.onLicenseUpload} />
+                                :
                                 <CurrentLicense license={licenseObject}/>
                         }
                     </Segment>

--- a/app/containers/AboutModal.js
+++ b/app/containers/AboutModal.js
@@ -8,11 +8,15 @@ import { push } from 'connected-react-router';
 import Consts from '../utils/consts';
 
 import AboutModal from '../components/AboutModal'
+import stageUtils from '../utils/stageUtils';
 
 const mapStateToProps = (state, ownProps) => {
+    const manager = _.get(state, 'manager', {});
+
     return {
-        version: _.get(state, 'manager.version', {}),
-        license: _.get(state, 'manager.license.data', {})
+        canLicenseManagement: stageUtils.isUserAuthorized(Consts.permissions.LICENSE_UPLOAD, manager),
+        version: _.get(manager, 'version', {}),
+        license: _.get(manager, 'license.data', {})
     };
 };
 

--- a/app/containers/LicensePage.js
+++ b/app/containers/LicensePage.js
@@ -8,14 +8,17 @@ import {setLicense} from '../actions/license';
 import {push} from 'connected-react-router';
 import Consts from '../utils/consts';
 import Auth from '../utils/auth';
+import stageUtils from '../utils/stageUtils';
 
 const mapStateToProps = (state, ownProps) => {
-    const license = _.get(state, 'manager.license', {});
+    const manager = _.get(state, 'manager', {});
+    const license = _.get(manager, 'license', {});
 
     return {
-        manager: state.manager,
+        canUploadLicense: stageUtils.isUserAuthorized(Consts.permissions.LICENSE_UPLOAD, manager),
         isProductOperational:  Auth.isProductOperational(license),
         license: _.get(license, 'data', {}),
+        manager,
         status: _.get(license, 'status', Consts.LICENSE.EMPTY)
     }
 };

--- a/app/containers/Users.js
+++ b/app/containers/Users.js
@@ -12,11 +12,11 @@ import stageUtils from '../utils/stageUtils';
 import { push } from 'connected-react-router';
 
 const mapStateToProps = (state, ownProps) => {
-    var isTemplateManagementActive = !!state.templateManagement.templates || !!state.templateManagement.page;
+    const isTemplateManagementActive = !!state.templateManagement.templates || !!state.templateManagement.page;
 
-    var canEditMode = !isTemplateManagementActive && stageUtils.isUserAuthorized(Consts.permissions.STAGE_EDIT_MODE, state.manager);
-    var canTemplateManagement = state.config.mode === Consts.MODE_MAIN && stageUtils.isUserAuthorized(Consts.permissions.STAGE_TEMPLATE_MANAGEMENT, state.manager);
-    var canLicenseManagement = state.config.mode === Consts.MODE_MAIN && stageUtils.isUserAuthorized(Consts.permissions.LICENSE_MANAGEMENT, state.manager) && _.get(state, 'manager.license.isRequired', false);
+    const canEditMode = !isTemplateManagementActive && stageUtils.isUserAuthorized(Consts.permissions.STAGE_EDIT_MODE, state.manager);
+    const canTemplateManagement = state.config.mode === Consts.MODE_MAIN && stageUtils.isUserAuthorized(Consts.permissions.STAGE_TEMPLATE_MANAGEMENT, state.manager);
+    const canLicenseManagement = state.config.mode === Consts.MODE_MAIN && stageUtils.isUserAuthorized(Consts.permissions.LICENSE_UPLOAD, state.manager) && _.get(state, 'manager.license.isRequired', false);
 
     return {
         isEditMode: canEditMode ? (state.config.isEditMode || false) : false,

--- a/app/utils/ErrorCodes.js
+++ b/app/utils/ErrorCodes.js
@@ -1,7 +1,7 @@
 /**
  * Created by edenp on 07/09/2017.
  */
-'use strict';
 
 export const NO_TENANTS_ERR = 'NO_TENANTS_ERR';
 export const UNAUTHORIZED_ERR = 'UNAUTHORIZED_ERR';
+export const LICENSE_ERR = 'LICENSE_ERR';

--- a/app/utils/Interceptor.js
+++ b/app/utils/Interceptor.js
@@ -2,7 +2,9 @@
  * Created by edenp on 08/11/2017.
  */
 
-import {unauthorized} from '../actions/auth';
+import {showAppError} from '../actions/auth';
+import Consts from './consts';
+
 var singleton = null;
 
 export default class Interceptor {
@@ -11,7 +13,15 @@ export default class Interceptor {
     }
 
     handle401(){
-        this._store.dispatch(unauthorized('Unauthorized - Invalid Credentials'));
+        this._store.dispatch(showAppError('Unauthorized - Invalid Credentials'));
+    }
+
+    handleLicenseError(errorCode){
+        if (errorCode === Consts.NO_LICENSE_ERROR_CODE) {
+            this._store.dispatch(showAppError('No active license'));
+        } else if (errorCode === Consts.EXPIRED_LICENSE_ERROR_CODE) {
+            this._store.dispatch(showAppError('License has expired'));
+        }
     }
 
     static create(store){

--- a/app/utils/Internal.js
+++ b/app/utils/Internal.js
@@ -36,4 +36,10 @@ export default class Internal extends External {
     _isUnauthorized(response){
         return response.status === 401;
     }
+
+    _isLicenseError(response, body) {
+        return response.status === 400 &&
+            (body.error_code === Consts.NO_LICENSE_ERROR_CODE ||
+             body.error_code === Consts.EXPIRED_LICENSE_ERROR_CODE);
+    }
 }

--- a/app/utils/consts.js
+++ b/app/utils/consts.js
@@ -29,6 +29,8 @@ export default {
         EXPIRED: 'expired_license',
         ACTIVE: 'active_license',
     },
+    NO_LICENSE_ERROR_CODE: 'missing_cloudify_license',
+    EXPIRED_LICENSE_ERROR_CODE: 'expired_cloudify_license',
 
     DEFAULT_TENANT: 'default_tenant',
     MODE_MAIN: 'main',

--- a/app/utils/consts.js
+++ b/app/utils/consts.js
@@ -41,7 +41,8 @@ export default {
         STAGE_CONFIGURE: 'stage_configure',
         STAGE_TEMPLATE_MANAGEMENT: 'stage_template_management',
         CREATE_GLOBAL_RESOURCE: 'create_global_resource',
-        LICENSE_MANAGEMENT: 'license'
+        LICENSE_LIST: 'license_list',
+        LICENSE_UPLOAD: 'license_upload'
     },
     visibility: {
         PRIVATE: {name: 'private', icon: 'lock', color: 'red', title: 'Private resource'},

--- a/backend/routes/Auth.js
+++ b/backend/routes/Auth.js
@@ -31,13 +31,15 @@ router.post('/login', (req, res) =>
                     AuthHandler.getLicense(token.value)
                         .then((data) => ({
                             license: _.get(data, 'items[0]', {}),
-                            version
+                            version,
+                            role: token.role
                         }))
                 :
                     Promise.resolve(
                         {
                             license: null,
-                            version
+                            version,
+                            role: token.role
                         }
                     );
 
@@ -45,7 +47,7 @@ router.post('/login', (req, res) =>
                 return Promise.reject({message: 'User has no tenants', error_code: 'no_tenants'});
             }
         })
-        .then(({license, version}) => res.send({license, version}))
+        .then(({license, version, role}) => res.send({license, version, role}))
         .catch((err) => {
             logger.error(err);
             if(err.error_code === 'unauthorized_error'){
@@ -76,16 +78,12 @@ router.post('/saml/callback', passport.authenticate('saml', {session: false}), f
 });
 
 router.get('/user', passport.authenticate('token', {session: false}), (req, res) => {
-    AuthHandler.getManagerVersion(req.headers['authentication-token'])
-        .then((version) =>
-            res.send({
-                username: req.user.username,
-                role: req.user.role,
-                groupSystemRoles: req.user.group_system_roles,
-                tenantsRoles: req.user.tenants,
-                serverVersion: version.version
-            })
-        )
+    res.send({
+        username: req.user.username,
+        role: req.user.role,
+        groupSystemRoles: req.user.group_system_roles,
+        tenantsRoles: req.user.tenants
+    })
 });
 
 router.post('/logout', passport.authenticate('token', {session: false}), (req, res) => {


### PR DESCRIPTION
# About modal
For users without `upload_license` permission there's no *License Management* button present.
![image](https://user-images.githubusercontent.com/5202105/54599869-dd6dd780-4a3b-11e9-9c96-2f9bb528c5de.png)

# License Management page
For users without `upload_license` permission there's no *Edit License* button present.
![image](https://user-images.githubusercontent.com/5202105/54599914-ef4f7a80-4a3b-11e9-8e11-ce4e644022a8.png)

# Menus
For users without `upload_license` permission there's no *License Management* option present.
![image](https://user-images.githubusercontent.com/5202105/54599956-055d3b00-4a3c-11e9-8fda-d843ce492641.png)
![image](https://user-images.githubusercontent.com/5202105/54599981-0f7f3980-4a3c-11e9-9f7e-9578474d1a8f.png)

# Error handling
Interceptor improved to block action just after we start getting 'expired_cloudify_license' or 'missing_cloudify_license' error codes from Cloudify Manager REST API.
![image](https://user-images.githubusercontent.com/5202105/54606159-4dd02500-4a4b-11e9-9ede-4a2d15465a3d.png)
![image](https://user-images.githubusercontent.com/5202105/54606261-9d165580-4a4b-11e9-8eea-839dbbb15659.png)

