### PR TITLE
CY-1710 DeploymentUpdate: add the update_executions param

### DIFF
--- a/widgets/common/src/DeploymentActions.js
+++ b/widgets/common/src/DeploymentActions.js
@@ -53,7 +53,8 @@ class DeploymentActions {
         shouldRunReinstall = true,
         reinstallList = [],
         forceUpdate = false,
-        preview = false
+        preview = false,
+        updateExecutions = false,
     ) {
         const data = {};
 
@@ -69,6 +70,7 @@ class DeploymentActions {
         data.reinstall_list = reinstallList;
         data.force = forceUpdate;
         data.preview = preview;
+        data.update_executions = updateExecutions;
 
         if (!_.isEmpty(deploymentInputs)) {
             data.inputs = deploymentInputs;

--- a/widgets/common/src/DeploymentActions.js
+++ b/widgets/common/src/DeploymentActions.js
@@ -54,7 +54,7 @@ class DeploymentActions {
         reinstallList = [],
         forceUpdate = false,
         preview = false,
-        updateExecutions = false,
+        updateExecutions = false
     ) {
         const data = {};
 

--- a/widgets/common/src/UpdateDeploymentModal.js
+++ b/widgets/common/src/UpdateDeploymentModal.js
@@ -336,19 +336,6 @@ class UpdateDeploymentModal extends React.Component {
                             />
                         </Form.Field>
 
-                        <Form.Field>
-                            <Form.Checkbox
-                                label="Update stored operations"
-                                name="updateExecutions"
-                                toggle
-                                help="Reevaluate inputs to stored operations, so that resuming
-                                                a workflow which was started before the update,
-                                                will use the updated values"
-                                checked={this.state.updateExecutions}
-                                onChange={this._handleInputChange.bind(this)}
-                            />
-                        </Form.Field>
-
                         <NodeInstancesFilter
                             name="reinstallList"
                             deploymentId={this.props.deployment.id}
@@ -372,6 +359,19 @@ class UpdateDeploymentModal extends React.Component {
                                                  update on this deployment has failed to
                                                  finished successfully"
                                 checked={this.state.force}
+                                onChange={this._handleInputChange.bind(this)}
+                            />
+                        </Form.Field>
+
+                        <Form.Field>
+                            <Form.Checkbox
+                                label="Update stored operations"
+                                name="updateExecutions"
+                                toggle
+                                help="Reevaluate inputs to stored operations, so that resuming
+                                                a workflow which was started before the update,
+                                                will use the updated values"
+                                checked={this.state.updateExecutions}
                                 onChange={this._handleInputChange.bind(this)}
                             />
                         </Form.Field>

--- a/widgets/common/src/UpdateDeploymentModal.js
+++ b/widgets/common/src/UpdateDeploymentModal.js
@@ -341,9 +341,9 @@ class UpdateDeploymentModal extends React.Component {
                                 label="Update stored operations"
                                 name="updateExecutions"
                                 toggle
-                                help='Reevaluate inputs to stored operations, so that resuming
+                                help="Reevaluate inputs to stored operations, so that resuming
                                                 a workflow which was started before the update,
-                                                will use the updated values'
+                                                will use the updated values"
                                 checked={this.state.updateExecutions}
                                 onChange={this._handleInputChange.bind(this)}
                             />

--- a/widgets/common/src/UpdateDeploymentModal.js
+++ b/widgets/common/src/UpdateDeploymentModal.js
@@ -22,6 +22,7 @@ class UpdateDeploymentModal extends React.Component {
         installWorkflowFirst: false,
         ignoreFailure: false,
         automaticReinstall: true,
+        updateExecutions: false,
         reinstallList: [],
         showPreview: false,
         previewData: {},
@@ -106,7 +107,8 @@ class UpdateDeploymentModal extends React.Component {
                 this.state.automaticReinstall,
                 this.state.reinstallList,
                 this.state.force,
-                preview
+                preview,
+                this.state.updateExecutions
             )
             .then(data => {
                 if (preview) {
@@ -330,6 +332,19 @@ class UpdateDeploymentModal extends React.Component {
                                                  that were explicitly given to "Reinstall
                                                  node instances list" will still be reinstalled'
                                 checked={this.state.automaticReinstall}
+                                onChange={this._handleInputChange.bind(this)}
+                            />
+                        </Form.Field>
+
+                        <Form.Field>
+                            <Form.Checkbox
+                                label="Update stored operations"
+                                name="updateExecutions"
+                                toggle
+                                help='Reevaluate inputs to stored operations, so that resuming
+                                                a workflow which was started before the update,
+                                                will use the updated values'
+                                checked={this.state.updateExecutions}
                                 onChange={this._handleInputChange.bind(this)}
                             />
                         </Form.Field>


### PR DESCRIPTION
Add a frontend for the parameter introduced in cloudify-cosmo/cloudify-manager#1919

This involves an additional checkbox in the deployment update modal,
which will make a deployment update also reevaluate operation inputs.

![update-operations](https://user-images.githubusercontent.com/790215/64475121-a7094d80-d17e-11e9-82f9-0ede0567d6ba.png)
