### PR TITLE
Migrations: don't attempt to bulkInsert nothing

### DIFF
--- a/backend/migrations/20190401111659-5_0-MovePageResourcesToFiles.js
+++ b/backend/migrations/20190401111659-5_0-MovePageResourcesToFiles.js
@@ -79,6 +79,8 @@ module.exports = {
       }
 
       logger.info('Records to be inserted:', records);
-      return queryInterface.bulkInsert('Resources', records);
+      if (!_.isEmpty(records)){
+        return queryInterface.bulkInsert('Resources', records);
+      }
   }
 };

--- a/backend/migrations/20190401130022-5_0-MoveTemplatesResourcesToFiles.js
+++ b/backend/migrations/20190401130022-5_0-MoveTemplatesResourcesToFiles.js
@@ -84,6 +84,8 @@ module.exports = {
     }
 
     logger.info('Records to be inserted:', records);
-    return queryInterface.bulkInsert('Resources', records);
+    if (!_.isEmpty(records)){
+      return queryInterface.bulkInsert('Resources', records);
+    }
   }
 };


### PR DESCRIPTION
If bulkInsert is called with an empty records array, it will
emit invalid SQL, eg. `INSERT INTO Resources () VALUES ;`, which leads
to a sql syntax error. Instead, let's not emit the insert at all, if
there's nothing to insert