### PR TITLE
CY-1539 - On deployment update UI shows blueprints in a wrong way

### DIFF
--- a/widgets/executions/src/widget.js
+++ b/widgets/executions/src/widget.js
@@ -5,17 +5,14 @@
 import ExecutionsTable from './ExecutionsTable';
 
 Stage.defineWidget({
-    id: "executions",
+    id: 'executions',
     name: 'Executions',
     description: 'This widget shows the deployment executions',
     initialWidth: 8,
     initialHeight: 24,
     hasStyle: true,
-    color : "teal",
-    fetchUrl: {
-        executions: '[manager]/executions?[params]',
-        deploymentUpdates: '[manager]/deployment-updates?_include=old_blueprint_id,execution_id[params:deployment_id]'
-    },
+    color : 'teal',
+    fetchUrl: '[manager]/executions?[params]',
     isReact: true,
     hasReadme: true,
     permission: Stage.GenericConfig.WIDGET_PERMISSION('executions'),
@@ -25,10 +22,10 @@ Stage.defineWidget({
         [
             Stage.GenericConfig.POLLING_TIME_CONFIG(5),
             Stage.GenericConfig.PAGE_SIZE_CONFIG(),
-            {id: "fieldsToShow",name: "List of fields to show in the table", placeHolder: "Select fields from the list",
-                items: ["Blueprint","Deployment","Workflow","Id","Created","Scheduled","Ended","Creator","Attributes","Status","Actions"],
+            {id: 'fieldsToShow',name: 'List of fields to show in the table', placeHolder: 'Select fields from the list',
+                items: ['Blueprint','Deployment','Workflow','Id','Created','Scheduled','Ended','Creator','Attributes','Status','Actions'],
                 default: 'Blueprint,Deployment,Workflow,Created,Ended,Creator,Attributes,Actions,Status', type: Stage.Basic.GenericField.MULTI_SELECT_LIST_TYPE},
-            {id: "showSystemExecutions", name: "Show system executions", default: true, type: Stage.Basic.GenericField.BOOLEAN_TYPE},
+            {id: 'showSystemExecutions', name: 'Show system executions', default: true, type: Stage.Basic.GenericField.BOOLEAN_TYPE},
             Stage.GenericConfig.SORT_COLUMN_CONFIG('created_at'),
             Stage.GenericConfig.SORT_ASCENDING_CONFIG(false)
         ],
@@ -49,29 +46,21 @@ Stage.defineWidget({
     render: function(widget,data,error,toolbox) {
 
         if (_.isEmpty(data)) {
-            return <Stage.Basic.Loading/>;
+            return <Stage.Basic.Loading />;
         }
 
-        let {executions, deploymentUpdates} = data;
-
-        // Create map from deployments updates items where execution_id is a key and blueprint_id is a value
-        let executionIdToBlueprintIdMap = {};
-        _.forEach(deploymentUpdates.items, (deploymentUpdate) =>
-            executionIdToBlueprintIdMap[deploymentUpdate.execution_id] = deploymentUpdate.old_blueprint_id);
-
-        let selectedExecution = toolbox.getContext().getValue('executionId');
-        let params = this.fetchParams(widget, toolbox);
-        let formattedData = {
-            items: _.map (executions.items,(item)=>{
-                return Object.assign({},item,{
-                    blueprint_id: _.get(executionIdToBlueprintIdMap, item.id, item.blueprint_id),
+        const selectedExecution = toolbox.getContext().getValue('executionId');
+        const params = this.fetchParams(widget, toolbox);
+        const formattedData = {
+            items: _.map (data.items, item =>
+                Object.assign({}, item,{
                     created_at: Stage.Utils.Time.formatTimestamp(item.created_at), //2016-07-20 09:10:53.103579
                     scheduled_for: Stage.Utils.Time.formatTimestamp(item.scheduled_for),
                     ended_at: Stage.Utils.Time.formatTimestamp(item.ended_at),
                     isSelected: item.id === selectedExecution
                 })
-            }),
-            total: _.get(executions, 'metadata.pagination.total', 0),
+            ),
+            total: _.get(data, 'metadata.pagination.total', 0),
             blueprintId: params.blueprint_id,
             deploymentId: params.deployment_id
         };


### PR DESCRIPTION
Updated Executions widget not to calculate blueprint ID for update workflows as it is now done on backend side.