### PR TITLE
CY-2464 - Added execution progress bar to the Deployments widget

### DIFF
--- a/widgets/common/src/NodeInstancesConsts.js
+++ b/widgets/common/src/NodeInstancesConsts.js
@@ -2,16 +2,23 @@
  * Created by jakub.niezgoda on 21/09/2018.
  */
 
+const groupNames = {
+    uninitialized: 'uninitialized',
+    inProgress: 'in progress',
+    started: 'started',
+    deleted: 'deleted'
+};
+
 const groupStates = [
     {
-        name: 'uninitialized',
+        name: groupNames.uninitialized,
         icon: 'cancel',
         colorSUI: 'blue',
         colorHTML: '#2185d0',
         states: ['uninitialized']
     },
     {
-        name: 'in progress',
+        name: groupNames.inProgress,
         icon: 'spinner',
         colorSUI: 'yellow',
         colorHTML: '#fbbd08',
@@ -28,14 +35,14 @@ const groupStates = [
         ]
     },
     {
-        name: 'started',
+        name: groupNames.started,
         icon: 'checkmark',
         colorSUI: 'green',
         colorHTML: '#21ba45',
         states: ['started']
     },
     {
-        name: 'deleted',
+        name: groupNames.deleted,
         icon: 'trash',
         colorSUI: 'black',
         colorHTML: '#1b1c1d',
@@ -45,5 +52,5 @@ const groupStates = [
 
 Stage.defineCommon({
     name: 'NodeInstancesConsts',
-    common: { groupStates }
+    common: { groupNames, groupStates }
 });

--- a/widgets/deployments/src/DeploymentsSegment.js
+++ b/widgets/deployments/src/DeploymentsSegment.js
@@ -4,6 +4,7 @@
 
 import MenuAction from './MenuAction';
 import DeploymentUpdatedIcon from './DeploymentUpdatedIcon';
+import ExecutionProgress from './ExecutionProgress';
 
 export default class DeploymentsSegment extends React.Component {
     static propTypes = {
@@ -146,6 +147,11 @@ export default class DeploymentsSegment extends React.Component {
                                     </Grid.Column>
                                 </Grid.Row>
                             </Grid>
+                            <ExecutionProgress
+                                execution={item.lastExecution}
+                                instancesCount={item.nodeInstancesCount}
+                                instancesStates={item.nodeInstancesStates}
+                            />
                         </DataSegment.Item>
                     );
                 })}

--- a/widgets/deployments/src/ExecutionProgress.js
+++ b/widgets/deployments/src/ExecutionProgress.js
@@ -1,0 +1,33 @@
+export default function ExecutionProgress({ execution, instancesCount, instancesStates }) {
+    const { Progress } = Stage.Basic;
+    const {
+        NodeInstancesConsts: { groupNames }
+    } = Stage.Common;
+    const { Execution } = Stage.Utils;
+
+    const color = Execution.isActiveExecution(execution) ? 'yellow' : 'green';
+    const error = Execution.isFailedExecution(execution);
+
+    let ratio = 1;
+    const { workflow_id: workflowId } = execution;
+    if (workflowId === 'install') {
+        ratio = _.get(instancesStates, groupNames.started, 0) / instancesCount;
+    } else if (workflowId === 'uninstall') {
+        ratio = _.get(instancesStates, groupNames.deleted, 0) / instancesCount;
+    }
+    const percent = parseInt(100 * ratio, 10);
+
+    return <Progress percent={percent} error={error} attached="bottom" color={color} />;
+}
+
+ExecutionProgress.propTypes = {
+    execution: PropTypes.shape({
+        workflow_id: PropTypes.string,
+        error: PropTypes.string
+    }).isRequired,
+    instancesCount: PropTypes.number.isRequired,
+    instancesStates: PropTypes.shape({
+        started: PropTypes.number,
+        deleted: PropTypes.number
+    }).isRequired
+};


### PR DESCRIPTION
![deployment_progress_bar](https://user-images.githubusercontent.com/5202105/81397113-fa290b00-9126-11ea-9004-b6c871ab9802.gif)

Colors:
- green - finished execution
- yellow - execution in progress
- red - failed execution

Limitations:
- works only with `install` and `uninstall` workflows