### PR TITLE
Fixed JUnit reporter configuration for Cypress tests in Jenkins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12807,9 +12807,9 @@
       }
     },
     "mocha-junit-reporter": {
-      "version": "1.23.2",
-      "resolved": "https://registry.npmjs.org/mocha-junit-reporter/-/mocha-junit-reporter-1.23.2.tgz",
-      "integrity": "sha512-ro39KUheimNkqdtjk1qXNw4B8b/REkCjlNYAsZ5Eso7tsVIX5BoQzA24vWSnWBdP/KNEKDoMoldzYyCwHuHZlw==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/mocha-junit-reporter/-/mocha-junit-reporter-1.23.0.tgz",
+      "integrity": "sha512-pmpnEO4iDTmLfrT2RKqPsc5relG4crnDSGmXPuGogdda27A7kLujDNJV4EbTbXlVBCZXggN9rQYPEWMkOv4AAA==",
       "dev": true,
       "requires": {
         "debug": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "json-loader": "^0.5.7",
     "loader-utils": "^1.1.0",
     "mocha": "^6.2.2",
-    "mocha-junit-reporter": "^1.23.2",
+    "mocha-junit-reporter": "1.23.0",
     "nightwatch": "^0.9.21",
     "node-sass": "^4.13.1",
     "prettier": "^1.18.2",


### PR DESCRIPTION
Recent upgrade of `mocha-junit-reporter` caused a problem in Jenkins which stopped showing test results properly. This PR is to fix that.