### PR TITLE
CY-3091 - Port Blueprints Catalog improvements to 5.0.5

### DIFF
--- a/templates/pages/catalog-community.json
+++ b/templates/pages/catalog-community.json
@@ -5,14 +5,9 @@
       "name": "Blueprints Catalog",
       "definition": "blueprintCatalog",
       "width": 12,
-      "height": 26,
+      "height": 24,
       "x": 0,
-      "y": 0,
-      "configuration":{
-        "displayStyle":"catalog",
-        "username":"cloudify-examples",
-        "filter":"blueprint in:name NOT local"
-      }
+      "y": 0
     },
     {
       "name": "Plugins Catalog",
@@ -20,7 +15,7 @@
       "width": 12,
       "height": 24,
       "x": 0,
-      "y": 0
+      "y": 24
     }
   ]
 }

--- a/templates/pages/catalog.json
+++ b/templates/pages/catalog.json
@@ -5,14 +5,9 @@
       "name": "Blueprints Catalog",
       "definition": "blueprintCatalog",
       "width": 12,
-      "height": 26,
+      "height": 24,
       "x": 0,
-      "y": 0,
-      "configuration":{
-        "displayStyle":"catalog",
-        "username":"cloudify-examples",
-        "filter":"blueprint in:name NOT local"
-      }
+      "y": 0
     },
     {
       "name": "Plugins Catalog",
@@ -20,13 +15,13 @@
       "width": 12,
       "height": 24,
       "x": 0,
-      "y": 0
+      "y": 24
     },
     {
       "name": "Composer link",
       "definition": "composerLink",
       "x": 0,
-      "y": 25
+      "y": 48
     }
   ]
 }

--- a/tours/main-sys_admin.json
+++ b/tours/main-sys_admin.json
@@ -203,7 +203,7 @@
                 "title": "Upload a Blueprint",
                 "content": "When you click <strong>Upload</strong>, the blueprint is uploaded to your Cloudify Manager. The blueprint is available in Local Blueprints, where you can also upload other blueprints.",
                 "onNextRedirectTo": ["/page/local_blueprints", "Local Blueprints", "No Blueprints", "You need to have <strong>Blueprints</strong> widget present on current page with at least one blueprint to proceed to the next step."],
