### PR TITLE
CY-2959 - Fix issues in cloudify-stage - React props and state - app

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -105,6 +105,23 @@
                 "browser": true
             }
         },
+        { // FIXME: Temporary override, to be removed when /widgets directory will be fixed
+            "files": ["app/**/*.js"],
+            "rules": {
+                "react/prop-types": ["error"],
+                "react/default-props-match-prop-types": ["error"],
+                "react/forbid-prop-types": ["error"],
+                "react/no-unused-prop-types": ["error"],
+                "react/no-unused-state": ["error"],
+                "react/require-default-props": ["error"]
+            }
+        },
+        {
+            "files": ["widgets/**/*.js"],
+            "globals": {
+                "PropTypes": true
+            }
+        },
         {
             "files": ["backend/**/*.js", "scripts/*.js"],
             "env": {
@@ -130,7 +147,6 @@
         "L": true,
         "markdown": true,
         "moment": true,
-        "PropTypes": true,
         "React": true,
 
         "Stage": true

--- a/app/components/AboutModal.js
+++ b/app/components/AboutModal.js
@@ -3,60 +3,54 @@
  */
 
 import PropTypes from 'prop-types';
-
-import React, { Component } from 'react';
+import React from 'react';
 
 import Banner from '../containers/banner/Banner';
 import CurrentLicense from './license/CurrentLicense';
 import CurrentVersion from './license/CurrentVersion';
 import EulaLink from './license/EulaLink';
 
-export default class AboutModal extends Component {
-    constructor(props) {
-        super(props);
-    }
+export default function AboutModal({ canLicenseManagement, license, onHide, onLicenseManagement, open, version }) {
+    const { Button, CancelButton, Divider, Header, Modal } = Stage.Basic;
 
-    static propTypes = {
-        open: PropTypes.bool.isRequired,
-        onHide: PropTypes.func.isRequired,
-        version: PropTypes.object.isRequired,
-        license: PropTypes.object,
-        onLicenseManagment: PropTypes.func
-    };
+    return (
+        <Modal open={open} onClose={onHide}>
+            <Modal.Header className="mainBackgroundColor" style={{ padding: 0, paddingLeft: 10 }}>
+                <Banner hideOnSmallScreen={false} />
+            </Modal.Header>
 
-    static defaultProps = {
-        onLicenseManagment: _.noop
-    };
+            <Modal.Content>
+                <Header>Version Details</Header>
+                <Divider />
+                <CurrentVersion version={version} />
 
-    render() {
-        const { canLicenseManagement, license, onHide, onLicenseManagment, open, version } = this.props;
-        const { Button, CancelButton, Divider, Header, Modal } = Stage.Basic;
+                <Header>License Details</Header>
+                <Divider />
+                <CurrentLicense license={license} />
 
-        return (
-            <Modal open={open} onClose={onHide}>
-                <Modal.Header className="mainBackgroundColor" style={{ padding: 0, paddingLeft: 10 }}>
-                    <Banner hideOnSmallScreen={false} />
-                </Modal.Header>
+                <EulaLink />
+            </Modal.Content>
 
-                <Modal.Content>
-                    <Header>Version Details</Header>
-                    <Divider />
-                    <CurrentVersion version={version} />
-
-                    <Header>License Details</Header>
-                    <Divider />
-                    <CurrentLicense license={license} />
-
-                    <EulaLink />
-                </Modal.Content>
-
-                <Modal.Actions>
-                    {canLicenseManagement && (
-                        <Button content="License Management" icon="key" color="yellow" onClick={onLicenseManagment} />
-                    )}
-                    <CancelButton content="Close" onClick={onHide} />
-                </Modal.Actions>
-            </Modal>
-        );
-    }
+            <Modal.Actions>
+                {canLicenseManagement && (
+                    <Button content="License Management" icon="key" color="yellow" onClick={onLicenseManagement} />
+                )}
+                <CancelButton content="Close" onClick={onHide} />
+            </Modal.Actions>
+        </Modal>
+    );
 }
+
+AboutModal.propTypes = {
+    canLicenseManagement: PropTypes.bool.isRequired,
+    open: PropTypes.bool.isRequired,
+    onHide: PropTypes.func.isRequired,
+    version: PropTypes.shape({}).isRequired,
+    license: PropTypes.shape({}),
+    onLicenseManagement: PropTypes.func
+};
+
+AboutModal.defaultProps = {
+    license: {},
+    onLicenseManagement: _.noop
+};

--- a/app/components/AddButton.js
+++ b/app/components/AddButton.js
@@ -1,29 +1,26 @@
 /**
  * Created by kinneretzin on 30/08/2016.
  */
-
 import PropTypes from 'prop-types';
+import React from 'react';
 
-import React, { Component } from 'react';
-
-export default class AddButton extends Component {
-    static propTypes = {
-        children: PropTypes.any.isRequired,
-        onClick: PropTypes.func
-    };
-
-    static defaultProps = {
-        onClick() {}
-    };
-
-    render() {
-        const { children, className, onClick } = this.props;
-        return (
-            // eslint-disable-next-line react/button-has-type
-            <button className={`ui labeled icon button tiny teal basic compact ${className}`} onClick={onClick}>
-                <i className="plus icon" />
-                {children}
-            </button>
-        );
-    }
+export default function AddButton({ children, className, onClick }) {
+    return (
+        // eslint-disable-next-line react/button-has-type
+        <button className={`ui labeled icon button tiny teal basic compact ${className}`} onClick={onClick}>
+            <i className="plus icon" />
+            {children}
+        </button>
+    );
 }
+
+AddButton.propTypes = {
+    children: PropTypes.node.isRequired,
+    className: PropTypes.string,
+    onClick: PropTypes.func
+};
+
+AddButton.defaultProps = {
+    className: '',
+    onClick: _.noop
+};

--- a/app/components/AddWidgetModal.js
+++ b/app/components/AddWidgetModal.js
@@ -26,7 +26,6 @@ import {
     Segment
 } from './basic/index';
 import InstallWidgetModal from './InstallWidgetModal';
-import { addWidget } from '../actions/widgets';
 import EditModeButton from './EditModeButton';
 
 let nameIndex = 0;
@@ -54,15 +53,6 @@ export default class AddWidgetModal extends Component {
             categories: AddWidgetModal.generateCategories(props.widgetDefinitions),
             selectedCategory: GenericConfig.CATEGORY.ALL
         };
-    };
-
-    static propTypes = {
-        widgetDefinitions: PropTypes.array.isRequired,
-        onWidgetAdded: PropTypes.func.isRequired,
-        onWidgetInstalled: PropTypes.func.isRequired,
-        onWidgetUninstalled: PropTypes.func.isRequired,
-        onWidgetUpdated: PropTypes.func.isRequired,
-        onWidgetUsed: PropTypes.func.isRequired
     };
 
     componentDidUpdate(prevProps) {
@@ -445,3 +435,20 @@ export default class AddWidgetModal extends Component {
         );
     }
 }
+
+AddWidgetModal.propTypes = {
+    canInstallWidgets: PropTypes.bool.isRequired,
+    widgetDefinitions: PropTypes.arrayOf(
+        PropTypes.shape({
+            description: PropTypes.string,
+            id: PropTypes.string,
+            isCustom: PropTypes.bool,
+            name: PropTypes.string
+        })
+    ).isRequired,
+    onWidgetAdded: PropTypes.func.isRequired,
+    onWidgetInstalled: PropTypes.func.isRequired,
+    onWidgetUninstalled: PropTypes.func.isRequired,
+    onWidgetUpdated: PropTypes.func.isRequired,
+    onWidgetUsed: PropTypes.func.isRequired
+};

--- a/app/components/EditWidgetIcon.js
+++ b/app/components/EditWidgetIcon.js
@@ -1,27 +1,25 @@
 /**
  * Created by kinneretzin on 01/09/2016.
  */
-
 import PropTypes from 'prop-types';
+import React from 'react';
+import { Icon } from './basic/index';
 
-import React, { Component } from 'react';
-
-export default class EditWidgetIcon extends Component {
-    static propTypes = {
-        widgetId: PropTypes.string.isRequired,
-        onShowConfig: PropTypes.func.isRequired
-    };
-
-    render() {
-        return (
-            <i
-                className="setting link icon small editWidgetIcon"
-                onClick={event => {
-                    event.stopPropagation();
-                    const { onShowConfig } = this.props;
-                    onShowConfig();
-                }}
-            />
-        );
-    }
+export default function EditWidgetIcon({ onShowConfig }) {
+    return (
+        <Icon
+            name="setting"
+            link
+            size="small"
+            className="editWidgetIcon"
+            onClick={event => {
+                event.stopPropagation();
+                onShowConfig();
+            }}
+        />
+    );
 }
+
+EditWidgetIcon.propTypes = {
+    onShowConfig: PropTypes.func.isRequired
+};

--- a/app/components/EditWidgetModal.js
+++ b/app/components/EditWidgetModal.js
@@ -14,15 +14,6 @@ export default class EditWidgetModal extends Component {
         this.state = EditWidgetModal.initialState(props);
     }
 
-    static propTypes = {
-        configuration: PropTypes.object.isRequired,
-        configDef: PropTypes.array.isRequired,
-        widget: PropTypes.object.isRequired,
-        show: PropTypes.bool.isRequired,
-        onWidgetEdited: PropTypes.func.isRequired,
-        onHideConfig: PropTypes.func.isRequired
-    };
-
     static initialState = props => {
         const fields = {};
 
@@ -107,3 +98,21 @@ export default class EditWidgetModal extends Component {
         );
     }
 }
+
+EditWidgetModal.propTypes = {
+    configuration: PropTypes.shape({}).isRequired,
+    configDef: PropTypes.arrayOf(
+        PropTypes.shape({
+            default: PropTypes.any,
+            id: PropTypes.string,
+            name: PropTypes.string,
+            hidden: PropTypes.bool,
+            value: PropTypes.any
+        })
+    ).isRequired,
+    widget: PropTypes.shape({ id: PropTypes.string }).isRequired,
+    show: PropTypes.bool.isRequired,
+    onWidgetEdited: PropTypes.func.isRequired,
+    onHideConfig: PropTypes.func.isRequired,
+    open: PropTypes.bool.isRequired
+};

--- a/app/components/EditWidgetModal.js
+++ b/app/components/EditWidgetModal.js
@@ -28,8 +28,8 @@ export default class EditWidgetModal extends Component {
     };
 
     componentDidUpdate(prevProps) {
-        const { open } = this.props;
-        if (!prevProps.open && open) {
+        const { show } = this.props;
+        if (!prevProps.show && show) {
             this.setState(EditWidgetModal.initialState(this.props));
         }
     }
@@ -113,6 +113,5 @@ EditWidgetModal.propTypes = {
     widget: PropTypes.shape({ id: PropTypes.string }).isRequired,
     show: PropTypes.bool.isRequired,
     onWidgetEdited: PropTypes.func.isRequired,
-    onHideConfig: PropTypes.func.isRequired,
-    open: PropTypes.bool.isRequired
+    onHideConfig: PropTypes.func.isRequired
 };

--- a/app/components/ErrorPage.js
+++ b/app/components/ErrorPage.js
@@ -2,7 +2,8 @@
  * Created by pposel on 8/17/17.
  */
 
-import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { Redirect } from 'react-router-dom';
 
 import Consts from '../utils/consts';
@@ -10,17 +11,18 @@ import LinkToLogin from '../containers/LinkToLogin';
 import { Header, Message } from './basic';
 import { MessageContainer } from './shared';
 
-export default class ErrorPage extends Component {
-    render() {
-        const { error } = this.props;
-        return _.isEmpty(error) ? (
-            <Redirect to={Consts.LOGOUT_PAGE_PATH} />
-        ) : (
-            <MessageContainer>
-                <Header as="h2">Unexpected Error Occurred</Header>
-                <Message content={error} error />
-                <LinkToLogin />
-            </MessageContainer>
-        );
-    }
+export default function ErrorPage({ error }) {
+    return _.isEmpty(error) ? (
+        <Redirect to={Consts.LOGOUT_PAGE_PATH} />
+    ) : (
+        <MessageContainer>
+            <Header as="h2">Unexpected Error Occurred</Header>
+            <Message content={error} error />
+            <LinkToLogin />
+        </MessageContainer>
+    );
 }
+
+ErrorPage.propTypes = {
+    error: PropTypes.node.isRequired
+};

--- a/app/components/ExternalRedirect.js
+++ b/app/components/ExternalRedirect.js
@@ -2,16 +2,18 @@
  * Created by jakubniezgoda on 23/04/2018.
  */
 
-import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import React, { useEffect } from 'react';
 
-export class ExternalRedirect extends Component {
-    componentDidMount() {
-        const { url } = this.props;
+export default function ExternalRedirect({ url }) {
+    useEffect(() => {
+        // eslint-disable-next-line scanjs-rules/assign_to_location
         window.location = url;
-    }
+    }, []);
 
-    render() {
-        const { url } = this.props;
-        return <section>Redirecting to {url}...</section>;
-    }
+    return <section>Redirecting to {url}...</section>;
 }
+
+ExternalRedirect.propTypes = {
+    url: PropTypes.string.isRequired
+};

--- a/app/components/Home.js
+++ b/app/components/Home.js
@@ -2,6 +2,7 @@
  * Created by kinneretzin on 29/08/2016.
  */
 
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 
 import SideBar from '../containers/SideBar';
@@ -88,3 +89,23 @@ export default class Home extends Component {
         );
     }
 }
+
+Home.propTypes = {
+    contextParams: PropTypes.shape([]).isRequired,
+    emptyPages: PropTypes.bool.isRequired,
+    isMaintenance: PropTypes.bool.isRequired,
+    navigateTo404: PropTypes.func.isRequired,
+    navigateToError: PropTypes.func.isRequired,
+    navigateToMaintenancePage: PropTypes.func.isRequired,
+    onClearContext: PropTypes.func.isRequired,
+    onSetContextValue: PropTypes.func.isRequired,
+    onSetDrilldownContext: PropTypes.func.isRequired,
+    onStorePageId: PropTypes.func.isRequired,
+    pageId: PropTypes.string.isRequired,
+    pageName: PropTypes.string.isRequired,
+    selectedPage: PropTypes.shape({})
+};
+
+Home.defaultProps = {
+    selectedPage: null
+};

--- a/app/components/Home.js
+++ b/app/components/Home.js
@@ -91,7 +91,7 @@ export default class Home extends Component {
 }
 
 Home.propTypes = {
-    contextParams: PropTypes.shape([]).isRequired,
+    contextParams: PropTypes.arrayOf(PropTypes.shape({ context: PropTypes.shape({}) })).isRequired,
     emptyPages: PropTypes.bool.isRequired,
     isMaintenance: PropTypes.bool.isRequired,
     navigateTo404: PropTypes.func.isRequired,

--- a/app/components/InstallWidgetModal.js
+++ b/app/components/InstallWidgetModal.js
@@ -25,19 +25,6 @@ export default class InstallWidgetModal extends Component {
         scriptError: ''
     };
 
-    static propTypes = {
-        trigger: PropTypes.object.isRequired,
-        header: PropTypes.string.isRequired,
-        buttonLabel: PropTypes.string.isRequired,
-        onWidgetInstalled: PropTypes.func.isRequired,
-        className: PropTypes.string
-    };
-
-    static defaultProps = {
-        className: 'installWidgetModal',
-        onWidgetInstalled: () => Promise.resolve()
-    };
-
     componentDidUpdate(prevProps) {
         const { open } = this.props;
         if (!prevProps.open && open) {
@@ -156,3 +143,17 @@ export default class InstallWidgetModal extends Component {
         );
     }
 }
+
+InstallWidgetModal.propTypes = {
+    buttonLabel: PropTypes.string.isRequired,
+    header: PropTypes.string.isRequired,
+    open: PropTypes.bool.isRequired,
+    trigger: PropTypes.node.isRequired,
+    className: PropTypes.string,
+    onWidgetInstalled: PropTypes.func
+};
+
+InstallWidgetModal.defaultProps = {
+    className: 'installWidgetModal',
+    onWidgetInstalled: () => Promise.resolve()
+};

--- a/app/components/InstallWidgetModal.js
+++ b/app/components/InstallWidgetModal.js
@@ -25,9 +25,9 @@ export default class InstallWidgetModal extends Component {
         scriptError: ''
     };
 
-    componentDidUpdate(prevProps) {
-        const { open } = this.props;
-        if (!prevProps.open && open) {
+    componentDidUpdate(prevProps, prevState) {
+        const { open } = this.state;
+        if (!prevState.open && open) {
             this.setState(InstallWidgetModal.initialState);
         }
     }
@@ -147,7 +147,6 @@ export default class InstallWidgetModal extends Component {
 InstallWidgetModal.propTypes = {
     buttonLabel: PropTypes.string.isRequired,
     header: PropTypes.string.isRequired,
-    open: PropTypes.bool.isRequired,
     trigger: PropTypes.node.isRequired,
     className: PropTypes.string,
     onWidgetInstalled: PropTypes.func

--- a/app/components/LicensePage.js
+++ b/app/components/LicensePage.js
@@ -14,7 +14,7 @@ import EulaLink from './license/EulaLink';
 import UploadLicense from './license/UploadLicense';
 import { MessageContainer } from './shared';
 
-function LicenseSwitchButton({ isEditLicenseActive, onClick, color }) {
+function LicenseSwitchButton({ color, isEditLicenseActive, onClick }) {
     return (
         <Button
             content={isEditLicenseActive ? 'Show License' : 'Edit License'}
@@ -27,9 +27,18 @@ function LicenseSwitchButton({ isEditLicenseActive, onClick, color }) {
     );
 }
 
+LicenseSwitchButton.propTypes = {
+    color: PropTypes.string.isRequired,
+    isEditLicenseActive: PropTypes.bool.isRequired,
+    onClick: PropTypes.func.isRequired
+};
+
 function DescriptionMessage({ canUploadLicense, isTrial, isEditLicenseActive, onLicenseButtonClick, status }) {
     const commonMessageProps = { icon: true };
     const SpanMessage = ({ children }) => <span>{children}</span>;
+    SpanMessage.propTypes = {
+        children: PropTypes.node.isRequired
+    };
 
     switch (status) {
         case Consts.LICENSE.EMPTY:
@@ -132,6 +141,14 @@ function DescriptionMessage({ canUploadLicense, isTrial, isEditLicenseActive, on
     }
 }
 
+DescriptionMessage.propTypes = {
+    canUploadLicense: PropTypes.bool.isRequired,
+    isTrial: PropTypes.bool.isRequired,
+    isEditLicenseActive: PropTypes.bool.isRequired,
+    onLicenseButtonClick: PropTypes.func.isRequired,
+    status: PropTypes.oneOf([Consts.LICENSE.EMPTY, Consts.LICENSE.EXPIRED, Consts.LICENSE.ACTIVE]).isRequired
+};
+
 export default class LicensePage extends Component {
     constructor(props) {
         super(props);
@@ -148,18 +165,6 @@ export default class LicensePage extends Component {
         this.onLicenseEdit = this.onLicenseEdit.bind(this);
         this.onLicenseUpload = this.onLicenseUpload.bind(this);
     }
-
-    static propTypes = {
-        canUploadLicense: PropTypes.bool.isRequired,
-        isProductOperational: PropTypes.bool.isRequired,
-        license: PropTypes.object.isRequired,
-        onLicenseChange: PropTypes.func.isRequired,
-        onGoToApp: PropTypes.func.isRequired,
-        status: PropTypes.oneOf([Consts.LICENSE.ACTIVE, Consts.LICENSE.EMPTY, Consts.LICENSE.EXPIRED]).isRequired,
-        manager: PropTypes.object.isRequired
-    };
-
-    static defaultProps = {};
 
     componentDidMount() {
         const { manager, onLicenseChange } = this.props;
@@ -259,3 +264,13 @@ export default class LicensePage extends Component {
         );
     }
 }
+
+LicensePage.propTypes = {
+    canUploadLicense: PropTypes.bool.isRequired,
+    isProductOperational: PropTypes.bool.isRequired,
+    license: PropTypes.shape({ trial: PropTypes.bool }).isRequired,
+    onLicenseChange: PropTypes.func.isRequired,
+    onGoToApp: PropTypes.func.isRequired,
+    status: PropTypes.oneOf([Consts.LICENSE.ACTIVE, Consts.LICENSE.EMPTY, Consts.LICENSE.EXPIRED]).isRequired,
+    manager: PropTypes.shape({ doGet: PropTypes.func, doPut: PropTypes.func }).isRequired
+};

--- a/app/components/LinkToLogin.js
+++ b/app/components/LinkToLogin.js
@@ -2,23 +2,24 @@
  * Created by edenp on 09/10/2017.
  */
 import PropTypes from 'prop-types';
-
-import React, { Component } from 'react';
+import React from 'react';
 import { Link } from 'react-router-dom';
+
 import Consts from '../utils/consts';
 
-export default class LinkToLogin extends Component {
-    static propTypes = {
-        portalUrl: PropTypes.string,
-        searchQuery: PropTypes.string.isRequired
-    };
-
-    render() {
-        const { portalUrl, searchQuery } = this.props;
-        return portalUrl ? (
-            <a href={portalUrl}>Back to apps</a>
-        ) : (
-            <Link to={{ pathname: Consts.LOGIN_PAGE_PATH, search: searchQuery }}>Back to login</Link>
-        );
-    }
+export default function LinkToLogin({ portalUrl, searchQuery }) {
+    return portalUrl ? (
+        <a href={portalUrl}>Back to apps</a>
+    ) : (
+        <Link to={{ pathname: Consts.LOGIN_PAGE_PATH, search: searchQuery }}>Back to login</Link>
+    );
 }
+
+LinkToLogin.propTypes = {
+    searchQuery: PropTypes.string.isRequired,
+    portalUrl: PropTypes.string
+};
+
+LinkToLogin.defaultProps = {
+    portalUrl: null
+};

--- a/app/components/LoginPage.js
+++ b/app/components/LoginPage.js
@@ -137,8 +137,8 @@ export default class LoginPage extends Component {
 
 LoginPage.propTypes = {
     isLoggingIn: PropTypes.bool.isRequired,
-    location: PropTypes.string.isRequired,
     onLogin: PropTypes.func.isRequired,
+    location: PropTypes.shape({ search: PropTypes.string }),
     loginError: PropTypes.string,
     username: PropTypes.string,
     whiteLabel: PropTypes.shape({
@@ -150,6 +150,7 @@ LoginPage.propTypes = {
 };
 
 LoginPage.defaultProps = {
+    location: { search: '' },
     loginError: null,
     username: '',
     whiteLabel: PropTypes.shape({

--- a/app/components/LoginPage.js
+++ b/app/components/LoginPage.js
@@ -14,19 +14,11 @@ import FullScreenSegment from './layout/FullScreenSegment';
 import 'cloudify-ui-common/styles/font-JosefinSans-Bold.css';
 
 export default class LoginPage extends Component {
-    static propTypes = {
-        username: PropTypes.string,
-        loginError: PropTypes.string,
-        onLogin: PropTypes.func.isRequired,
-        isLoggingIn: PropTypes.bool.isRequired,
-        whiteLabel: PropTypes.object
-    };
-
     constructor(props, context) {
         super(props, context);
 
         this.state = {
-            username: props.username || '',
+            username: props.username,
             password: '',
             errors: {}
         };
@@ -142,3 +134,28 @@ export default class LoginPage extends Component {
         );
     }
 }
+
+LoginPage.propTypes = {
+    isLoggingIn: PropTypes.bool.isRequired,
+    location: PropTypes.string.isRequired,
+    onLogin: PropTypes.func.isRequired,
+    loginError: PropTypes.string,
+    username: PropTypes.string,
+    whiteLabel: PropTypes.shape({
+        loginPageHeader: PropTypes.string,
+        loginPageHeaderColor: PropTypes.string,
+        loginPageText: PropTypes.string,
+        loginPageTextColor: PropTypes.string
+    })
+};
+
+LoginPage.defaultProps = {
+    loginError: null,
+    username: '',
+    whiteLabel: PropTypes.shape({
+        loginPageHeader: '',
+        loginPageHeaderColor: '',
+        loginPageText: '',
+        loginPageTextColor: ''
+    })
+};

--- a/app/components/Page.js
+++ b/app/components/Page.js
@@ -3,34 +3,15 @@
  */
 
 import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+
 import Breadcrumbs from './Breadcrumbs';
 import EditModeBubble from './EditModeBubble';
 import { Button, EditableLabel } from './basic';
 import PageContent from './PageContent';
-import AddWidget from '../containers/AddWidget';
-import AddPageButton from '../containers/AddPageButton';
 
 export default class Page extends Component {
-    static propTypes = {
-        page: PropTypes.object.isRequired,
-        pagesList: PropTypes.array.isRequired,
-        onPageNameChange: PropTypes.func.isRequired,
-        onPageDescriptionChange: PropTypes.func.isRequired,
-        onWidgetUpdated: PropTypes.func.isRequired,
-        onWidgetRemoved: PropTypes.func.isRequired,
-        onWidgetAdded: PropTypes.func.isRequired,
-        onTabAdded: PropTypes.func.isRequired,
-        onTabRemoved: PropTypes.func.isRequired,
-        onTabUpdated: PropTypes.func.isRequired,
-        onTabMoved: PropTypes.func.isRequired,
-        onPageSelected: PropTypes.func.isRequired,
-        onEditModeExit: PropTypes.func.isRequired,
-        isEditMode: PropTypes.bool.isRequired
-    };
-
-    shouldComponentUpdate(nextProps, nextState) {
+    shouldComponentUpdate(nextProps) {
         const { isEditMode, page } = this.props;
         return !_.isEqual(page, nextProps.page) || isEditMode !== nextProps.isEditMode;
     }
@@ -101,3 +82,25 @@ export default class Page extends Component {
         );
     }
 }
+
+Page.propTypes = {
+    page: PropTypes.shape({
+        id: PropTypes.string,
+        description: PropTypes.string,
+        widgets: PropTypes.arrayOf(PropTypes.shape({})),
+        tabs: PropTypes.arrayOf(PropTypes.shape({ widgets: PropTypes.arrayOf(PropTypes.shape({})) }))
+    }).isRequired,
+    pagesList: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
+    onPageNameChange: PropTypes.func.isRequired,
+    onPageDescriptionChange: PropTypes.func.isRequired,
+    onWidgetUpdated: PropTypes.func.isRequired,
+    onWidgetRemoved: PropTypes.func.isRequired,
+    onWidgetAdded: PropTypes.func.isRequired,
+    onTabAdded: PropTypes.func.isRequired,
+    onTabRemoved: PropTypes.func.isRequired,
+    onTabUpdated: PropTypes.func.isRequired,
+    onTabMoved: PropTypes.func.isRequired,
+    onPageSelected: PropTypes.func.isRequired,
+    onEditModeExit: PropTypes.func.isRequired,
+    isEditMode: PropTypes.bool.isRequired
+};

--- a/app/components/PagesList.js
+++ b/app/components/PagesList.js
@@ -4,10 +4,10 @@
 
 import 'jquery-ui/ui/widgets/sortable';
 import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
+
 import AddPageButton from '../containers/AddPageButton';
-import { Confirm, Message } from './basic';
+import { Confirm } from './basic';
 
 export default class PagesList extends Component {
     constructor(props) {
@@ -16,16 +16,6 @@ export default class PagesList extends Component {
         this.pagesRef = React.createRef();
         this.state = {};
     }
-
-    static propTypes = {
-        onPageSelected: PropTypes.func.isRequired,
-        onPageRemoved: PropTypes.func.isRequired,
-        onPageReorder: PropTypes.func.isRequired,
-        onSidebarClose: PropTypes.func.isRequired,
-        pages: PropTypes.array.isRequired,
-        selected: PropTypes.string,
-        isEditMode: PropTypes.bool.isRequired
-    };
 
     componentDidMount() {
         const { onPageReorder } = this.props;
@@ -40,7 +30,7 @@ export default class PagesList extends Component {
         this.enableReorderInEditMode();
     }
 
-    componentDidUpdate(prevProps, prevState) {
+    componentDidUpdate(/* prevProps, prevState */) {
         this.enableReorderInEditMode();
     }
 
@@ -117,3 +107,24 @@ export default class PagesList extends Component {
         );
     }
 }
+
+PagesList.propTypes = {
+    onPageSelected: PropTypes.func.isRequired,
+    onPageRemoved: PropTypes.func.isRequired,
+    onPageReorder: PropTypes.func.isRequired,
+    pages: PropTypes.arrayOf(
+        PropTypes.shape({
+            id: PropTypes.string,
+            name: PropTypes.string,
+            isDrillDown: PropTypes.bool,
+            tabs: PropTypes.arrayOf(PropTypes.shape({})),
+            widgets: PropTypes.arrayOf(PropTypes.shape({}))
+        })
+    ).isRequired,
+    selected: PropTypes.string,
+    isEditMode: PropTypes.bool.isRequired
+};
+
+PagesList.defaultProps = {
+    selected: ''
+};

--- a/app/components/ResetPagesModal.js
+++ b/app/components/ResetPagesModal.js
@@ -1,6 +1,7 @@
 /**
  * Created by aleksander laktionow on 19/10/2017.
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import { Modal, Icon, ApproveButton, CancelButton, Checkbox, List, Card, Confirm } from './basic';
@@ -87,3 +88,12 @@ export default class ResetPagesModal extends React.Component {
         );
     }
 }
+
+ResetPagesModal.propTypes = {
+    onConfirm: PropTypes.func.isRequired,
+    onHide: PropTypes.func.isRequired,
+    open: PropTypes.bool.isRequired,
+    tenants: PropTypes.shape({
+        items: PropTypes.arrayOf(PropTypes.shape({ name: PropTypes.string }))
+    }).isRequired
+};

--- a/app/components/Routes.js
+++ b/app/components/Routes.js
@@ -2,7 +2,8 @@
  * Created by jakubniezgoda on 18/04/2018.
  */
 
-import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { Route, Redirect, Switch } from 'react-router-dom';
 
 import Consts from '../utils/consts';
@@ -11,62 +12,61 @@ import LogoPage from './LogoPage';
 import LoginPage from '../containers/LoginPage';
 import LicensePage from '../containers/LicensePage';
 import MaintenanceMode from '../containers/maintenance/MaintenanceModePageMessage';
-import { ExternalRedirect } from './ExternalRedirect';
+import ExternalRedirect from './ExternalRedirect';
 
-class Routes extends Component {
-    render() {
-        const {
-            isInMaintenanceMode,
-            isLicenseRequired,
-            isLoggedIn,
-            isProductOperational,
-            isSamlEnabled,
-            samlPortalUrl,
-            samlSsoUrl
-        } = this.props;
-        return (
-            <Switch>
-                <Route
-                    exact
-                    path={Consts.LOGIN_PAGE_PATH}
-                    render={() => (isSamlEnabled ? <ExternalRedirect url={samlSsoUrl} /> : <LoginPage />)}
-                />
-                <Route
-                    exact
-                    path={Consts.LOGOUT_PAGE_PATH}
-                    render={() =>
-                        isSamlEnabled ? (
-                            <ExternalRedirect url={samlPortalUrl} />
+export default function Routes({
+    isInMaintenanceMode,
+    isLicenseRequired,
+    isLoggedIn,
+    isProductOperational,
+    isSamlEnabled,
+    samlPortalUrl,
+    samlSsoUrl
+}) {
+    return (
+        <Switch>
+            <Route
+                exact
+                path={Consts.LOGIN_PAGE_PATH}
+                render={() => (isSamlEnabled ? <ExternalRedirect url={samlSsoUrl} /> : <LoginPage />)}
+            />
+            <Route
+                exact
+                path={Consts.LOGOUT_PAGE_PATH}
+                render={() =>
+                    isSamlEnabled ? <ExternalRedirect url={samlPortalUrl} /> : <Redirect to={Consts.LOGIN_PAGE_PATH} />
+                }
+            />
+            <Route exact path={Consts.ERROR_PAGE_PATH} component={LogoPage} />
+            <Route exact path={Consts.ERROR_NO_TENANTS_PAGE_PATH} component={LogoPage} />
+            <Route exact path={Consts.ERROR_404_PAGE_PATH} component={LogoPage} />
+            {isLoggedIn && isLicenseRequired && <Route exact path={Consts.LICENSE_PAGE_PATH} component={LicensePage} />}
+            {isLoggedIn && <Route exact path={Consts.MAINTENANCE_PAGE_PATH} component={MaintenanceMode} />}
+            <Route
+                render={props =>
+                    isLoggedIn ? (
+                        isInMaintenanceMode ? (
+                            <Redirect to={Consts.MAINTENANCE_PAGE_PATH} />
+                        ) : isProductOperational ? (
+                            <Layout {...props} />
                         ) : (
-                            <Redirect to={Consts.LOGIN_PAGE_PATH} />
+                            <Redirect to={Consts.LICENSE_PAGE_PATH} />
                         )
-                    }
-                />
-                <Route exact path={Consts.ERROR_PAGE_PATH} component={LogoPage} />
-                <Route exact path={Consts.ERROR_NO_TENANTS_PAGE_PATH} component={LogoPage} />
-                <Route exact path={Consts.ERROR_404_PAGE_PATH} component={LogoPage} />
-                {isLoggedIn && isLicenseRequired && (
-                    <Route exact path={Consts.LICENSE_PAGE_PATH} component={LicensePage} />
-                )}
-                {isLoggedIn && <Route exact path={Consts.MAINTENANCE_PAGE_PATH} component={MaintenanceMode} />}
-                <Route
-                    render={props =>
-                        isLoggedIn ? (
-                            isInMaintenanceMode ? (
-                                <Redirect to={Consts.MAINTENANCE_PAGE_PATH} />
-                            ) : isProductOperational ? (
-                                <Layout {...props} />
-                            ) : (
-                                <Redirect to={Consts.LICENSE_PAGE_PATH} />
-                            )
-                        ) : (
-                            <Redirect to={Consts.LOGIN_PAGE_PATH} />
-                        )
-                    }
-                />
-            </Switch>
-        );
-    }
+                    ) : (
+                        <Redirect to={Consts.LOGIN_PAGE_PATH} />
+                    )
+                }
+            />
+        </Switch>
+    );
 }
 
-export default Routes;
+Routes.propTypes = {
+    isInMaintenanceMode: PropTypes.bool.isRequired,
+    isLicenseRequired: PropTypes.bool.isRequired,
+    isLoggedIn: PropTypes.bool.isRequired,
+    isProductOperational: PropTypes.bool.isRequired,
+    isSamlEnabled: PropTypes.bool.isRequired,
+    samlPortalUrl: PropTypes.string.isRequired,
+    samlSsoUrl: PropTypes.string.isRequired
+};

--- a/app/components/SideBar.js
+++ b/app/components/SideBar.js
@@ -3,29 +3,25 @@
  */
 
 import PropTypes from 'prop-types';
-
-import React, { Component } from 'react';
+import React from 'react';
 
 import Pages from '../containers/Pages';
 
-export default class SideBar extends Component {
-    static propTypes = {
-        homePageId: PropTypes.string.isRequired,
-        pageId: PropTypes.string.isRequired,
-        isEditMode: PropTypes.bool.isRequired,
-        isOpen: PropTypes.bool
-    };
+export default function SideBar({ homePageId, isEditMode, isOpen, pageId }) {
+    const className = isOpen ? 'open' : '';
 
-    render() {
-        const { homePageId, isEditMode, isOpen, pageId } = this.props;
-        const className = isOpen ? 'open' : '';
-
-        return (
-            <div className="sidebarContainer">
-                <div className={`ui visible left vertical sidebar menu small basic ${className}`}>
-                    <Pages pageId={pageId} isEditMode={isEditMode} homePageId={homePageId} />
-                </div>
+    return (
+        <div className="sidebarContainer">
+            <div className={`ui visible left vertical sidebar menu small basic ${className}`}>
+                <Pages pageId={pageId} isEditMode={isEditMode} homePageId={homePageId} />
             </div>
-        );
-    }
+        </div>
+    );
 }
+
+SideBar.propTypes = {
+    homePageId: PropTypes.string.isRequired,
+    pageId: PropTypes.string.isRequired,
+    isEditMode: PropTypes.bool.isRequired,
+    isOpen: PropTypes.bool.isRequired
+};

--- a/app/components/Tenants.js
+++ b/app/components/Tenants.js
@@ -9,12 +9,6 @@ import EventBus from '../utils/EventBus';
 import { Dropdown, Icon, Input, Loader } from './basic';
 
 export default class Tenants extends Component {
-    static propTypes = {
-        manager: PropTypes.object.isRequired,
-        onTenantChange: PropTypes.func.isRequired,
-        onTenantsRefresh: PropTypes.func.isRequired
-    };
-
     constructor(props) {
         super(props);
 
@@ -95,3 +89,17 @@ export default class Tenants extends Component {
         );
     }
 }
+
+Tenants.propTypes = {
+    manager: PropTypes.shape({
+        tenants: PropTypes.arrayOf(
+            PropTypes.shape({
+                items: PropTypes.arrayOf(PropTypes.shape({ name: PropTypes.string })),
+                isFetching: PropTypes.bool,
+                selected: PropTypes.string
+            })
+        )
+    }).isRequired,
+    onTenantChange: PropTypes.func.isRequired,
+    onTenantsRefresh: PropTypes.func.isRequired
+};

--- a/app/components/Tenants.js
+++ b/app/components/Tenants.js
@@ -92,13 +92,11 @@ export default class Tenants extends Component {
 
 Tenants.propTypes = {
     manager: PropTypes.shape({
-        tenants: PropTypes.arrayOf(
-            PropTypes.shape({
-                items: PropTypes.arrayOf(PropTypes.shape({ name: PropTypes.string })),
-                isFetching: PropTypes.bool,
-                selected: PropTypes.string
-            })
-        )
+        tenants: PropTypes.shape({
+            items: PropTypes.arrayOf(PropTypes.shape({ name: PropTypes.string })),
+            isFetching: PropTypes.bool,
+            selected: PropTypes.string
+        })
     }).isRequired,
     onTenantChange: PropTypes.func.isRequired,
     onTenantsRefresh: PropTypes.func.isRequired

--- a/app/components/ToursButton.js
+++ b/app/components/ToursButton.js
@@ -73,7 +73,7 @@ export default class ToursButton extends React.Component {
 
 ToursButton.propTypes = {
     tours: PropTypes.arrayOf(
-        PropTypes.shape({ id: PropTypes.string, name: PropTypes.string, steps: PropTypes.shape({}) })
+        PropTypes.shape({ id: PropTypes.string, name: PropTypes.string, steps: PropTypes.arrayOf(PropTypes.shape({})) })
     ).isRequired,
     onTourStart: PropTypes.func.isRequired
 };

--- a/app/components/ToursButton.js
+++ b/app/components/ToursButton.js
@@ -12,15 +12,9 @@ export default class ToursButton extends React.Component {
         super(props, context);
 
         this.state = {
-            open: false,
             hovered: false
         };
     }
-
-    static propTypes = {
-        tours: PropTypes.array.isRequired,
-        onTourStart: PropTypes.func.isRequired
-    };
 
     startTour(tour) {
         const { onTourStart } = this.props;
@@ -76,3 +70,10 @@ export default class ToursButton extends React.Component {
         );
     }
 }
+
+ToursButton.propTypes = {
+    tours: PropTypes.arrayOf(
+        PropTypes.shape({ id: PropTypes.string, name: PropTypes.string, steps: PropTypes.shape({}) })
+    ).isRequired,
+    onTourStart: PropTypes.func.isRequired
+};

--- a/app/components/Users.js
+++ b/app/components/Users.js
@@ -2,6 +2,7 @@
  * Created by jakubniezgoda on 07/02/2017.
  */
 
+import _ from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 
@@ -21,21 +22,6 @@ export default class Users extends Component {
         this.onHideChangePasswordModal = this.onHideChangePasswordModal.bind(this);
         this.onEditModeClick = this.onEditModeClick.bind(this);
     }
-
-    static propTypes = {
-        manager: PropTypes.object.isRequired,
-        showAllOptions: PropTypes.bool.isRequired,
-        isEditMode: PropTypes.bool.isRequired,
-        canChangePassword: PropTypes.bool.isRequired,
-        canEditMode: PropTypes.bool.isRequired,
-        canTemplateManagement: PropTypes.bool.isRequired,
-        canLicenseManagement: PropTypes.bool.isRequired,
-        onEditModeChange: PropTypes.func.isRequired,
-        onLogout: PropTypes.func.isRequired,
-        onReset: PropTypes.func,
-        onTemplates: PropTypes.func,
-        onLicense: PropTypes.func
-    };
 
     componentDidMount() {
         const { onLogout } = this.props;
@@ -158,3 +144,24 @@ export default class Users extends Component {
         );
     }
 }
+
+Users.propTypes = {
+    manager: PropTypes.shape({ username: PropTypes.string }).isRequired,
+    showAllOptions: PropTypes.bool.isRequired,
+    isEditMode: PropTypes.bool.isRequired,
+    canChangePassword: PropTypes.bool.isRequired,
+    canEditMode: PropTypes.bool.isRequired,
+    canTemplateManagement: PropTypes.bool.isRequired,
+    canLicenseManagement: PropTypes.bool.isRequired,
+    onEditModeChange: PropTypes.func.isRequired,
+    onLogout: PropTypes.func.isRequired,
+    onReset: PropTypes.func,
+    onTemplates: PropTypes.func,
+    onLicense: PropTypes.func
+};
+
+Users.defaultProps = {
+    onReset: _.noop,
+    onTemplates: _.noop,
+    onLicense: _.noop
+};

--- a/app/components/Widget.js
+++ b/app/components/Widget.js
@@ -23,17 +23,6 @@ export default class Widget extends Component {
         };
     }
 
-    static propTypes = {
-        widget: PropTypes.object.isRequired,
-        context: PropTypes.object.isRequired,
-        manager: PropTypes.object.isRequired,
-        widgetData: PropTypes.object,
-        setContextValue: PropTypes.func.isRequired,
-        onWidgetRemoved: PropTypes.func.isRequired,
-        onWidgetUpdated: PropTypes.func.isRequired,
-        fetchWidgetData: PropTypes.func.isRequired
-    };
-
     static getDerivedStateFromError() {
         return { hasError: true };
     }
@@ -229,3 +218,30 @@ export default class Widget extends Component {
         );
     }
 }
+
+Widget.propTypes = {
+    context: PropTypes.shape({}).isRequired,
+    fetchWidgetData: PropTypes.func.isRequired,
+    isEditMode: PropTypes.bool.isRequired,
+    manager: PropTypes.shape({
+        tenants: PropTypes.shape({ selected: PropTypes.string, isFetching: PropTypes.bool })
+    }).isRequired,
+    onWidgetRemoved: PropTypes.func.isRequired,
+    onWidgetUpdated: PropTypes.func.isRequired,
+    setContextValue: PropTypes.func.isRequired,
+    widget: PropTypes.shape({
+        configuration: PropTypes.shape({}),
+        id: PropTypes.string,
+        name: PropTypes.string,
+        definition: PropTypes.shape({
+            color: PropTypes.string,
+            helpUrl: PropTypes.string,
+            permission: PropTypes.string,
+            readme: PropTypes.string,
+            showHeader: PropTypes.bool,
+            showBorder: PropTypes.bool
+        }),
+        maximized: PropTypes.bool
+    }).isRequired,
+    widgetData: PropTypes.shape({}).isRequired
+};

--- a/app/components/WidgetDynamicContent.js
+++ b/app/components/WidgetDynamicContent.js
@@ -10,14 +10,6 @@ import WidgetParamsHandler from '../utils/WidgetParamsHandler';
 import { ErrorMessage } from './basic';
 
 export default class WidgetDynamicContent extends Component {
-    static propTypes = {
-        widget: PropTypes.object.isRequired,
-        manager: PropTypes.object.isRequired,
-        data: PropTypes.object.isRequired,
-        onWidgetConfigUpdate: PropTypes.func,
-        fetchWidgetData: PropTypes.func.isRequired
-    };
-
     constructor(props) {
         super(props);
         this.state = {
@@ -313,3 +305,35 @@ export default class WidgetDynamicContent extends Component {
         );
     }
 }
+
+WidgetDynamicContent.propTypes = {
+    context: PropTypes.shape({}).isRequired,
+    data: PropTypes.shape({ data: PropTypes.any, error: PropTypes.string }).isRequired,
+    fetchWidgetData: PropTypes.func.isRequired,
+    onWidgetConfigUpdate: PropTypes.func.isRequired,
+    manager: PropTypes.shape({ tenants: PropTypes.shape({ selected: PropTypes.string }) }).isRequired,
+    widget: PropTypes.shape({
+        configuration: PropTypes.shape({
+            pollingTime: PropTypes.number,
+            pageSize: PropTypes.number
+        }),
+        id: PropTypes.string,
+        name: PropTypes.string,
+        definition: PropTypes.shape({
+            events: PropTypes.arrayOf(
+                PropTypes.shape({
+                    selector: PropTypes.string,
+                    event: PropTypes.string,
+                    fn: PropTypes.func
+                })
+            ),
+            fetchUrl: PropTypes.string,
+            fetchData: PropTypes.func,
+            isReact: PropTypes.bool,
+            postRender: PropTypes.func,
+            render: PropTypes.func,
+            showHeader: PropTypes.bool,
+            showBorder: PropTypes.bool
+        })
+    }).isRequired
+};

--- a/app/components/WidgetDynamicContent.js
+++ b/app/components/WidgetDynamicContent.js
@@ -308,7 +308,7 @@ export default class WidgetDynamicContent extends Component {
 
 WidgetDynamicContent.propTypes = {
     context: PropTypes.shape({}).isRequired,
-    data: PropTypes.shape({ data: PropTypes.any, error: PropTypes.string }).isRequired,
+    data: PropTypes.shape({ data: PropTypes.any, error: ErrorMessage.propTypes.error }).isRequired,
     fetchWidgetData: PropTypes.func.isRequired,
     onWidgetConfigUpdate: PropTypes.func.isRequired,
     manager: PropTypes.shape({ tenants: PropTypes.shape({ selected: PropTypes.string }) }).isRequired,
@@ -327,7 +327,7 @@ WidgetDynamicContent.propTypes = {
                     fn: PropTypes.func
                 })
             ),
-            fetchUrl: PropTypes.string,
+            fetchUrl: PropTypes.oneOfType([PropTypes.string, PropTypes.objectOf(PropTypes.string)]),
             fetchData: PropTypes.func,
             isReact: PropTypes.bool,
             postRender: PropTypes.func,

--- a/app/components/banner/Banner.js
+++ b/app/components/banner/Banner.js
@@ -3,12 +3,10 @@
  */
 
 import PropTypes from 'prop-types';
-
-import React, { Component } from 'react';
+import React from 'react';
 import { Link } from 'react-router-dom';
 
 import Consts from '../../utils/consts';
-
 import { Header } from '../basic';
 import LicenseTag from './LicenseTag';
 import Logo from './Logo';
@@ -16,63 +14,57 @@ import ProductName from './ProductName';
 import ProductVersion from './ProductVersion';
 import LicenseEdition from './LicenseEdition';
 
-export default class Banner extends Component {
-    static propTypes = {
-        isCommunity: PropTypes.bool,
-        isExpired: PropTypes.bool,
-        isTrial: PropTypes.bool,
-        productName: PropTypes.string,
-        productVersion: PropTypes.string,
-        licenseEdition: PropTypes.string,
-        hideOnSmallScreen: PropTypes.bool
-    };
+export default function Banner({
+    hideOnSmallScreen,
+    isCommunity,
+    isExpired,
+    isTrial,
+    licenseEdition,
+    productName,
+    productVersion,
+    showVersionDetails
+}) {
+    const className = hideOnSmallScreen ? 'hide-on-small-screen' : '';
 
-    static defaultProps = {
-        isCommunity: false,
-        isExpired: false,
-        isTrial: false,
-        productName: '',
-        productVersion: '',
-        licenseEdition: '',
-        hideOnSmallScreen: true
-    };
-
-    render() {
-        const {
-            hideOnSmallScreen,
-            isCommunity,
-            isExpired,
-            isTrial,
-            licenseEdition,
-            productName,
-            productVersion,
-            showVersionDetails
-        } = this.props;
-        const className = hideOnSmallScreen ? 'hide-on-small-screen' : '';
-
-        return (
-            <div style={{ lineHeight: '55px' }}>
-                <Link to={Consts.HOME_PAGE_PATH}>
-                    <Header as="h1" style={{ textDecoration: 'none', display: 'inline-block' }}>
-                        <Logo />
-                        <ProductName name={productName} className={className} />
-                        {showVersionDetails && !isCommunity && (
-                            <>
-                                <LicenseEdition edition={licenseEdition} className={className} />
-                                <ProductVersion version={productVersion} className={className} />
-                            </>
-                        )}
-                    </Header>
-                </Link>
-                {showVersionDetails && (
-                    <LicenseTag
-                        isCommunity={isCommunity}
-                        isExpired={isExpired}
-                        isTrial={isTrial}
-                        className={className}
-                    />
-                )}
-            </div>
-        );
-    }
+    return (
+        <div style={{ lineHeight: '55px' }}>
+            <Link to={Consts.HOME_PAGE_PATH}>
+                <Header as="h1" style={{ textDecoration: 'none', display: 'inline-block' }}>
+                    <Logo />
+                    <ProductName name={productName} className={className} />
+                    {showVersionDetails && !isCommunity && (
+                        <>
+                            <LicenseEdition edition={licenseEdition} className={className} />
+                            <ProductVersion version={productVersion} className={className} />
+                        </>
+                    )}
+                </Header>
+            </Link>
+            {showVersionDetails && (
+                <LicenseTag isCommunity={isCommunity} isExpired={isExpired} isTrial={isTrial} className={className} />
+            )}
+        </div>
+    );
 }
+
+Banner.propTypes = {
+    isCommunity: PropTypes.bool,
+    isExpired: PropTypes.bool,
+    isTrial: PropTypes.bool,
+    hideOnSmallScreen: PropTypes.bool,
+    licenseEdition: PropTypes.string,
+    productName: PropTypes.string,
+    productVersion: PropTypes.string,
+    showVersionDetails: PropTypes.bool
+};
+
+Banner.defaultProps = {
+    isCommunity: false,
+    isExpired: false,
+    isTrial: false,
+    hideOnSmallScreen: true,
+    licenseEdition: '',
+    productName: '',
+    productVersion: '',
+    showVersionDetails: true
+};

--- a/app/components/banner/LicenseEdition.js
+++ b/app/components/banner/LicenseEdition.js
@@ -2,9 +2,10 @@
  * Created by jakub.niezgoda on 15/03/2019.
  */
 
+import PropTypes from 'prop-types';
 import React from 'react';
 
-export default function LicenseEdition({ edition, className = '' }) {
+export default function LicenseEdition({ edition, className }) {
     return (
         !_.isEmpty(edition) && (
             <span style={{ color: 'white', verticalAlign: 'middle' }} className={className}>
@@ -14,3 +15,13 @@ export default function LicenseEdition({ edition, className = '' }) {
         )
     );
 }
+
+LicenseEdition.propTypes = {
+    className: PropTypes.string,
+    edition: PropTypes.string
+};
+
+LicenseEdition.defaultProps = {
+    className: '',
+    edition: ''
+};

--- a/app/components/banner/LicenseTag.js
+++ b/app/components/banner/LicenseTag.js
@@ -2,6 +2,7 @@
  * Created by jakub.niezgoda on 15/03/2019.
  */
 
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Link } from 'react-router-dom';
 
@@ -17,21 +18,32 @@ export default function LicenseTag({ isCommunity, isExpired, isTrial, className 
         ? { content: 'Trial' }
         : {};
 
-    const LicenseLabel = labelProps => (
+    const LicenseLabel = props => (
         <Label
-            {...labelProps}
+            {...props}
             size="large"
             style={{ marginLeft: 15, backgroundColor: '#FFC304', color: '#000000' }}
             className={className}
         />
     );
 
-    const LinkedLicenseLabel = labelProps =>
-        !_.isEmpty(labelProps) && (
+    const LinkedLicenseLabel = props =>
+        !_.isEmpty(props) && (
             <Link to={Consts.LICENSE_PAGE_PATH} className={className}>
-                <LicenseLabel {...labelProps} />
+                <LicenseLabel {...props} />
             </Link>
         );
 
     return isCommunity ? <LicenseLabel {...labelProps} /> : <LinkedLicenseLabel {...labelProps} />;
 }
+
+LicenseTag.propTypes = {
+    isCommunity: PropTypes.bool.isRequired,
+    isExpired: PropTypes.bool.isRequired,
+    isTrial: PropTypes.bool.isRequired,
+    className: PropTypes.string
+};
+
+LicenseTag.defaultProps = {
+    className: ''
+};

--- a/app/components/banner/ProductName.js
+++ b/app/components/banner/ProductName.js
@@ -2,12 +2,22 @@
  * Created by jakub.niezgoda on 15/03/2019.
  */
 
+import PropTypes from 'prop-types';
 import React from 'react';
 
-export default function ProductName({ name, className = '' }) {
+export default function ProductName({ name, className }) {
     return (
         <span style={{ color: 'white', verticalAlign: 'middle' }} className={className}>
             {name}
         </span>
     );
 }
+
+ProductName.propTypes = {
+    name: PropTypes.string.isRequired,
+    className: PropTypes.string
+};
+
+ProductName.defaultProps = {
+    className: ''
+};

--- a/app/components/banner/ProductVersion.js
+++ b/app/components/banner/ProductVersion.js
@@ -2,9 +2,10 @@
  * Created by jakub.niezgoda on 15/03/2019.
  */
 
+import PropTypes from 'prop-types';
 import React from 'react';
 
-export default function ProductVersion({ version = '', className = '' }) {
+export default function ProductVersion({ version, className }) {
     const versionMatches = version.match(/^(\d+)\.(\d+).*$/);
     const major = !!versionMatches && _.size(versionMatches) >= 2 ? versionMatches[1] : '';
     const minor = !!versionMatches && _.size(versionMatches) >= 3 ? versionMatches[2] : '';
@@ -19,3 +20,12 @@ export default function ProductVersion({ version = '', className = '' }) {
         )
     );
 }
+
+ProductVersion.propTypes = {
+    version: PropTypes.string.isRequired,
+    className: PropTypes.string
+};
+
+ProductVersion.defaultProps = {
+    className: ''
+};

--- a/app/components/layout/FullScreenSegment.js
+++ b/app/components/layout/FullScreenSegment.js
@@ -2,9 +2,14 @@
  * Created by jakub.niezgoda on 15/03/2019.
  */
 
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Segment } from '../basic';
 
 export default function FullScreenSegment({ children }) {
     return <Segment className="logoPage">{children}</Segment>;
 }
+
+FullScreenSegment.propTypes = {
+    children: PropTypes.node.isRequired
+};

--- a/app/components/layout/Grid.js
+++ b/app/components/layout/Grid.js
@@ -10,11 +10,6 @@ import GridItem from './GridItem';
 const ReactGridLayout = WidthProvider(Responsive);
 
 export default class Grid extends Component {
-    static propTypes = {
-        onGridDataChange: PropTypes.func.isRequired,
-        isEditMode: PropTypes.bool.isRequired
-    };
-
     saveChangedItems(layout) {
         const { isEditMode, onGridDataChange } = this.props;
         isEditMode &&
@@ -66,3 +61,9 @@ export default class Grid extends Component {
         );
     }
 }
+
+Grid.propTypes = {
+    children: PropTypes.node.isRequired,
+    onGridDataChange: PropTypes.func.isRequired,
+    isEditMode: PropTypes.bool.isRequired
+};

--- a/app/components/layout/GridItem.js
+++ b/app/components/layout/GridItem.js
@@ -2,32 +2,11 @@
  * Created by kinneretzin on 13/12/2016.
  */
 
+import _ from 'lodash';
 import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
 
 export default class GridItem extends Component {
-    static propTypes = {
-        id: PropTypes.string.isRequired,
-        x: PropTypes.number,
-        y: PropTypes.number,
-        width: PropTypes.number,
-        height: PropTypes.number,
-        className: PropTypes.string,
-        onItemAdded: PropTypes.func,
-        onItemRemoved: PropTypes.func,
-        maximized: PropTypes.bool
-    };
-
-    static defaultProps = {
-        x: 0,
-        y: 0,
-        width: 10,
-        height: 5,
-        className: '',
-        maximized: false
-    };
-
     componentDidMount() {
         const { id, onItemAdded } = this.props;
         if (onItemAdded) {
@@ -51,3 +30,17 @@ export default class GridItem extends Component {
         );
     }
 }
+
+GridItem.propTypes = {
+    id: PropTypes.string.isRequired,
+    children: PropTypes.node.isRequired,
+    className: PropTypes.string,
+    onItemAdded: PropTypes.func,
+    onItemRemoved: PropTypes.func
+};
+
+GridItem.defaultProps = {
+    className: '',
+    onItemAdded: _.noop,
+    onItemRemoved: _.noop
+};

--- a/app/components/layout/GridItem.js
+++ b/app/components/layout/GridItem.js
@@ -36,11 +36,26 @@ GridItem.propTypes = {
     children: PropTypes.node.isRequired,
     className: PropTypes.string,
     onItemAdded: PropTypes.func,
-    onItemRemoved: PropTypes.func
+    onItemRemoved: PropTypes.func,
+
+    // FIXME: These props are only used outside, in Grid component
+    // eslint-disable-next-line react/no-unused-prop-types
+    x: PropTypes.number,
+    // eslint-disable-next-line react/no-unused-prop-types
+    y: PropTypes.number,
+    // eslint-disable-next-line react/no-unused-prop-types
+    width: PropTypes.number,
+    // eslint-disable-next-line react/no-unused-prop-types
+    height: PropTypes.number
 };
 
 GridItem.defaultProps = {
     className: '',
     onItemAdded: _.noop,
-    onItemRemoved: _.noop
+    onItemRemoved: _.noop,
+
+    x: 0,
+    y: 0,
+    width: 10,
+    height: 5
 };

--- a/app/components/layout/Header.js
+++ b/app/components/layout/Header.js
@@ -16,14 +16,6 @@ import { Icon } from '../basic';
 import Consts from '../../utils/consts';
 
 export default class Header extends Component {
-    static propTypes = {
-        manager: PropTypes.any.isRequired,
-        mode: PropTypes.string.isRequired,
-        pageTitle: PropTypes.string.isRequired,
-        onResetPages: PropTypes.func.isRequired,
-        onSidebarOpen: PropTypes.func.isRequired
-    };
-
     constructor(props, context) {
         super(props, context);
 
@@ -100,3 +92,11 @@ export default class Header extends Component {
         );
     }
 }
+
+Header.propTypes = {
+    manager: PropTypes.shape({ tenants: PropTypes.shape({}) }).isRequired,
+    mode: PropTypes.string.isRequired,
+    pageTitle: PropTypes.string.isRequired,
+    onResetPages: PropTypes.func.isRequired,
+    onSidebarOpen: PropTypes.func.isRequired
+};

--- a/app/components/layout/Layout.js
+++ b/app/components/layout/Layout.js
@@ -25,21 +25,15 @@ export default class Layout extends Component {
         this.state = Layout.initialState;
     }
 
-    static propTypes = {
-        isLoading: PropTypes.bool.isRequired,
-        isUserAuthorizedForTemplateManagement: PropTypes.bool.isRequired,
-        intialPageLoad: PropTypes.func.isRequired
-    };
-
     static initialState = {
         initialized: false
     };
 
     componentDidMount() {
-        const { doLogout, intialPageLoad } = this.props;
+        const { doLogout, initialPageLoad } = this.props;
         console.log('First time logging in , fetching stuff');
 
-        intialPageLoad()
+        initialPageLoad()
             .then(() => {
                 StatusPoller.getPoller().start();
                 UserAppDataAutoSaver.getAutoSaver().start();
@@ -107,3 +101,10 @@ export default class Layout extends Component {
         );
     }
 }
+
+Layout.propTypes = {
+    doLogout: PropTypes.func.isRequired,
+    initialPageLoad: PropTypes.func.isRequired,
+    isLoading: PropTypes.bool.isRequired,
+    isUserAuthorizedForTemplateManagement: PropTypes.bool.isRequired
+};

--- a/app/components/layout/ScrollToTop.js
+++ b/app/components/layout/ScrollToTop.js
@@ -23,7 +23,7 @@ class ScrollToTop extends Component {
 }
 
 ScrollToTop.propTypes = {
-    location: PropTypes.string.isRequired,
+    location: PropTypes.shape({}).isRequired,
     children: PropTypes.node.isRequired
 };
 

--- a/app/components/layout/ScrollToTop.js
+++ b/app/components/layout/ScrollToTop.js
@@ -2,6 +2,7 @@
  * Created by jakub.niezgoda on 21/09/2018.
  */
 
+import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { withRouter } from 'react-router-dom';
 
@@ -20,4 +21,10 @@ class ScrollToTop extends Component {
         return children;
     }
 }
+
+ScrollToTop.propTypes = {
+    location: PropTypes.string.isRequired,
+    children: PropTypes.node.isRequired
+};
+
 export default withRouter(ScrollToTop);

--- a/app/components/license/CurrentLicense.js
+++ b/app/components/license/CurrentLicense.js
@@ -2,6 +2,7 @@
  * Created by jakub.niezgoda on 15/03/2019.
  */
 
+import PropTypes from 'prop-types';
 import React from 'react';
 import StageUtils from '../../utils/stageUtils';
 
@@ -54,3 +55,14 @@ export default function CurrentLicense({ license }) {
         )
     );
 }
+
+CurrentLicense.propTypes = {
+    license: PropTypes.shape({
+        capabilities: PropTypes.any,
+        cloudify_version: PropTypes.any,
+        customer_id: PropTypes.string,
+        exiration_date: PropTypes.string,
+        license_edition: PropTypes.string,
+        trial: PropTypes.bool
+    }).isRequired
+};

--- a/app/components/license/CurrentVersion.js
+++ b/app/components/license/CurrentVersion.js
@@ -2,6 +2,7 @@
  * Created by jakub.niezgoda on 15/03/2019.
  */
 
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import { Icon, Header, Message, Segment, Table } from '../basic';
@@ -46,3 +47,15 @@ export default function CurrentVersion({ version = {} }) {
         <Message>There is no version data.</Message>
     );
 }
+
+CurrentVersion.propTypes = {
+    version: PropTypes.shape({
+        build: PropTypes.string,
+        commit: PropTypes.string,
+        date: PropTypes.string,
+        distribution: PropTypes.string,
+        distro_release: PropTypes.string,
+        edition: PropTypes.string,
+        version: PropTypes.string
+    }).isRequired
+};

--- a/app/components/license/UploadLicense.js
+++ b/app/components/license/UploadLicense.js
@@ -2,9 +2,10 @@
  * Created by jakub.niezgoda on 15/03/2019.
  */
 
+import PropTypes from 'prop-types';
 import React from 'react';
 
-import { Button, Form, Segment } from '../basic';
+import { Button, ErrorMessage, Form, Segment } from '../basic';
 
 export default function UploadLicense({ error, isLoading, license, onChange, onErrorDismiss, onUpload }) {
     return (
@@ -34,3 +35,16 @@ export default function UploadLicense({ error, isLoading, license, onChange, onE
         </Segment>
     );
 }
+
+UploadLicense.propTypes = {
+    error: ErrorMessage.propTypes.error,
+    isLoading: PropTypes.bool.isRequired,
+    license: PropTypes.string.isRequired,
+    onChange: PropTypes.func.isRequired,
+    onErrorDismiss: PropTypes.func.isRequired,
+    onUpload: PropTypes.func.isRequired
+};
+
+UploadLicense.defaultProps = {
+    error: ''
+};

--- a/app/components/shared/ExecutionStatus.js
+++ b/app/components/shared/ExecutionStatus.js
@@ -3,7 +3,7 @@
  */
 
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React from 'react';
 import { Icon, Label } from 'semantic-ui-react';
 import { Popup } from 'cloudify-ui-components';
 
@@ -29,61 +29,84 @@ import ExecutionUtils from '../../utils/shared/ExecutionUtils';
  * ```
  *
  */
-export default class ExecutionStatus extends Component {
-    /**
-     * @property {object} execution Execution resource object
-     * @property {object} [labelProps={}] Props to be passed to Label component
-     * @property {object} [iconProps={}] Props to be passed to Icon component
-     * @property {boolean} [allowShowingPopup=true] If set to true and execution is in one of the waiting states, then popup will be shown on hovering execution status label displaying scheduled_for value
-     * @property {boolean} [showLabel=true] If set to true, then execution status will be added to label
-     * @property {boolean} [showWorkflowId=true] If set to true, then workflow ID will be added to label
-     */
-    static propTypes = {
-        execution: PropTypes.object.isRequired,
+export default function ExecutionStatus({
+    execution,
+    allowShowingPopup,
+    iconProps,
+    labelProps,
+    showLabel,
+    showWorkflowId
+}) {
+    const executionStatusDisplay = execution.status_display || execution.status;
+    const showPopup =
+        allowShowingPopup && ExecutionUtils.isWaitingExecution(execution) && !_.isEmpty(execution.scheduled_for);
 
-        allowShowingPopup: PropTypes.bool,
-        iconProps: PropTypes.object,
-        labelProps: PropTypes.object,
-        showLabel: PropTypes.bool,
-        showWorkflowId: PropTypes.bool
-    };
-
-    static defaultProps = {
-        allowShowingPopup: true,
-        iconProps: {},
-        labelProps: {},
-        showLabel: true,
-        showWorkflowId: false
-    };
-
-    render() {
-        const { execution, allowShowingPopup, iconProps, labelProps, showLabel, showWorkflowId } = this.props;
-        const executionStatusDisplay = execution.status_display || execution.status;
-        const showPopup =
-            allowShowingPopup && ExecutionUtils.isWaitingExecution(execution) && !_.isEmpty(execution.scheduled_for);
-
-        return showLabel ? (
-            <Popup on={showPopup ? 'hover' : []}>
-                <Popup.Trigger>
-                    <Label {...labelProps} onClick={e => e.stopPropagation()}>
-                        <Icon {...ExecutionUtils.getExecutionStatusIconParams(execution)} {...iconProps} />
-                        {showWorkflowId && execution.workflow_id}
-                        {showWorkflowId && ' '}
-                        {executionStatusDisplay}
-                    </Label>
-                </Popup.Trigger>
-                {showPopup ? (
-                    <span>
-                        Scheduled for: <strong>{execution.scheduled_for}</strong>
-                    </span>
-                ) : null}
-            </Popup>
-        ) : (
-            <Icon
-                {...ExecutionUtils.getExecutionStatusIconParams(execution)}
-                {...iconProps}
-                onClick={e => e.stopPropagation()}
-            />
-        );
-    }
+    return showLabel ? (
+        <Popup on={showPopup ? 'hover' : []}>
+            <Popup.Trigger>
+                <Label {...labelProps} onClick={e => e.stopPropagation()}>
+                    <Icon {...ExecutionUtils.getExecutionStatusIconParams(execution)} {...iconProps} />
+                    {showWorkflowId && execution.workflow_id}
+                    {showWorkflowId && ' '}
+                    {executionStatusDisplay}
+                </Label>
+            </Popup.Trigger>
+            {showPopup ? (
+                <span>
+                    Scheduled for: <strong>{execution.scheduled_for}</strong>
+                </span>
+            ) : null}
+        </Popup>
+    ) : (
+        <Icon
+            {...ExecutionUtils.getExecutionStatusIconParams(execution)}
+            {...iconProps}
+            onClick={e => e.stopPropagation()}
+        />
+    );
 }
+
+ExecutionStatus.propTypes = {
+    /**
+     * Execution resource object
+     */
+    execution: PropTypes.shape({
+        status_display: PropTypes.string,
+        status: PropTypes.string,
+        scheduled_for: PropTypes.string,
+        workflow_id: PropTypes.string
+    }).isRequired,
+
+    /**
+     * If set to true and execution is in one of the waiting states, then popup will be shown on hovering execution status label displaying scheduled_for value
+     */
+    allowShowingPopup: PropTypes.bool,
+
+    /**
+     * Props to be passed to Icon component
+     */
+    iconProps: PropTypes.shape({}),
+
+    /**
+     * Props to be passed to Label component
+     */
+    labelProps: PropTypes.shape({}),
+
+    /**
+     * If set to true, then execution status will be added to label
+     */
+    showLabel: PropTypes.bool,
+
+    /**
+     * If set to true, then workflow ID will be added to label
+     */
+    showWorkflowId: PropTypes.bool
+};
+
+ExecutionStatus.defaultProps = {
+    allowShowingPopup: true,
+    iconProps: {},
+    labelProps: {},
+    showLabel: true,
+    showWorkflowId: false
+};

--- a/app/components/shared/MaintenanceModeModal.js
+++ b/app/components/shared/MaintenanceModeModal.js
@@ -38,20 +38,6 @@ class MaintenanceModeModal extends Component {
         error: ''
     };
 
-    static propTypes = {
-        show: PropTypes.bool.isRequired,
-        manager: PropTypes.object.isRequired,
-        activeExecutions: PropTypes.object,
-        onHide: PropTypes.func.isRequired,
-        onMaintenanceActivate: PropTypes.func.isRequired,
-        onMaintenanceDeactivate: PropTypes.func.isRequired,
-        onFetchActiveExecutions: PropTypes.func.isRequired
-    };
-
-    static defaultProps = {
-        activeExecutions: {}
-    };
-
     componentDidUpdate(prevProps) {
         const { onClose, show } = this.props;
         if (!prevProps.show && show) {
@@ -269,6 +255,31 @@ class MaintenanceModeModal extends Component {
         );
     }
 }
+
+MaintenanceModeModal.propTypes = {
+    show: PropTypes.bool.isRequired,
+    manager: PropTypes.shape({ maintenance: PropTypes.string }).isRequired,
+    onCancelExecution: PropTypes.func.isRequired,
+    onClose: PropTypes.func.isRequired,
+    onHide: PropTypes.func.isRequired,
+    onMaintenanceActivate: PropTypes.func.isRequired,
+    onMaintenanceDeactivate: PropTypes.func.isRequired,
+    onFetchActiveExecutions: PropTypes.func.isRequired,
+    activeExecutions: PropTypes.shape({
+        items: PropTypes.shape({
+            blueprint_id: PropTypes.string,
+            deployment_id: PropTypes.string,
+            id: PropTypes.string,
+            is_system_workflow: PropTypes.string,
+            map: PropTypes.func,
+            workflow_id: PropTypes.string
+        })
+    })
+};
+
+MaintenanceModeModal.defaultProps = {
+    activeExecutions: {}
+};
 
 const mapStateToProps = (state, ownProps) => {
     return {

--- a/app/components/shared/MessageContainer.js
+++ b/app/components/shared/MessageContainer.js
@@ -3,7 +3,7 @@
  */
 
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React from 'react';
 import { Grid, Segment } from 'semantic-ui-react';
 
 import SplashLoadingScreen from '../../utils/SplashLoadingScreen';
@@ -25,49 +25,59 @@ import SplashLoadingScreen from '../../utils/SplashLoadingScreen';
  * ```
  *
  */
-export default class MessageContainer extends Component {
-    /**
-     * propTypes
-     *
-     * @property {object[]} children - primary content
-     * @property {string} [textAlign='center'] - sets the horizontal alignment of the text
-     * @property {boolean} [loading=false] - if set to true show its content is being loaded
-     * @property {string} [size='big'] - sets the Segment's size
-     * @property {boolean} [wide=false] - if set to true the container will be wider
-     * @property {string} [margin='80px auto'] - sets the Segment's margin
-     */
-    static propTypes = {
-        children: PropTypes.any.isRequired,
-        textAlign: PropTypes.string,
-        loading: PropTypes.bool,
-        size: PropTypes.string,
-        wide: PropTypes.bool,
-        margin: PropTypes.string
-    };
+export default function MessageContainer({ children, loading, margin, size, textAlign, wide }) {
+    SplashLoadingScreen.turnOff();
 
-    static defaultProps = {
-        textAlign: 'center',
-        loading: false,
-        size: 'big',
-        wide: false,
-        margin: '80px auto'
-    };
+    const style = { margin, textAlign };
+    const widths = wide ? { mobile: 14, tablet: 14, computer: 12 } : { mobile: 12, tablet: 8, computer: 6 };
 
-    render() {
-        const { children, loading, margin, size, textAlign, wide } = this.props;
-        SplashLoadingScreen.turnOff();
-
-        const style = { margin, textAlign };
-        const widths = wide ? { mobile: 14, tablet: 14, computer: 12 } : { mobile: 12, tablet: 8, computer: 6 };
-
-        return (
-            <Grid centered container columns={1}>
-                <Grid.Column {...widths}>
-                    <Segment size={size} padded raised style={style} loading={loading}>
-                        {children}
-                    </Segment>
-                </Grid.Column>
-            </Grid>
-        );
-    }
+    return (
+        <Grid centered container columns={1}>
+            <Grid.Column {...widths}>
+                <Segment size={size} padded raised style={style} loading={loading}>
+                    {children}
+                </Segment>
+            </Grid.Column>
+        </Grid>
+    );
 }
+
+MessageContainer.propTypes = {
+    /**
+     * primary content
+     */
+    children: PropTypes.node.isRequired,
+
+    /**
+     * if set to true show its content is being loaded
+     */
+    loading: PropTypes.bool,
+
+    /**
+     * sets the Segment's margin
+     */
+    margin: PropTypes.string,
+
+    /**
+     * sets the Segment's size
+     */
+    size: PropTypes.string,
+
+    /**
+     * sets the horizontal alignment of the text
+     */
+    textAlign: PropTypes.string,
+
+    /**
+     * if set to true the container will be wider
+     */
+    wide: PropTypes.bool
+};
+
+MessageContainer.defaultProps = {
+    loading: false,
+    margin: '80px auto',
+    size: 'big',
+    textAlign: 'center',
+    wide: false
+};

--- a/app/components/shared/PageFilter.js
+++ b/app/components/shared/PageFilter.js
@@ -31,25 +31,8 @@ class PageFilter extends React.Component {
         this.state = PageFilter.initialState(props);
     }
 
-    /**
-     * propTypes
-     *
-     * @property {string} name name of the field
-     * @property {string} value value of the field
-     * @property {Array} pages array containing page objects - {id, name} - it is fetched from redux store automatically
-     * @property {Function} [onChange=()=>{}] function called on input value change
-     */
-    static propTypes = {
-        name: PropTypes.string.isRequired,
-        value: PropTypes.string.isRequired,
-        pages: PropTypes.array.isRequired,
-        onChange: PropTypes.func,
-        allowDrillDownPages: PropTypes.bool
-    };
-
     static initialState = props => ({
-        pageId: props.value,
-        allowDrillDownPages: false
+        pageId: props.value
     });
 
     handleInputChange(event, field) {
@@ -92,6 +75,46 @@ class PageFilter extends React.Component {
         );
     }
 }
+
+PageFilter.propTypes = {
+    /**
+     * name of the field
+     */
+    name: PropTypes.string.isRequired,
+
+    /**
+     * value of the field
+     */
+    // eslint-disable-next-line react/no-unused-prop-types
+    value: PropTypes.string.isRequired,
+
+    /**
+     * array containing page objects
+     */
+    pages: PropTypes.arrayOf(
+        PropTypes.shape({
+            id: PropTypes.string,
+            isDrilldown: PropTypes.bool,
+            name: PropTypes.string,
+            parent: PropTypes.string
+        })
+    ).isRequired,
+
+    /**
+     *
+     */
+    allowDrillDownPages: PropTypes.bool,
+
+    /**
+     * function called on input value change
+     */
+    onChange: PropTypes.func
+};
+
+PageFilter.defaultProps = {
+    allowDrillDownPages: false,
+    onChange: _.noop
+};
 
 const mapStateToProps = state => {
     return {

--- a/app/components/shared/graphs/Graph.js
+++ b/app/components/shared/graphs/Graph.js
@@ -172,49 +172,6 @@ export default class Graph extends Component {
      */
     static MAX_NUMBER_OF_CHARTS = 5;
 
-    /**
-     * propTypes
-     *
-     * @property {object[]} data charts input data (see class description for the format details)
-     * @property {string} type graph chart type ({@link Graph.LINE_CHART_TYPE}, {@link Graph.BAR_CHART_TYPE} or {@link Graph.AREA_CHART_TYPE})
-     * @property {object[]} charts charts configuration (see class description for format details)
-     * @property {string} [xDataKey=Graph.DEFAULT_X_DATA_KEY] X-axis key name, must match key in data object
-     * @property {boolean} [showXAxis=true] should show X-axis
-     * @property {boolean} [showYAxis=true] should show Y-axis
-     * @property {boolean} [showBrush=false] should show brush (zoom)
-     * @property {boolean} [showTooltip=true] should show tooltip on line
-     * @property {boolean} [showLegend=true] should show legend
-     * @property {string} [dataTimeFormat=undefined] input date format, by default not specified
-     * @property {string} [xAxisTimeFormat='DD-MM-YYYY HH:mm'] format of X-axis tick label
-     * @property {object} [xAxisTick={fontSize:'10px'}] stylesheet for X-axis tick
-     * @property {object} [yAxisTick={fontSize:'10px'}] stylesheet for Y-axis tick
-     * @property {object} [tooltipFormatter=undefined] callback function to format the text of the tooltip
-     * @property {boolean} [yAxisAllowDecimals=true] whether to allow decimals in Y-axis tick
-     * @property {object} [yAxisDataFormatter=undefined] format of Y-axis tick label
-     */
-    static propTypes = {
-        data: PropTypes.array.isRequired,
-        type: PropTypes.string.isRequired,
-        charts: PropTypes.array.isRequired,
-        xDataKey: PropTypes.string
-    };
-
-    static defaultProps = {
-        xDataKey: Graph.DEFAULT_X_DATA_KEY,
-        showXAxis: true,
-        showYAxis: true,
-        showBrush: false,
-        showTooltip: true,
-        showLegend: true,
-        dataTimeFormat: undefined,
-        xAxisTimeFormat: 'DD-MM-YYYY HH:mm',
-        xAxisTick: { fontSize: '10px' },
-        yAxisTick: { fontSize: '10px' },
-        tooltipFormatter: undefined,
-        yAxisAllowDecimals: true,
-        yAxisDataFormatter: undefined
-    };
-
     render() {
         const {
             charts,
@@ -382,3 +339,119 @@ export default class Graph extends Component {
         );
     }
 }
+
+Graph.propTypes = {
+    /**
+     * charts configuration (see class description for format details)
+     */
+    charts: PropTypes.arrayOf(
+        PropTypes.shape({
+            name: PropTypes.string,
+            label: PropTypes.string,
+            axisLabel: PropTypes.string
+        })
+    ).isRequired,
+
+    /**
+     * data charts input data (see class description for the format details)
+     */
+    data: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
+
+    /**
+     * graph chart type ({@link Graph.LINE_CHART_TYPE}, {@link Graph.BAR_CHART_TYPE} or {@link Graph.AREA_CHART_TYPE})
+     */
+    type: PropTypes.string.isRequired,
+
+    /**
+     * input date format, by default not specified
+     */
+    dataTimeFormat: PropTypes.string,
+
+    /**
+     * function to be called on graph click
+     */
+    onClick: PropTypes.func,
+
+    /**
+     * should show brush (zoom)
+     */
+    showBrush: PropTypes.bool,
+
+    /**
+     * should show legend
+     */
+    showLegend: PropTypes.bool,
+
+    /**
+     * should show tooltip on line
+     */
+    showTooltip: PropTypes.bool,
+
+    /**
+     * should show X-axis
+     */
+    showXAxis: PropTypes.bool,
+
+    /**
+     * should show Y-axis
+     */
+    showYAxis: PropTypes.bool,
+
+    /**
+     * syncId to sync tooltip position (see recharts documentation for details)
+     */
+    syncId: PropTypes.string,
+
+    /**
+     * callback function to format the text of the tooltip
+     */
+    tooltipFormatter: PropTypes.func,
+
+    /**
+     * stylesheet for X-axis tick
+     */
+    xAxisTick: PropTypes.shape({}),
+
+    /**
+     * format of X-axis tick label
+     */
+    xAxisTimeFormat: PropTypes.string,
+
+    /**
+     * X-axis key name, must match key in data object
+     */
+    xDataKey: PropTypes.string,
+
+    /**
+     * whether to allow decimals in Y-axis tick
+     */
+    yAxisAllowDecimals: PropTypes.bool,
+
+    /**
+     * format of Y-axis tick label
+     */
+    yAxisDataFormatter: PropTypes.func,
+
+    /**
+     * stylesheet for Y-axis tick
+     */
+    yAxisTick: PropTypes.shape({})
+};
+
+Graph.defaultProps = {
+    dataTimeFormat: undefined,
+    onClick: _.noop,
+    showBrush: false,
+    showLegend: true,
+    showTooltip: true,
+    showXAxis: true,
+    showYAxis: true,
+    syncId: '',
+    tooltipFormatter: _.noop,
+    xAxisTick: { fontSize: '10px' },
+    xAxisTimeFormat: 'DD-MM-YYYY HH:mm',
+    xDataKey: Graph.DEFAULT_X_DATA_KEY,
+    yAxisAllowDecimals: true,
+    yAxisDataFormatter: _.noop,
+    yAxisTick: { fontSize: '10px' }
+};

--- a/app/components/shared/graphs/PieGraph.js
+++ b/app/components/shared/graphs/PieGraph.js
@@ -3,8 +3,7 @@
  */
 
 import PropTypes from 'prop-types';
-
-import React, { Component } from 'react';
+import React from 'react';
 import { PieChart, Pie, Legend, Cell, ResponsiveContainer } from 'recharts';
 
 /**
@@ -40,34 +39,27 @@ import { PieChart, Pie, Legend, Cell, ResponsiveContainer } from 'recharts';
  * return (<PieGraph data={formattedData} />);
  * ```
  */
-export default class PieGraph extends Component {
-    constructor(props) {
-        super(props);
-    }
-
-    /**
-     * propTypes
-     *
-     * @property {object[]} data graph input data
-     */
-    static propTypes = {
-        data: PropTypes.array.isRequired
-    };
-
-    render() {
-        const { data } = this.props;
-
-        return (
-            <ResponsiveContainer width="100%" height="100%">
-                <PieChart>
-                    <Pie dataKey="value" data={data} labelLine label isAnimationActive={false} cx="40%">
-                        {data.map((entry, index) => (
-                            <Cell key={index} fill={entry.color} />
-                        ))}
-                    </Pie>
-                    <Legend layout="vertical" verticalAlign="middle" align="right" />
-                </PieChart>
-            </ResponsiveContainer>
-        );
-    }
+export default function PieGraph({ data }) {
+    return (
+        <ResponsiveContainer width="100%" height="100%">
+            <PieChart>
+                <Pie dataKey="value" data={data} labelLine label isAnimationActive={false} cx="40%">
+                    {data.map((entry, index) => (
+                        <Cell key={index} fill={entry.color} />
+                    ))}
+                </Pie>
+                <Legend layout="vertical" verticalAlign="middle" align="right" />
+            </PieChart>
+        </ResponsiveContainer>
+    );
 }
+
+PieGraph.propTypes = {
+    data: PropTypes.arrayOf(
+        PropTypes.shape({
+            color: PropTypes.string,
+            name: PropTypes.string,
+            value: PropTypes.number
+        })
+    ).isRequired
+};

--- a/app/components/templates/CreatePageModal.js
+++ b/app/components/templates/CreatePageModal.js
@@ -2,7 +2,6 @@
  * Created by pposel on 22/08/2017.
  */
 import PropTypes from 'prop-types';
-
 import React, { Component } from 'react';
 
 import { ApproveButton, Button, CancelButton, Form, Icon, Modal } from '../basic/index';
@@ -21,14 +20,6 @@ export default class CreatePageModal extends Component {
             pageName: props.pageName,
             errors: {}
         };
-    };
-
-    static propTypes = {
-        onCreatePage: PropTypes.func.isRequired
-    };
-
-    static defaultProps = {
-        pageName: ''
     };
 
     openModal() {
@@ -107,3 +98,13 @@ export default class CreatePageModal extends Component {
         );
     }
 }
+
+CreatePageModal.propTypes = {
+    onCreatePage: PropTypes.func.isRequired,
+    // eslint-disable-next-line react/no-unused-prop-types
+    pageName: PropTypes.string
+};
+
+CreatePageModal.defaultProps = {
+    pageName: ''
+};

--- a/app/components/templates/CreateTemplateModal.js
+++ b/app/components/templates/CreateTemplateModal.js
@@ -42,26 +42,6 @@ export default class CreateTemplateModal extends Component {
         };
     };
 
-    static propTypes = {
-        availableTenants: PropTypes.object,
-        availablePages: PropTypes.array,
-        availableRoles: PropTypes.array,
-        templateName: PropTypes.string,
-        pages: PropTypes.array,
-        roles: PropTypes.array,
-        tenants: PropTypes.array,
-        onCreateTemplate: PropTypes.func.isRequired
-    };
-
-    static defaultProps = {
-        templateName: '',
-        pages: [],
-        roles: [],
-        tenants: [Consts.DEFAULT_ALL],
-        availablePages: [],
-        availableRoles: []
-    };
-
     componentDidUpdate() {
         if (!$('#reorderList').hasClass('ui-sortable')) {
             $('#reorderList').sortable({
@@ -305,3 +285,27 @@ export default class CreateTemplateModal extends Component {
         );
     }
 }
+
+CreateTemplateModal.propTypes = {
+    availableTenants: PropTypes.shape({}).isRequired,
+    // eslint-disable-next-line react/no-unused-prop-types
+    availablePages: PropTypes.arrayOf(PropTypes.shape({})),
+    availableRoles: PropTypes.arrayOf(PropTypes.shape({})),
+    templateName: PropTypes.string,
+    // eslint-disable-next-line react/no-unused-prop-types
+    pages: PropTypes.arrayOf(PropTypes.string),
+    // eslint-disable-next-line react/no-unused-prop-types
+    roles: PropTypes.arrayOf(PropTypes.string),
+    // eslint-disable-next-line react/no-unused-prop-types
+    tenants: PropTypes.arrayOf(PropTypes.string),
+    onCreateTemplate: PropTypes.func.isRequired
+};
+
+CreateTemplateModal.defaultProps = {
+    templateName: '',
+    pages: [],
+    roles: [],
+    tenants: [Consts.DEFAULT_ALL],
+    availablePages: [],
+    availableRoles: []
+};

--- a/app/components/templates/PageList.js
+++ b/app/components/templates/PageList.js
@@ -2,52 +2,56 @@
  * Created by pposel on 11/08/2017.
  */
 
+import _ from 'lodash';
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React from 'react';
 
 import { Segment, Icon, Divider, List, Message, PopupConfirm } from '../basic';
 
-export default class PageList extends Component {
-    static propTypes = {
-        pages: PropTypes.any.isRequired,
-        onDelete: PropTypes.func,
-        custom: PropTypes.bool,
-        style: PropTypes.any
-    };
+export default function PageList({ custom, onDelete, pages, style }) {
+    return (
+        <Segment style={style}>
+            <Icon name="block layout" /> Pages
+            <Divider />
+            <List divided relaxed verticalAlign="middle" className="light">
+                {pages.map(item => {
+                    return (
+                        <List.Item key={item}>
+                            {item}
 
-    render() {
-        const { custom, onDelete, pages, style } = this.props;
-        return (
-            <Segment style={style}>
-                <Icon name="block layout" /> Pages
-                <Divider />
-                <List divided relaxed verticalAlign="middle" className="light">
-                    {pages.map(item => {
-                        return (
-                            <List.Item key={item}>
-                                {item}
+                            {custom && _.size(pages) > 1 && (
+                                <PopupConfirm
+                                    trigger={
+                                        <Icon
+                                            link
+                                            name="remove"
+                                            className="right floated"
+                                            onClick={e => e.stopPropagation()}
+                                        />
+                                    }
+                                    content="Are you sure to remove this page from template?"
+                                    onConfirm={() => onDelete(item)}
+                                />
+                            )}
+                        </List.Item>
+                    );
+                })}
 
-                                {custom && _.size(pages) > 1 && (
-                                    <PopupConfirm
-                                        trigger={
-                                            <Icon
-                                                link
-                                                name="remove"
-                                                className="right floated"
-                                                onClick={e => e.stopPropagation()}
-                                            />
-                                        }
-                                        content="Are you sure to remove this page from template?"
-                                        onConfirm={() => onDelete(item)}
-                                    />
-                                )}
-                            </List.Item>
-                        );
-                    })}
-
-                    {_.isEmpty(pages) && <Message content="No pages available" />}
-                </List>
-            </Segment>
-        );
-    }
+                {_.isEmpty(pages) && <Message content="No pages available" />}
+            </List>
+        </Segment>
+    );
 }
+
+PageList.propTypes = {
+    pages: PropTypes.arrayOf(PropTypes.string).isRequired,
+    onDelete: PropTypes.func,
+    custom: PropTypes.bool,
+    style: PropTypes.shape({})
+};
+
+PageList.defaultProps = {
+    onDelete: _.noop,
+    custom: false,
+    style: {}
+};

--- a/app/components/templates/Pages.js
+++ b/app/components/templates/Pages.js
@@ -2,125 +2,133 @@
  * Created by pposel on 11/08/2017.
  */
 
+import _ from 'lodash';
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React from 'react';
 
 import CreatePageModal from './CreatePageModal';
 import TemplateList from './TemplateList';
 import { Segment, Header, DataTable, Icon, PopupConfirm, Label } from '../basic';
 import StageUtils from '../../utils/stageUtils';
 
-export default class Pages extends Component {
-    static propTypes = {
-        pages: PropTypes.array,
-        onSelectPage: PropTypes.func,
-        onCreatePage: PropTypes.func,
-        onDeletePage: PropTypes.func,
-        onCanDeletePage: PropTypes.func,
-        onEditPage: PropTypes.func,
-        onPreviewPage: PropTypes.func
-    };
+export default function Pages({
+    onCanDeletePage,
+    onCreatePage,
+    onDeletePage,
+    onEditPage,
+    onPreviewPage,
+    onSelectPage,
+    pages
+}) {
+    return (
+        <Segment color="red">
+            <Header dividing as="h5">
+                Pages
+            </Header>
 
-    static defaultProps = {
-        pages: []
-    };
+            <DataTable>
+                <DataTable.Column label="Page id" width="25%" />
+                <DataTable.Column label="Page name" width="25%" />
+                <DataTable.Column label="Templates" width="10%" />
+                <DataTable.Column label="Updated at" width="15%" />
+                <DataTable.Column label="Updated by" width="15%" />
+                <DataTable.Column width="10%" />
 
-    render() {
-        const {
-            onCanDeletePage,
-            onCreatePage,
-            onDeletePage,
-            onEditPage,
-            onPreviewPage,
-            onSelectPage,
-            pages
-        } = this.props;
-        return (
-            <Segment color="red">
-                <Header dividing as="h5">
-                    Pages
-                </Header>
+                {pages.map(item => {
+                    return (
+                        <DataTable.RowExpandable key={item.id} expanded={item.selected}>
+                            <DataTable.Row key={item.id} selected={item.selected} onClick={() => onSelectPage(item)}>
+                                <DataTable.Data>
+                                    <Header as="a" size="small">
+                                        {item.id}
+                                    </Header>
+                                </DataTable.Data>
+                                <DataTable.Data>{item.name}</DataTable.Data>
+                                <DataTable.Data>
+                                    <Label color="blue" horizontal>
+                                        {_.size(item.templates)}
+                                    </Label>
+                                </DataTable.Data>
+                                <DataTable.Data>
+                                    {item.updatedAt && StageUtils.Time.formatLocalTimestamp(item.updatedAt)}
+                                </DataTable.Data>
+                                <DataTable.Data>{item.updatedBy}</DataTable.Data>
+                                <DataTable.Data className="center aligned rowActions">
+                                    {item.custom ? (
+                                        <div>
+                                            <PopupConfirm
+                                                trigger={<Icon name="remove" link onClick={e => e.stopPropagation()} />}
+                                                content="Are you sure to remove this page?"
+                                                onConfirm={() => onDeletePage(item)}
+                                                onCanConfirm={() => onCanDeletePage(item)}
+                                            />
+                                            <Icon
+                                                name="edit"
+                                                link
+                                                className="updatePageIcon"
+                                                onClick={e => {
+                                                    e.stopPropagation();
+                                                    onEditPage(item);
+                                                }}
+                                            />
+                                        </div>
+                                    ) : (
+                                        <div>
+                                            <Icon
+                                                name="search"
+                                                link
+                                                className="updatePageIcon"
+                                                onClick={e => {
+                                                    e.stopPropagation();
+                                                    onPreviewPage(item);
+                                                }}
+                                            />
+                                        </div>
+                                    )}
+                                </DataTable.Data>
+                            </DataTable.Row>
 
-                <DataTable>
-                    <DataTable.Column label="Page id" width="25%" />
-                    <DataTable.Column label="Page name" width="25%" />
-                    <DataTable.Column label="Templates" width="10%" />
-                    <DataTable.Column label="Updated at" width="15%" />
-                    <DataTable.Column label="Updated by" width="15%" />
-                    <DataTable.Column width="10%" />
+                            <DataTable.DataExpandable key={item.id}>
+                                <TemplateList templates={item.templates} />
+                            </DataTable.DataExpandable>
+                        </DataTable.RowExpandable>
+                    );
+                })}
 
-                    {pages.map(item => {
-                        return (
-                            <DataTable.RowExpandable key={item.id} expanded={item.selected}>
-                                <DataTable.Row
-                                    key={item.id}
-                                    selected={item.selected}
-                                    onClick={() => onSelectPage(item)}
-                                >
-                                    <DataTable.Data>
-                                        <Header as="a" size="small">
-                                            {item.id}
-                                        </Header>
-                                    </DataTable.Data>
-                                    <DataTable.Data>{item.name}</DataTable.Data>
-                                    <DataTable.Data>
-                                        <Label color="blue" horizontal>
-                                            {_.size(item.templates)}
-                                        </Label>
-                                    </DataTable.Data>
-                                    <DataTable.Data>
-                                        {item.updatedAt && StageUtils.Time.formatLocalTimestamp(item.updatedAt)}
-                                    </DataTable.Data>
-                                    <DataTable.Data>{item.updatedBy}</DataTable.Data>
-                                    <DataTable.Data className="center aligned rowActions">
-                                        {item.custom ? (
-                                            <div>
-                                                <PopupConfirm
-                                                    trigger={
-                                                        <Icon name="remove" link onClick={e => e.stopPropagation()} />
-                                                    }
-                                                    content="Are you sure to remove this page?"
-                                                    onConfirm={() => onDeletePage(item)}
-                                                    onCanConfirm={() => onCanDeletePage(item)}
-                                                />
-                                                <Icon
-                                                    name="edit"
-                                                    link
-                                                    className="updatePageIcon"
-                                                    onClick={e => {
-                                                        e.stopPropagation();
-                                                        onEditPage(item);
-                                                    }}
-                                                />
-                                            </div>
-                                        ) : (
-                                            <div>
-                                                <Icon
-                                                    name="search"
-                                                    link
-                                                    className="updatePageIcon"
-                                                    onClick={e => {
-                                                        e.stopPropagation();
-                                                        onPreviewPage(item);
-                                                    }}
-                                                />
-                                            </div>
-                                        )}
-                                    </DataTable.Data>
-                                </DataTable.Row>
-
-                                <DataTable.DataExpandable key={item.id}>
-                                    <TemplateList templates={item.templates} />
-                                </DataTable.DataExpandable>
-                            </DataTable.RowExpandable>
-                        );
-                    })}
-
-                    <DataTable.Action>
-                        <CreatePageModal onCreatePage={onCreatePage} />
-                    </DataTable.Action>
-                </DataTable>
-            </Segment>
-        );
-    }
+                <DataTable.Action>
+                    <CreatePageModal onCreatePage={onCreatePage} />
+                </DataTable.Action>
+            </DataTable>
+        </Segment>
+    );
 }
+
+Pages.propTypes = {
+    onCanDeletePage: PropTypes.func,
+    onCreatePage: PropTypes.func,
+    onDeletePage: PropTypes.func,
+    onEditPage: PropTypes.func,
+    onPreviewPage: PropTypes.func,
+    onSelectPage: PropTypes.func,
+    pages: PropTypes.arrayOf(
+        PropTypes.shape({
+            id: PropTypes.string,
+            name: PropTypes.string,
+            selected: PropTypes.string,
+            templates: PropTypes.arrayOf(PropTypes.string),
+            updatedAt: PropTypes.string,
+            updatedBy: PropTypes.string,
+            custom: PropTypes.bool
+        })
+    )
+};
+
+Pages.defaultProps = {
+    onCanDeletePage: _.noop,
+    onCreatePage: _.noop,
+    onDeletePage: _.noop,
+    onEditPage: _.noop,
+    onPreviewPage: _.noop,
+    onSelectPage: _.noop,
+    pages: []
+};

--- a/app/components/templates/Pages.js
+++ b/app/components/templates/Pages.js
@@ -112,13 +112,13 @@ Pages.propTypes = {
     onSelectPage: PropTypes.func,
     pages: PropTypes.arrayOf(
         PropTypes.shape({
+            custom: PropTypes.bool,
             id: PropTypes.string,
             name: PropTypes.string,
-            selected: PropTypes.string,
+            selected: PropTypes.bool,
             templates: PropTypes.arrayOf(PropTypes.string),
             updatedAt: PropTypes.string,
-            updatedBy: PropTypes.string,
-            custom: PropTypes.bool
+            updatedBy: PropTypes.string
         })
     )
 };

--- a/app/components/templates/RoleList.js
+++ b/app/components/templates/RoleList.js
@@ -2,55 +2,56 @@
  * Created by pposel on 11/08/2017.
  */
 
+import _ from 'lodash';
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React from 'react';
 
 import { Segment, Icon, Divider, List, Message, PopupConfirm } from '../basic';
 
-export default class RoleList extends Component {
-    static propTypes = {
-        roles: PropTypes.any.isRequired,
-        onDelete: PropTypes.func,
-        custom: PropTypes.bool,
-        style: PropTypes.any
-    };
+export default function RoleList({ custom, onDelete, roles, style }) {
+    return (
+        <Segment style={style}>
+            <Icon name="student" /> Roles
+            <Divider />
+            <List divided relaxed verticalAlign="middle" className="light">
+                {roles.map(item => {
+                    return (
+                        <List.Item key={item}>
+                            {item}
 
-    static defaultProps = {
-        roles: []
-    };
-
-    render() {
-        const { custom, onDelete, roles, style } = this.props;
-        return (
-            <Segment style={style}>
-                <Icon name="student" /> Roles
-                <Divider />
-                <List divided relaxed verticalAlign="middle" className="light">
-                    {roles.map(item => {
-                        return (
-                            <List.Item key={item}>
-                                {item}
-
-                                {custom && _.size(roles) > 1 && (
-                                    <PopupConfirm
-                                        trigger={
-                                            <Icon
-                                                link
-                                                name="remove"
-                                                className="right floated"
-                                                onClick={e => e.stopPropagation()}
-                                            />
-                                        }
-                                        content="Are you sure to remove this role from template?"
-                                        onConfirm={() => onDelete(item)}
-                                    />
-                                )}
-                            </List.Item>
-                        );
-                    })}
-                    {_.isEmpty(roles) && <Message content="No roles available" />}
-                </List>
-            </Segment>
-        );
-    }
+                            {custom && _.size(roles) > 1 && (
+                                <PopupConfirm
+                                    trigger={
+                                        <Icon
+                                            link
+                                            name="remove"
+                                            className="right floated"
+                                            onClick={e => e.stopPropagation()}
+                                        />
+                                    }
+                                    content="Are you sure to remove this role from template?"
+                                    onConfirm={() => onDelete(item)}
+                                />
+                            )}
+                        </List.Item>
+                    );
+                })}
+                {_.isEmpty(roles) && <Message content="No roles available" />}
+            </List>
+        </Segment>
+    );
 }
+
+RoleList.propTypes = {
+    custom: PropTypes.bool,
+    onDelete: PropTypes.func,
+    roles: PropTypes.arrayOf(PropTypes.string),
+    style: PropTypes.shape({})
+};
+
+RoleList.defaultProps = {
+    custom: false,
+    onDelete: _.noop,
+    roles: [],
+    style: {}
+};

--- a/app/components/templates/TemplateList.js
+++ b/app/components/templates/TemplateList.js
@@ -3,33 +3,31 @@
  */
 
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React from 'react';
 
 import { Segment, Icon, Divider, List, Message } from '../basic';
 
-export default class TemplateList extends Component {
-    static propTypes = {
-        templates: PropTypes.any.isRequired,
-        style: PropTypes.any
-    };
-
-    static defaultProps = {
-        tenants: []
-    };
-
-    render() {
-        const { style, templates } = this.props;
-        return (
-            <Segment style={style}>
-                <Icon name="list layout" /> Templates
-                <Divider />
-                <List divided relaxed verticalAlign="middle" className="light">
-                    {templates.map(item => {
-                        return <List.Item key={item}>{item}</List.Item>;
-                    })}
-                    {_.isEmpty(templates) && <Message content="Page not used by any template" />}
-                </List>
-            </Segment>
-        );
-    }
+export default function TemplateList({ style, templates }) {
+    return (
+        <Segment style={style}>
+            <Icon name="list layout" /> Templates
+            <Divider />
+            <List divided relaxed verticalAlign="middle" className="light">
+                {templates.map(item => {
+                    return <List.Item key={item}>{item}</List.Item>;
+                })}
+                {_.isEmpty(templates) && <Message content="Page not used by any template" />}
+            </List>
+        </Segment>
+    );
 }
+
+TemplateList.propTypes = {
+    templates: PropTypes.arrayOf(PropTypes.shape({})),
+    style: PropTypes.shape({})
+};
+
+TemplateList.defaultProps = {
+    templates: [],
+    style: {}
+};

--- a/app/components/templates/TemplateList.js
+++ b/app/components/templates/TemplateList.js
@@ -23,7 +23,7 @@ export default function TemplateList({ style, templates }) {
 }
 
 TemplateList.propTypes = {
-    templates: PropTypes.arrayOf(PropTypes.shape({})),
+    templates: PropTypes.arrayOf(PropTypes.string),
     style: PropTypes.shape({})
 };
 

--- a/app/components/templates/Templates.js
+++ b/app/components/templates/Templates.js
@@ -150,7 +150,10 @@ Templates.propTypes = {
     templates: PropTypes.arrayOf(
         PropTypes.shape({
             custom: PropTypes.bool,
-            data: PropTypes.arrayOf(PropTypes.shape({ roles: [], tenants: [] })),
+            data: PropTypes.shape({
+                roles: PropTypes.arrayOf(PropTypes.string),
+                tenants: PropTypes.arrayOf(PropTypes.string)
+            }),
             id: PropTypes.string,
             pages: PropTypes.arrayOf(PropTypes.string),
             updatedAt: PropTypes.string,

--- a/app/components/templates/Templates.js
+++ b/app/components/templates/Templates.js
@@ -2,8 +2,9 @@
  * Created by pposel on 11/08/2017.
  */
 
+import _ from 'lodash';
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React from 'react';
 
 import PageList from './PageList';
 import RoleList from './RoleList';
@@ -13,152 +14,162 @@ import Const from '../../utils/consts';
 import { Segment, Icon, Header, DataTable, PopupConfirm, Label } from '../basic';
 import StageUtils from '../../utils/stageUtils';
 
-export default class Templates extends Component {
-    static propTypes = {
-        templates: PropTypes.array,
-        pages: PropTypes.array,
-        roles: PropTypes.array,
-        tenants: PropTypes.object,
-        onSelectTemplate: PropTypes.func,
-        onRemoveTemplatePage: PropTypes.func,
-        onRemoveTemplateRole: PropTypes.func,
-        onRemoveTemplateTenant: PropTypes.func,
-        onCreateTemplate: PropTypes.func,
-        onModifyTemplate: PropTypes.func,
-        onDeleteTemplate: PropTypes.func
-    };
+export default function Templates({
+    onCreateTemplate,
+    onDeleteTemplate,
+    onModifyTemplate,
+    onRemoveTemplatePage,
+    onRemoveTemplateRole,
+    onRemoveTemplateTenant,
+    onSelectTemplate,
+    pages,
+    roles,
+    templates,
+    tenants
+}) {
+    return (
+        <Segment color="blue">
+            <Header dividing as="h5">
+                Templates
+            </Header>
 
-    static defaultProps = {
-        templates: [],
-        pages: [],
-        tenants: { items: [] }
-    };
+            <DataTable>
+                <DataTable.Column label="Template id" width="25%" />
+                <DataTable.Column label="Roles" width="25%" />
+                <DataTable.Column label="Tenants" width="10%" />
+                <DataTable.Column label="Updated at" width="15%" />
+                <DataTable.Column label="Updated by" width="15%" />
+                <DataTable.Column width="10%" />
 
-    render() {
-        const {
-            onCreateTemplate,
-            onDeleteTemplate,
-            onModifyTemplate,
-            onRemoveTemplatePage,
-            onRemoveTemplateRole,
-            onRemoveTemplateTenant,
-            onSelectTemplate,
-            pages,
-            roles,
-            templates,
-            tenants
-        } = this.props;
-        return (
-            <Segment color="blue">
-                <Header dividing as="h5">
-                    Templates
-                </Header>
+                {templates.map(item => {
+                    const data = item.data || { roles: [], tenants: [] };
+                    const tenantsCount =
+                        _.indexOf(data.tenants, Const.DEFAULT_ALL) >= 0 ? _.size(tenants.items) : _.size(data.tenants);
 
-                <DataTable>
-                    <DataTable.Column label="Template id" width="25%" />
-                    <DataTable.Column label="Roles" width="25%" />
-                    <DataTable.Column label="Tenants" width="10%" />
-                    <DataTable.Column label="Updated at" width="15%" />
-                    <DataTable.Column label="Updated by" width="15%" />
-                    <DataTable.Column width="10%" />
+                    return (
+                        <DataTable.RowExpandable key={item.id} expanded={item.selected}>
+                            <DataTable.Row
+                                key={item.id}
+                                selected={item.selected}
+                                onClick={() => onSelectTemplate(item)}
+                            >
+                                <DataTable.Data>
+                                    <Header as="a" size="small">
+                                        {item.id}
+                                    </Header>
+                                </DataTable.Data>
+                                <DataTable.Data>
+                                    {data.roles.map((role, index) => (
+                                        <span key={role}>
+                                            {role === Const.DEFAULT_ALL ? 'all' : role}
+                                            {index < data.roles.length - 1 && <span>, </span>}
+                                        </span>
+                                    ))}
+                                </DataTable.Data>
+                                <DataTable.Data>
+                                    <Label color="green" horizontal>
+                                        {tenantsCount}
+                                    </Label>
+                                </DataTable.Data>
+                                <DataTable.Data>
+                                    {item.updatedAt && StageUtils.Time.formatLocalTimestamp(item.updatedAt)}
+                                </DataTable.Data>
+                                <DataTable.Data>{item.updatedBy}</DataTable.Data>
+                                <DataTable.Data className="center aligned rowActions">
+                                    {item.custom && (
+                                        <div>
+                                            <PopupConfirm
+                                                trigger={<Icon name="remove" link onClick={e => e.stopPropagation()} />}
+                                                content="Are you sure to remove this template?"
+                                                onConfirm={() => onDeleteTemplate(item)}
+                                            />
+                                            <CreateTemplateModal
+                                                availableTenants={tenants}
+                                                availablePages={pages}
+                                                availableRoles={roles}
+                                                templateName={item.id}
+                                                pages={item.pages}
+                                                roles={data.roles}
+                                                tenants={data.tenants}
+                                                onCreateTemplate={(...args) => onModifyTemplate(item, ...args)}
+                                            />
+                                        </div>
+                                    )}
+                                </DataTable.Data>
+                            </DataTable.Row>
 
-                    {templates.map(item => {
-                        const data = item.data || { roles: [], tenants: [] };
-                        const tenantsCount =
-                            _.indexOf(data.tenants, Const.DEFAULT_ALL) >= 0
-                                ? _.size(tenants.items)
-                                : _.size(data.tenants);
+                            <DataTable.DataExpandable key={item.id}>
+                                <Segment.Group horizontal>
+                                    <PageList
+                                        pages={item.pages}
+                                        custom={item.custom}
+                                        onDelete={page => onRemoveTemplatePage(item, page)}
+                                        style={{ width: '33%' }}
+                                    />
+                                    <RoleList
+                                        roles={data.roles}
+                                        custom={item.custom}
+                                        onDelete={role => onRemoveTemplateRole(item, role)}
+                                        style={{ width: '33%' }}
+                                    />
+                                    <TenantList
+                                        tenants={data.tenants}
+                                        custom={item.custom}
+                                        onDelete={tenant => onRemoveTemplateTenant(item, tenant)}
+                                        style={{ width: '33%' }}
+                                    />
+                                </Segment.Group>
+                            </DataTable.DataExpandable>
+                        </DataTable.RowExpandable>
+                    );
+                })}
 
-                        return (
-                            <DataTable.RowExpandable key={item.id} expanded={item.selected}>
-                                <DataTable.Row
-                                    key={item.id}
-                                    selected={item.selected}
-                                    onClick={() => onSelectTemplate(item)}
-                                >
-                                    <DataTable.Data>
-                                        <Header as="a" size="small">
-                                            {item.id}
-                                        </Header>
-                                    </DataTable.Data>
-                                    <DataTable.Data>
-                                        {data.roles.map((role, index) => (
-                                            <span key={role}>
-                                                {role === Const.DEFAULT_ALL ? 'all' : role}
-                                                {index < data.roles.length - 1 && <span>, </span>}
-                                            </span>
-                                        ))}
-                                    </DataTable.Data>
-                                    <DataTable.Data>
-                                        <Label color="green" horizontal>
-                                            {tenantsCount}
-                                        </Label>
-                                    </DataTable.Data>
-                                    <DataTable.Data>
-                                        {item.updatedAt && StageUtils.Time.formatLocalTimestamp(item.updatedAt)}
-                                    </DataTable.Data>
-                                    <DataTable.Data>{item.updatedBy}</DataTable.Data>
-                                    <DataTable.Data className="center aligned rowActions">
-                                        {item.custom && (
-                                            <div>
-                                                <PopupConfirm
-                                                    trigger={
-                                                        <Icon name="remove" link onClick={e => e.stopPropagation()} />
-                                                    }
-                                                    content="Are you sure to remove this template?"
-                                                    onConfirm={() => onDeleteTemplate(item)}
-                                                />
-                                                <CreateTemplateModal
-                                                    availableTenants={tenants}
-                                                    availablePages={pages}
-                                                    availableRoles={roles}
-                                                    templateName={item.id}
-                                                    pages={item.pages}
-                                                    roles={data.roles}
-                                                    tenants={data.tenants}
-                                                    onCreateTemplate={(...args) => onModifyTemplate(item, ...args)}
-                                                />
-                                            </div>
-                                        )}
-                                    </DataTable.Data>
-                                </DataTable.Row>
-
-                                <DataTable.DataExpandable key={item.id}>
-                                    <Segment.Group horizontal>
-                                        <PageList
-                                            pages={item.pages}
-                                            custom={item.custom}
-                                            onDelete={page => onRemoveTemplatePage(item, page)}
-                                            style={{ width: '33%' }}
-                                        />
-                                        <RoleList
-                                            roles={data.roles}
-                                            custom={item.custom}
-                                            onDelete={role => onRemoveTemplateRole(item, role)}
-                                            style={{ width: '33%' }}
-                                        />
-                                        <TenantList
-                                            tenants={data.tenants}
-                                            custom={item.custom}
-                                            onDelete={tenant => onRemoveTemplateTenant(item, tenant)}
-                                            style={{ width: '33%' }}
-                                        />
-                                    </Segment.Group>
-                                </DataTable.DataExpandable>
-                            </DataTable.RowExpandable>
-                        );
-                    })}
-
-                    <DataTable.Action>
-                        <CreateTemplateModal
-                            availableTenants={tenants}
-                            availablePages={pages}
-                            availableRoles={roles}
-                            onCreateTemplate={onCreateTemplate}
-                        />
-                    </DataTable.Action>
-                </DataTable>
-            </Segment>
-        );
-    }
+                <DataTable.Action>
+                    <CreateTemplateModal
+                        availableTenants={tenants}
+                        availablePages={pages}
+                        availableRoles={roles}
+                        onCreateTemplate={onCreateTemplate}
+                    />
+                </DataTable.Action>
+            </DataTable>
+        </Segment>
+    );
 }
+
+Templates.propTypes = {
+    onCreateTemplate: PropTypes.func,
+    onDeleteTemplate: PropTypes.func,
+    onModifyTemplate: PropTypes.func,
+    onRemoveTemplatePage: PropTypes.func,
+    onRemoveTemplateRole: PropTypes.func,
+    onRemoveTemplateTenant: PropTypes.func,
+    onSelectTemplate: PropTypes.func,
+    pages: PropTypes.arrayOf(PropTypes.shape({})),
+    roles: PropTypes.arrayOf(PropTypes.shape({})),
+    templates: PropTypes.arrayOf(
+        PropTypes.shape({
+            custom: PropTypes.bool,
+            data: PropTypes.arrayOf(PropTypes.shape({ roles: [], tenants: [] })),
+            id: PropTypes.string,
+            pages: PropTypes.arrayOf(PropTypes.string),
+            updatedAt: PropTypes.string,
+            updatedBy: PropTypes.string
+        })
+    ),
+    tenants: PropTypes.shape({ items: PropTypes.arrayOf(PropTypes.shape({})) })
+};
+
+Templates.defaultProps = {
+    onCreateTemplate: _.noop,
+    onDeleteTemplate: _.noop,
+    onModifyTemplate: _.noop,
+    onRemoveTemplatePage: _.noop,
+    onRemoveTemplateRole: _.noop,
+    onRemoveTemplateTenant: _.noop,
+    onSelectTemplate: _.noop,
+    templates: [],
+    pages: [],
+    roles: [],
+    tenants: { items: [] }
+};

--- a/app/components/templates/TenantList.js
+++ b/app/components/templates/TenantList.js
@@ -2,56 +2,57 @@
  * Created by pposel on 11/08/2017.
  */
 
+import _ from 'lodash';
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React from 'react';
 
 import Const from '../../utils/consts';
 import { Segment, Icon, Divider, List, Message, PopupConfirm } from '../basic';
 
-export default class TenantList extends Component {
-    static propTypes = {
-        tenants: PropTypes.any.isRequired,
-        onDelete: PropTypes.func,
-        custom: PropTypes.bool,
-        style: PropTypes.any
-    };
+export default function TenantList({ custom, onDelete, style, tenants }) {
+    return (
+        <Segment style={style}>
+            <Icon name="male" /> Tenants
+            <Divider />
+            <List divided relaxed verticalAlign="middle" className="light">
+                {tenants.map(item => {
+                    return (
+                        <List.Item key={item}>
+                            {item === Const.DEFAULT_ALL ? 'all' : item}
 
-    static defaultProps = {
-        tenants: []
-    };
-
-    render() {
-        const { custom, onDelete, style, tenants } = this.props;
-        return (
-            <Segment style={style}>
-                <Icon name="male" /> Tenants
-                <Divider />
-                <List divided relaxed verticalAlign="middle" className="light">
-                    {tenants.map(item => {
-                        return (
-                            <List.Item key={item}>
-                                {item === Const.DEFAULT_ALL ? 'all' : item}
-
-                                {custom && _.size(tenants) > 1 && (
-                                    <PopupConfirm
-                                        trigger={
-                                            <Icon
-                                                link
-                                                name="remove"
-                                                className="right floated"
-                                                onClick={e => e.stopPropagation()}
-                                            />
-                                        }
-                                        content="Are you sure to remove this tenant from template?"
-                                        onConfirm={() => onDelete(item)}
-                                    />
-                                )}
-                            </List.Item>
-                        );
-                    })}
-                    {_.isEmpty(tenants) && <Message content="No tenants available" />}
-                </List>
-            </Segment>
-        );
-    }
+                            {custom && _.size(tenants) > 1 && (
+                                <PopupConfirm
+                                    trigger={
+                                        <Icon
+                                            link
+                                            name="remove"
+                                            className="right floated"
+                                            onClick={e => e.stopPropagation()}
+                                        />
+                                    }
+                                    content="Are you sure to remove this tenant from template?"
+                                    onConfirm={() => onDelete(item)}
+                                />
+                            )}
+                        </List.Item>
+                    );
+                })}
+                {_.isEmpty(tenants) && <Message content="No tenants available" />}
+            </List>
+        </Segment>
+    );
 }
+
+TenantList.propTypes = {
+    custom: PropTypes.bool,
+    onDelete: PropTypes.func,
+    style: PropTypes.shape({}),
+    tenants: PropTypes.arrayOf(PropTypes.string)
+};
+
+TenantList.defaultProps = {
+    custom: false,
+    onDelete: _.noop,
+    style: {},
+    tenants: []
+};

--- a/app/containers/AboutModal.js
+++ b/app/containers/AboutModal.js
@@ -24,7 +24,7 @@ const mapStateToProps = (state, ownProps) => {
 
 const mapDispatchToProps = (dispatch, ownProps) => {
     return {
-        onLicenseManagment: () => dispatch(push(Consts.LICENSE_PAGE_PATH))
+        onLicenseManagement: () => dispatch(push(Consts.LICENSE_PAGE_PATH))
     };
 };
 

--- a/app/containers/AddPageButton.js
+++ b/app/containers/AddPageButton.js
@@ -2,15 +2,16 @@
  * Created by kinneretzin on 29/08/2016.
  */
 
+import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
+
 import { addPage } from '../actions/page';
-import { Button } from '../components/basic/index';
 import EditModeButton from '../components/EditModeButton';
 
 let nameIndex = 0;
 
-const mapDispatchToProps = (dispatch, ownProps) => {
+const mapDispatchToProps = dispatch => {
     return {
         onClick: () => {
             dispatch(addPage(`Page_${nameIndex++}`));
@@ -29,6 +30,10 @@ const AddPageButton = ({ onClick }) => {
             className="addPageBtn"
         />
     );
+};
+
+AddPageButton.propTypes = {
+    onClick: PropTypes.func.isRequired
 };
 
 const AddPage = connect(

--- a/app/containers/EditWidget.js
+++ b/app/containers/EditWidget.js
@@ -28,14 +28,10 @@ class EditWidgetComponent extends React.Component {
         this.state = {
             showConfig: false
         };
-    }
 
-    static propTypes = {
-        widget: PropTypes.object,
-        onWidgetEdited: PropTypes.func,
-        configDef: PropTypes.array,
-        configuration: PropTypes.object
-    };
+        this.hideConfig = this.hideConfig.bind(this);
+        this.showConfig = this.showConfig.bind(this);
+    }
 
     showConfig() {
         this.setState({ showConfig: true });
@@ -51,19 +47,26 @@ class EditWidgetComponent extends React.Component {
 
         return (
             <span>
-                <EditWidgetIcon widgetId={widget.id} onShowConfig={this.showConfig.bind(this)} />
+                <EditWidgetIcon onShowConfig={this.showConfig} />
                 <EditWidgetModal
                     widget={widget}
                     configDef={configDef}
                     configuration={configuration}
                     onWidgetEdited={onWidgetEdited}
                     show={showConfig}
-                    onHideConfig={this.hideConfig.bind(this)}
+                    onHideConfig={this.hideConfig}
                 />
             </span>
         );
     }
 }
+
+EditWidgetComponent.propTypes = {
+    widget: PropTypes.shape({}).isRequired,
+    onWidgetEdited: PropTypes.func.isRequired,
+    configDef: PropTypes.shape([]).isRequired,
+    configuration: PropTypes.shape({}).isRequired
+};
 
 const EditWidget = connect(
     mapStateToProps,

--- a/app/containers/EditWidget.js
+++ b/app/containers/EditWidget.js
@@ -64,7 +64,7 @@ class EditWidgetComponent extends React.Component {
 EditWidgetComponent.propTypes = {
     widget: PropTypes.shape({}).isRequired,
     onWidgetEdited: PropTypes.func.isRequired,
-    configDef: PropTypes.shape([]).isRequired,
+    configDef: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
     configuration: PropTypes.shape({}).isRequired
 };
 

--- a/app/containers/Pages.js
+++ b/app/containers/Pages.js
@@ -67,9 +67,6 @@ const mapDispatchToProps = (dispatch, ownProps) => {
         },
         onPageReorder: (pageIndex, newPageIndex) => {
             dispatch(reorderPage(pageIndex, newPageIndex));
-        },
-        onSidebarClose: () => {
-            dispatch(toogleSidebar());
         }
     };
 };

--- a/app/containers/layout/Layout.js
+++ b/app/containers/layout/Layout.js
@@ -23,7 +23,7 @@ const mapStateToProps = (state, ownProps) => {
 
 const mapDispatchToProps = (dispatch, ownProps) => {
     return {
-        intialPageLoad: () => {
+        initialPageLoad: () => {
             return dispatch(intialPageLoad());
         },
         doLogout: (err, path) => {

--- a/widgets/common/src/DeploymentDetails.js
+++ b/widgets/common/src/DeploymentDetails.js
@@ -11,18 +11,17 @@ function DeploymentParameter({ name, value, as, headerStyle, subHeaderStyle }) {
 
 DeploymentParameter.propTypes = {
     name: PropTypes.node.isRequired,
-    value: PropTypes.node.isRequired,
     as: PropTypes.string,
-    // eslint-disable-next-line react/forbid-prop-types
-    headerStyle: PropTypes.object,
-    // eslint-disable-next-line react/forbid-prop-types
-    subHeaderStyle: PropTypes.object
+    headerStyle: PropTypes.shape({}),
+    subHeaderStyle: PropTypes.shape({}),
+    value: PropTypes.node
 };
 
 DeploymentParameter.defaultProps = {
     as: 'h5',
     headerStyle: {},
-    subHeaderStyle: {}
+    subHeaderStyle: {},
+    value: ''
 };
 
 export default function DeploymentDetails({


### PR DESCRIPTION
Main goal of this PR was to fix the following issues:
* `react/prop-types`
* `react/default-props-match-prop-types`
* `react/forbid-prop-types`
* `react/no-unused-prop-types`
* `react/no-unused-state`
* `react/require-default-props`

in `/app` directory.

Reduced number of linter issues from:

> [2020-06-16T13:59:35.778Z] ✖ 3603 problems (0 errors, 3603 warnings)

to 

> [2020-06-17T06:25:54.959Z] ✖ 3272 problems (0 errors, 3272 warnings)

When fixing `react/prop-types` issues I tried to be reasonably specific with defining prop types. That means for me that detail level should be limited to the use in current component. Eg. if a component is getting `tenants` prop which is array of complex objects, but it just passes it down to another component (and don't use the internal specifics), then I used  `PropTypes.arrayOf(PropTypes.shape({}))`, no need to define the internal structure.

In places where it was quick I:
* converted class components into functional components
* converted pure Semantic UI elements into React Semantic UI components
* fixed typos in variable names