### PR TITLE
CY-2958 Added support for changing tabs order

### DIFF
--- a/app/actions/page.js
+++ b/app/actions/page.js
@@ -37,6 +37,10 @@ export function updateTab(pageId, tabIndex, name, isDefault) {
     };
 }
 
+export function moveTab(pageId, oldTabIndex, newTabIndex) {
+    return { type: types.MOVE_TAB, pageId, oldTabIndex, newTabIndex };
+}
+
 export function createPage(page, newPageId) {
     return {
         type: types.ADD_PAGE,

--- a/app/actions/types.js
+++ b/app/actions/types.js
@@ -5,6 +5,7 @@
 export const ADD_TAB = 'Add_TAB';
 export const REMOVE_TAB = 'REMOVE_TAB';
 export const UPDATE_TAB = 'UPDATE_TAB';
+export const MOVE_TAB = 'MOVE_TAB';
 
 export const ADD_PAGE = 'ADD_PAGE';
 export const SET_PAGES = 'SET_PAGES';

--- a/app/components/Page.js
+++ b/app/components/Page.js
@@ -24,6 +24,7 @@ export default class Page extends Component {
         onTabAdded: PropTypes.func.isRequired,
         onTabRemoved: PropTypes.func.isRequired,
         onTabUpdated: PropTypes.func.isRequired,
+        onTabMoved: PropTypes.func.isRequired,
         onPageSelected: PropTypes.func.isRequired,
         onEditModeExit: PropTypes.func.isRequired,
         isEditMode: PropTypes.bool.isRequired
@@ -47,6 +48,7 @@ export default class Page extends Component {
             onTabAdded,
             onTabRemoved,
             onTabUpdated,
+            onTabMoved,
             page,
             pagesList
         } = this.props;
@@ -87,6 +89,7 @@ export default class Page extends Component {
                     onTabAdded={onTabAdded}
                     onTabRemoved={onTabRemoved}
                     onTabUpdated={onTabUpdated}
+                    onTabMoved={onTabMoved}
                     isEditMode={isEditMode || false}
                 />
                 {isEditMode && (

--- a/app/components/PageContent.css
+++ b/app/components/PageContent.css
@@ -1,0 +1,20 @@
+.draggedTab {
+    border: 1px solid #d4d4d5;
+    border-bottom: none;
+    border-top-left-radius: 4px;
+    border-top-right-radius: 4px;
+    margin-bottom: 4px;
+    padding-top:13px;
+    text-align: center;
+    color:rgba(0, 0, 0, 0.95);
+    background-color: white;
+    opacity: 0.9;
+}
+
+.draggedTab.active {
+    font-weight: bold;
+}
+
+.draggedTab button {
+    margin-right: 0 !important;
+}

--- a/app/components/PagesList.js
+++ b/app/components/PagesList.js
@@ -7,13 +7,14 @@ import PropTypes from 'prop-types';
 
 import React, { Component } from 'react';
 import AddPageButton from '../containers/AddPageButton';
-import { Message } from './basic';
+import { Confirm, Message } from './basic';
 
 export default class PagesList extends Component {
     constructor(props) {
         super(props);
 
         this.pagesRef = React.createRef();
+        this.state = {};
     }
 
     static propTypes = {
@@ -56,6 +57,7 @@ export default class PagesList extends Component {
 
     render() {
         const { isEditMode, onPageRemoved, onPageSelected, pages, selected } = this.props;
+        const { pageToRemove } = this.state;
         let pageCount = 0;
         pages.map(p => {
             if (!p.isDrillDown) {
@@ -84,7 +86,8 @@ export default class PagesList extends Component {
                                         className="remove link icon small pageRemoveButton"
                                         onClick={event => {
                                             event.stopPropagation();
-                                            onPageRemoved(page);
+                                            if (_.isEmpty(page.tabs) && _.isEmpty(page.widgets)) onPageRemoved(page);
+                                            else this.setState({ pageToRemove: page });
                                         }}
                                     />
                                 ) : (
@@ -100,6 +103,16 @@ export default class PagesList extends Component {
                         <AddPageButton />
                     </div>
                 )}
+                <Confirm
+                    open={pageToRemove}
+                    onCancel={() => this.setState({ pageToRemove: null })}
+                    onConfirm={() => {
+                        onPageRemoved(pageToRemove);
+                        this.setState({ pageToRemove: null });
+                    }}
+                    header={`Are you sure you want to remove page ${_.get(pageToRemove, 'name')}?`}
+                    content="All widgets and tabs present in this page will be removed as well"
+                />
             </>
         );
     }

--- a/app/components/WidgetsList.js
+++ b/app/components/WidgetsList.js
@@ -5,40 +5,14 @@
 import PropTypes from 'prop-types';
 
 import React from 'react';
-import { Container, Header } from 'semantic-ui-react';
-
-import { useSelector } from 'react-redux';
 import Widget from '../containers/Widget';
 import Grid from './layout/Grid';
 import GridItem from './layout/GridItem';
-import stageUtils from '../utils/stageUtils';
 
-export default function WidgetsList({ onWidgetUpdated, onWidgetRemoved, isEditMode, tab, widgets }) {
-    const filteredWidgets = useSelector(state => {
-        const manager = state.manager || {};
-
-        return widgets.filter(
-            widget =>
-                widget.definition &&
-                stageUtils.isUserAuthorized(widget.definition.permission, manager) &&
-                stageUtils.isWidgetPermitted(widget.definition.supportedEditions, manager)
-        );
-    });
-
-    return _.isEmpty(filteredWidgets) ? (
-        <Container className="emptyPage alignCenter" style={{ padding: '10rem 0' }}>
-            {isEditMode ? (
-                <Header size="large">
-                    This {_.isNil(tab) ? 'page' : 'tab'} is empty, <br />
-                    don't be shy, give it a meaning!
-                </Header>
-            ) : (
-                <Header size="large">This {_.isNil(tab) ? 'page' : 'tab'} is empty</Header>
-            )}
-        </Container>
-    ) : (
+export default function WidgetsList({ onWidgetUpdated, onWidgetRemoved, isEditMode, widgets }) {
+    return (
         <Grid isEditMode={isEditMode} onGridDataChange={onWidgetUpdated}>
-            {filteredWidgets.map(widget => {
+            {widgets.map(widget => {
                 const widgetDefId = (widget.definition || {}).id;
                 return (
                     <GridItem
@@ -53,7 +27,6 @@ export default function WidgetsList({ onWidgetUpdated, onWidgetRemoved, isEditMo
                     >
                         <Widget
                             widget={widget}
-                            tab={tab}
                             isEditMode={isEditMode}
                             onWidgetUpdated={onWidgetUpdated}
                             onWidgetRemoved={onWidgetRemoved}
@@ -66,7 +39,6 @@ export default function WidgetsList({ onWidgetUpdated, onWidgetRemoved, isEditMo
 }
 
 WidgetsList.propTypes = {
-    tab: PropTypes.number,
     widgets: PropTypes.arrayOf(PropTypes.shape({})),
     onWidgetRemoved: PropTypes.func.isRequired,
     onWidgetUpdated: PropTypes.func.isRequired,
@@ -74,6 +46,5 @@ WidgetsList.propTypes = {
 };
 
 WidgetsList.defaultProps = {
-    tab: null,
     widgets: []
 };

--- a/app/components/WidgetsList.js
+++ b/app/components/WidgetsList.js
@@ -67,12 +67,13 @@ export default function WidgetsList({ onWidgetUpdated, onWidgetRemoved, isEditMo
 
 WidgetsList.propTypes = {
     tab: PropTypes.number,
-    widgets: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
+    widgets: PropTypes.arrayOf(PropTypes.shape({})),
     onWidgetRemoved: PropTypes.func.isRequired,
     onWidgetUpdated: PropTypes.func.isRequired,
     isEditMode: PropTypes.bool.isRequired
 };
 
 WidgetsList.defaultProps = {
-    tab: null
+    tab: null,
+    widgets: []
 };

--- a/app/components/templates/PageManagement.js
+++ b/app/components/templates/PageManagement.js
@@ -7,6 +7,7 @@ import { push } from 'connected-react-router';
 import { useDispatch, useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import v4 from 'uuid/v4';
+import { arrayMove } from 'react-sortable-hoc';
 import { Alert, Breadcrumb, Button, Divider, EditableLabel, ErrorMessage, Menu, Segment, Sidebar } from '../basic';
 import EditModeBubble from '../EditModeBubble';
 import PageContent from '../PageContent';
@@ -153,6 +154,8 @@ export default function PageManagement({ pageId, isEditMode }) {
         tabs[tabIndex] = { ...tabs[tabIndex], name, isDefault };
         setPage({ ...page, tabs });
     };
+    const onTabMoved = (oldTabIndex, newTabIndex) =>
+        setPage({ ...page, tabs: arrayMove(page.tabs, oldTabIndex, newTabIndex) });
 
     const isWidgetMaximized = findWidget({ maximized: true });
 
@@ -201,6 +204,7 @@ export default function PageManagement({ pageId, isEditMode }) {
                         onWidgetUpdated={onWidgetUpdated}
                         onWidgetRemoved={onWidgetRemoved}
                         onWidgetAdded={onWidgetAdded}
+                        onTabMoved={onTabMoved}
                         page={page}
                         isEditMode={isEditMode}
                     />

--- a/app/containers/Page.js
+++ b/app/containers/Page.js
@@ -10,6 +10,7 @@ import {
     changePageDescription,
     changePageName,
     createPagesMap,
+    moveTab,
     removeTab,
     selectPage,
     updateTab
@@ -95,6 +96,7 @@ const mapDispatchToProps = (dispatch, ownProps) => {
         onTabAdded: () => dispatch(addTab(ownProps.pageId)),
         onTabRemoved: tabIndex => dispatch(removeTab(ownProps.pageId, tabIndex)),
         onTabUpdated: (tabIndex, name, isDefault) => dispatch(updateTab(ownProps.pageId, tabIndex, name, isDefault)),
+        onTabMoved: (oldTabIndex, newTabIndex) => dispatch(moveTab(ownProps.pageId, oldTabIndex, newTabIndex)),
         onEditModeExit: () => {
             dispatch(setEditMode(false));
         },

--- a/app/reducers/pageReducer.js
+++ b/app/reducers/pageReducer.js
@@ -2,6 +2,7 @@
  * Created by kinneretzin on 30/08/2016.
  */
 
+import { arrayMove } from 'react-sortable-hoc';
 import * as types from '../actions/types';
 import widgets from './widgetsReducer';
 
@@ -53,6 +54,8 @@ const page = (state = {}, action) => {
             tabs[action.tabIndex] = { ...tabs[action.tabIndex], ..._.pick(action, 'name', 'isDefault') };
             return { ...state, tabs };
         }
+        case types.MOVE_TAB:
+            return { ...state, tabs: arrayMove(state.tabs, action.oldTabIndex, action.newTabIndex) };
         default:
             return state;
     }
@@ -103,6 +106,7 @@ const pages = (state = [], action) => {
         case types.ADD_TAB:
         case types.REMOVE_TAB:
         case types.UPDATE_TAB:
+        case types.MOVE_TAB:
             return state.map(p => {
                 if (p.id === action.pageId) {
                     return page(p, action);

--- a/package-lock.json
+++ b/package-lock.json
@@ -15539,6 +15539,16 @@
         "react-transition-group": "^2.5.0"
       }
     },
+    "react-sortable-hoc": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/react-sortable-hoc/-/react-sortable-hoc-1.11.0.tgz",
+      "integrity": "sha512-v1CDCvdfoR3zLGNp6qsBa4J1BWMEVH25+UKxF/RvQRh+mrB+emqtVHMgZ+WreUiKJoEaiwYoScaueIKhMVBHUg==",
+      "requires": {
+        "@babel/runtime": "^7.2.0",
+        "invariant": "^2.2.4",
+        "prop-types": "^15.5.7"
+      }
+    },
     "react-splitter-layout": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/react-splitter-layout/-/react-splitter-layout-3.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "react-redux": "^7.1.3",
     "react-resizable": "^1.7.5",
     "react-router-dom": "^5.1.2",
+    "react-sortable-hoc": "^1.11.0",
     "react-splitter-layout": "^3.0.0",
     "react-svg-pan-zoom": "^3.8.0",
     "react-visibility-sensor": "^5.1.1",


### PR DESCRIPTION
NOTE 1: No system tests. Some time ago I spent quite a lot of time trying to cover stencils drag'n'drop with cypress tests (in composer) and I failed. Since tabs reordering is not a crucial functionality I'd leave it without tests for now.

NOTE 2: I'm aware that `PageList.js` and `CreateTemplateModal.js` already implement reordering, but they are using a jquery based solution that I didn't want to copy, thus I decided to use a pure react solution. I assume `PageList.js` and `CreateTemplateModal.js` should be refactored at some point in the future to move away from jquery and consistently use the same solution as `PageContent.js` does.