### PR TITLE
CY-2277 - In Cluster Status widget node status details are not shown when node status is Fail (for next branch)

### DIFF
--- a/app/components/basic/cluster/NodeStatus.js
+++ b/app/components/basic/cluster/NodeStatus.js
@@ -9,7 +9,7 @@ import { clusterNodeStatusEnum, clusterNodeStatuses } from './consts';
 export default function NodeStatus({ name, type, status, services }) {
     const icon = {
         [clusterNodeStatusEnum.OK]: <Icon name="checkmark" color="green" link />,
-        [clusterNodeStatusEnum.FAIL]: <Icon name="remove" color="red" link />
+        [clusterNodeStatusEnum.Fail]: <Icon name="remove" color="red" link />
     }[status];
 
     return (

--- a/package-lock.json
+++ b/package-lock.json
@@ -4938,8 +4938,8 @@
       }
     },
     "cloudify-blueprint-topology": {
-      "version": "http://repository.cloudifysource.org/cloudify/5.0.5/.dev1-build/cloudify-blueprint-topology-5.0.5-.dev1.tar",
-      "integrity": "sha512-UIEDRgtY1uiRjM7YVyZ0fzOm36Cr3VWHQPiftswvClv2IGi5Gf7P/Utr6v9+ZHwUayOVRm7u5ijBtvqzHme1rw=="
+      "version": "http://repository.cloudifysource.org/cloudify/5.0.5/ga-build/cloudify-blueprint-topology-5.0.5-ga.tar",
+      "integrity": "sha512-O7wMBzjAv6AuC9tnNCfhH4hHSUJO6NihimJCCdj4jfe/+nzyQoanwcAIKUd+v2G+YmBXNBxhcxIOH28p7z9+Gg=="
     },
     "cloudify-ui-common": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "better-console": "^0.2.4",
     "blueimp-md5": "^2.7.0",
-    "cloudify-blueprint-topology": "http://repository.cloudifysource.org/cloudify/5.0.5/.dev1-build/cloudify-blueprint-topology-5.0.5-.dev1.tar",
+    "cloudify-blueprint-topology": "http://repository.cloudifysource.org/cloudify/5.0.5/ga-build/cloudify-blueprint-topology-5.0.5-ga.tar",
     "cloudify-ui-common": "1.4.0",
     "cloudify-ui-components": "0.0.12",
     "connected-react-router": "^6.5.2",

--- a/test/cypress/support/cluster_status_commons.js
+++ b/test/cypress/support/cluster_status_commons.js
@@ -3,3 +3,8 @@ export const styles = {
     OK: 'background-color: rgb(33, 186, 69);',
     Fail: 'background-color: rgb(219, 40, 40);'
 };
+
+export const className = {
+    OK: 'checkmark',
+    Fail: 'remove'
+};


### PR DESCRIPTION
The same PR as #915 , but for `next` branch.

* Fixed failed node status in Cluster Status widget
* Added system test for Cluster Status widget - node status details check
* Updated cloudify-blueprint-topology link