-                "target": "div.blueprintCatalogWidget div.ui.grid > div.row > div:first-child button.uploadButton",
+                "target": "div.blueprintCatalogWidget table.ui tr:first-child > td.rowActions > i.upload",
                 "placement": "right"
             },
             {

--- a/widgets/blueprintCatalog/src/RepositoryCatalog.js
+++ b/widgets/blueprintCatalog/src/RepositoryCatalog.js
@@ -1,6 +1,7 @@
 /**
  * Created by pposel on 06/02/2017.
  */
+import Consts from './consts';
 
 export default class extends React.Component {
     static propTypes = {
@@ -110,12 +111,16 @@ export default class extends React.Component {
             );
         }
 
+        // Show pagination only in case when data is provided from GitHub
+        const { data } = this.props;
+        const pageSize = data.source === Consts.GITHUB_DATA_SOURCE ? widget.configuration.pageSize : data.total;
+        const totalSize = data.source === Consts.GITHUB_DATA_SOURCE ? data.total : -1;
+
         return (
             <div>
                 <DataSegment
-                    fetchSize={this.props.data.items.length}
-                    totalSize={this.props.data.total}
-                    pageSize={this.props.widget.configuration.pageSize}
+                    totalSize={totalSize}
+                    pageSize={pageSize}
                     fetchData={this.props.fetchData}
                     className="repositoryCatalog"
                     noDataMessage={this.props.noDataMessage}

--- a/widgets/blueprintCatalog/src/RepositoryCatalog.js
+++ b/widgets/blueprintCatalog/src/RepositoryCatalog.js
@@ -112,7 +112,7 @@ export default class extends React.Component {
         }
 
         // Show pagination only in case when data is provided from GitHub
-        const { data } = this.props;
+        const { data, widget } = this.props;
         const pageSize = data.source === Consts.GITHUB_DATA_SOURCE ? widget.configuration.pageSize : data.total;
         const totalSize = data.source === Consts.GITHUB_DATA_SOURCE ? data.total : -1;
 

--- a/widgets/blueprintCatalog/src/RepositoryCatalog.js
+++ b/widgets/blueprintCatalog/src/RepositoryCatalog.js
@@ -80,7 +80,7 @@ export default class extends React.Component {
                                 className="uploadButton labeled icon"
                                 onClick={event => {
                                     event.stopPropagation();
-                                    this.props.onUpload(item.name, item.zip_url, item.image_url);
+                                    this.props.onUpload(item.name, item.zip_url, item.image_url, item.main_blueprint);
                                 }}
                             />
                         </div>

--- a/widgets/blueprintCatalog/src/RepositoryList.js
+++ b/widgets/blueprintCatalog/src/RepositoryList.js
@@ -60,7 +60,15 @@ export default class extends React.Component {
         this.props.actions
             .doListYamlFiles(zipUrl)
             .then(yamlFiles => {
-                this.setState({ error: null, repositoryName, defaultYamlFile, yamlFiles, zipUrl, imageUrl, showModal: true });
+                this.setState({
+                    error: null,
+                    repositoryName,
+                    defaultYamlFile,
+                    yamlFiles,
+                    zipUrl,
+                    imageUrl,
+                    showModal: true
+                });
                 this.props.toolbox.loading(false);
             })
             .catch(err => {

--- a/widgets/blueprintCatalog/src/RepositoryList.js
+++ b/widgets/blueprintCatalog/src/RepositoryList.js
@@ -18,6 +18,7 @@ export default class extends React.Component {
             readmeLoading: null,
             repositoryName: '',
             yamlFiles: [],
+            defaultYamlFile: '',
             zipUrl: '',
             imageUrl: '',
             error: null
@@ -53,13 +54,13 @@ export default class extends React.Component {
         return this.props.toolbox.refresh(fetchParams);
     }
 
-    _showModal(repositoryName, zipUrl, imageUrl) {
+    _showModal(repositoryName, zipUrl, imageUrl, defaultYamlFile = '') {
         this.props.toolbox.loading(true);
 
         this.props.actions
             .doListYamlFiles(zipUrl)
             .then(yamlFiles => {
-                this.setState({ error: null, repositoryName, yamlFiles, zipUrl, imageUrl, showModal: true });
+                this.setState({ error: null, repositoryName, defaultYamlFile, yamlFiles, zipUrl, imageUrl, showModal: true });
                 this.props.toolbox.loading(false);
             })
             .catch(err => {
@@ -134,6 +135,7 @@ export default class extends React.Component {
                     open={this.state.showModal}
                     repositoryName={this.state.repositoryName}
                     yamlFiles={this.state.yamlFiles}
+                    defaultYamlFile={this.state.defaultYamlFile}
                     zipUrl={this.state.zipUrl}
                     imageUrl={this.state.imageUrl}
                     onHide={this._hideModal.bind(this)}

--- a/widgets/blueprintCatalog/src/RepositoryTable.js
+++ b/widgets/blueprintCatalog/src/RepositoryTable.js
@@ -24,7 +24,8 @@ export default class extends React.Component {
     render() {
         const { DataTable, Image, Icon } = Stage.Basic;
 
-        // Show pagination only in case of data provided from GitHub
+        // Show pagination only in case when data is provided from GitHub
+        const { data } = this.props;
         const pageSize = data.source === Consts.GITHUB_DATA_SOURCE ? widget.configuration.pageSize : data.total;
         const totalSize = data.source === Consts.GITHUB_DATA_SOURCE ? data.total : -1;
 
@@ -49,6 +50,7 @@ export default class extends React.Component {
                     return (
                         <DataTable.Row
                             key={item.id}
+                            className={`bp_${item.name}`}
                             selected={item.isSelected}
                             onClick={() => this.props.onSelect(item)}
                         >

--- a/widgets/blueprintCatalog/src/RepositoryTable.js
+++ b/widgets/blueprintCatalog/src/RepositoryTable.js
@@ -1,6 +1,7 @@
 /**
  * Created by pposel on 08/02/2017.
  */
+import Consts from './consts';
 
 export default class extends React.Component {
     static propTypes = {
@@ -23,14 +24,17 @@ export default class extends React.Component {
     render() {
         const { DataTable, Image, Icon } = Stage.Basic;
 
+        // Show pagination only in case of data provided from GitHub
+        const pageSize = data.source === Consts.GITHUB_DATA_SOURCE ? widget.configuration.pageSize : data.total;
+        const totalSize = data.source === Consts.GITHUB_DATA_SOURCE ? data.total : -1;
+
         return (
             <DataTable
                 fetchData={this.props.fetchData}
-                pageSize={this.props.widget.configuration.pageSize}
+                pageSize={pageSize}
                 sortColumn={this.props.widget.configuration.sortColumn}
                 sortAscending={this.props.widget.configuration.sortAscending}
-                fetchSize={this.props.data.items.length}
-                totalSize={this.props.data.total}
+                totalSize={totalSize}
                 selectable
                 noDataMessage={this.props.noDataMessage}
             >

--- a/widgets/blueprintCatalog/src/RepositoryTable.js
+++ b/widgets/blueprintCatalog/src/RepositoryTable.js
@@ -80,7 +80,7 @@ export default class extends React.Component {
                                     bordered
                                     onClick={event => {
                                         event.stopPropagation();
-                                        this.props.onUpload(item.name, item.zip_url, item.image_url);
+                                        this.props.onUpload(item.name, item.zip_url, item.image_url, item.main_blueprint);
                                     }}
                                 />
                             </DataTable.Data>

--- a/widgets/blueprintCatalog/src/RepositoryTable.js
+++ b/widgets/blueprintCatalog/src/RepositoryTable.js
@@ -25,7 +25,7 @@ export default class extends React.Component {
         const { DataTable, Image, Icon } = Stage.Basic;
 
         // Show pagination only in case when data is provided from GitHub
-        const { data } = this.props;
+        const { data, widget } = this.props;
         const pageSize = data.source === Consts.GITHUB_DATA_SOURCE ? widget.configuration.pageSize : data.total;
         const totalSize = data.source === Consts.GITHUB_DATA_SOURCE ? data.total : -1;
 
@@ -82,7 +82,12 @@ export default class extends React.Component {
                                     bordered
                                     onClick={event => {
                                         event.stopPropagation();
-                                        this.props.onUpload(item.name, item.zip_url, item.image_url, item.main_blueprint);
+                                        this.props.onUpload(
+                                            item.name,
+                                            item.zip_url,
+                                            item.image_url,
+                                            item.main_blueprint
+                                        );
                                     }}
                                 />
                             </DataTable.Data>

--- a/widgets/blueprintCatalog/src/UploadModal.js
+++ b/widgets/blueprintCatalog/src/UploadModal.js
@@ -17,6 +17,7 @@ export default class UploadModal extends React.Component {
      * @property {Function} onHide function called when modal is closed
      * @property {object} toolbox Toolbox object
      * @property {object} actions Actions object
+     * @property {string} defaultYamlFile string name of the repository used as a blueprint name
      */
     static propTypes = {
         repositoryName: PropTypes.string.isRequired,
@@ -24,7 +25,12 @@ export default class UploadModal extends React.Component {
         open: PropTypes.bool.isRequired,
         onHide: PropTypes.func.isRequired,
         toolbox: PropTypes.object.isRequired,
-        actions: PropTypes.object.isRequired
+        actions: PropTypes.object.isRequired,
+        defaultYamlFile: PropTypes.string
+    };
+
+    static defaultProps = {
+        defaultYamlFile: ''
     };
 
     static initialState = {
@@ -47,15 +53,9 @@ export default class UploadModal extends React.Component {
     }
 
     componentDidUpdate(prevProps) {
-        if (!prevProps.open && this.props.open) {
-            if (!_.isEmpty(this.props.yamlFiles)) {
-                const defaultBlueprintYamlFile = Stage.Common.UploadBlueprintModal.DEFAULT_BLUEPRINT_YAML_FILE;
-                const { yamlFiles } = this.props;
-                const blueprintName = this.props.repositoryName;
-                const blueprintYamlFile = _.includes(yamlFiles, defaultBlueprintYamlFile)
-                    ? defaultBlueprintYamlFile
-                    : yamlFiles[0];
-
+        const { open, repositoryName: blueprintName, defaultYamlFile: blueprintYamlFile, yamlFiles } = this.props;
+        if (!prevProps.open && open) {
+            if (!_.isEmpty(yamlFiles)) {
                 this.setState({
                     ...UploadModal.initialState,
                     blueprintName,

--- a/widgets/blueprintCatalog/src/actions.js
+++ b/widgets/blueprintCatalog/src/actions.js
@@ -21,19 +21,16 @@ export default class Actions {
         if (!_.isEmpty(this.jsonPath)) {
             // JSON URL
             return this.toolbox
-                .getExternal()
-                .doGet(this.jsonPath)
-                .then(data => {
-                    const numberOfBlueprints = data.length;
-                    const startOffset = Math.min(params.per_page * (params.page - 1), numberOfBlueprints);
-                    const endOffset = Math.min(params.per_page * params.page, numberOfBlueprints);
-                    return Promise.resolve({
-                        items: _.slice(data, startOffset, endOffset),
-                        total_count: numberOfBlueprints,
+                .getInternal()
+                .doGet('/external/content', { url: this.jsonPath }, false)
+                .then(response => response.json())
+                .then(data =>
+                    Promise.resolve({
+                        items: data,
+                        total_count: data.length,
                         source: Consts.JSON_DATA_SOURCE
-                    });
-                })
-                .catch(() => Promise.reject({ message: `Cannot fetch data from ${this.jsonPath}.` }));
+                    })
+                );
         }
         // GitHub API
         return this.toolbox

--- a/widgets/blueprintCatalog/src/widget.js
+++ b/widgets/blueprintCatalog/src/widget.js
@@ -26,7 +26,7 @@ Stage.defineWidget({
             name: 'Blueprints Examples URL',
             placeHolder: 'Type URL to blueprint examples JSON file',
             description: 'If set, then GitHub options are not used for fetching data.',
-            default: 'http://repository.cloudifysource.org/cloudify/blueprints/5.0.5/examples.json',
+            default: 'https://repository.cloudifysource.org/cloudify/blueprints/5.0.5/examples.json',
             type: Stage.Basic.GenericField.STRING_TYPE
         },
         {

--- a/widgets/blueprintCatalog/src/widget.js
+++ b/widgets/blueprintCatalog/src/widget.js
@@ -26,7 +26,7 @@ Stage.defineWidget({
             name: 'Blueprints Examples URL',
             placeHolder: 'Type URL to blueprint examples JSON file',
             description: 'If set, then GitHub options are not used for fetching data.',
-            default: '//repository.cloudifysource.org/cloudify/blueprints/5.0.5/examples.json',
+            default: 'http://repository.cloudifysource.org/cloudify/blueprints/5.0.5/examples.json',
             type: Stage.Basic.GenericField.STRING_TYPE
         },
         {

--- a/widgets/blueprintCatalog/src/widget.js
+++ b/widgets/blueprintCatalog/src/widget.js
@@ -11,7 +11,7 @@ Stage.defineWidget({
     name: 'Blueprints Catalog',
     description: 'Shows blueprints catalog',
     initialWidth: 8,
-    initialHeight: 16,
+    initialHeight: 20,
     color: 'teal',
     hasStyle: true,
     isReact: true,
@@ -20,7 +20,7 @@ Stage.defineWidget({
     categories: [Stage.GenericConfig.CATEGORY.BLUEPRINTS],
 
     initialConfiguration: [
-        Stage.GenericConfig.PAGE_SIZE_CONFIG(3),
+        Stage.GenericConfig.PAGE_SIZE_CONFIG(),
         {
             id: 'jsonPath',
             name: 'Blueprints Examples URL',
@@ -53,7 +53,7 @@ Stage.defineWidget({
             id: 'displayStyle',
             name: 'Display style',
             items: [{ name: 'Table', value: 'table' }, { name: 'Catalog', value: 'catalog' }],
-            default: 'catalog',
+            default: 'table',
             type: Stage.Basic.GenericField.LIST_TYPE
         },
         {


### PR DESCRIPTION
Implemented:
* CY-2873 - Update Blueprints Catalog widget to be displayed by default as a table (#990, #992)
* CY-2870 - Add default blueprint YAML file handling in Blueprints Catalog widget (#991)
* Switched Blueprints Catalog to use stage backend to fetch examples instead of directly fetching from browser