### PR TITLE
migration.js: use `logger.info`

### DIFF
--- a/backend/migration.js
+++ b/backend/migration.js
@@ -198,7 +198,7 @@ const cmd = process.argv[2].trim();
 if (cmd === 'current') {
     getCurrMigration()
         .then(current => {
-            logger.log(current);
+            logger.info(current);
             process.exit(0)
         });
 } else {


### PR DESCRIPTION
After swithing from log4js to winston, this log call has been updated
from `console.log` to `logger.log`, however the arguments are slightly
different with winston.