### PR TITLE
CY-3169 - Execution task graph - no-task graph error

### DIFF
--- a/app/utils/stageUtils.js
+++ b/app/utils/stageUtils.js
@@ -29,8 +29,9 @@ export default class StageUtils {
         let hasCanceled = false;
 
         const wrappedPromise = new Promise((resolve, reject) => {
-            promise.then(val => (hasCanceled ? reject({ isCanceled: true }) : resolve(val)));
-            promise.catch(error => (hasCanceled ? reject({ isCanceled: true }) : reject(error)));
+            promise
+                .then(val => (hasCanceled ? reject({ isCanceled: true }) : resolve(val)))
+                .catch(error => (hasCanceled ? reject({ isCanceled: true }) : reject(error)));
         });
 
         return {

--- a/test/cypress/integration/widgets/executions_spec.js
+++ b/test/cypress/integration/widgets/executions_spec.js
@@ -28,7 +28,7 @@ describe('Executions', () => {
             .contains('install')
             .click();
 
-        cy.log('Check if Task Graph is is visible');
+        cy.log('Check if Task Graph is visible');
         cy.get('.executionsWidget svg').should('be.visible');
     });
 
@@ -46,8 +46,24 @@ describe('Executions', () => {
             .as('statusLabel');
 
         cy.get('@statusLabel').trigger('mouseover');
-        cy.get('.modal .header').should('have.text', 'Last Execution');
+        cy.get('.popup .header').should('have.text', 'Last Execution');
         cy.get('@statusLabel').trigger('mouseout');
+    });
+
+    it('provides message when there is no Task Execution Graph', () => {
+        cy.get('.tabular.menu')
+            .contains('a.item', 'History')
+            .click();
+
+        cy.log('Check if Executions widget has table rows');
+        cy.get('.executionsWidget')
+            .contains('tr', 'create_deployment_environment')
+            .click();
+
+        cy.log('Check if message is provided');
+        cy.get('.executionsTable .message')
+            .should('be.visible')
+            .should('have.text', 'The selected execution does not have a tasks graph');
     });
 
     describe('provides Task Execution Graph', () => {

--- a/widgets/executions/src/backend.js
+++ b/widgets/executions/src/backend.js
@@ -108,7 +108,7 @@ module.exports = r => {
 
         const runGraphCreation = () => {
             const tasksGraphParams = { ...req.query };
-            const headers = _.pick(req.headers, ['authentication-token', 'tenant']);
+            const headers = _.pick(req.headers, 'authentication-token', 'tenant');
 
             const operationsList = [];
             helper.Manager.doGet(tasksGraphsFetchUrl, tasksGraphParams, headers)
@@ -116,8 +116,7 @@ module.exports = r => {
                     const { items } = data;
 
                     if (_.isEmpty(items)) {
-                        const { execution_id: id } = tasksGraphParams;
-                        const message = `No tasks graph for execution id=${id}.`;
+                        const message = `No tasks graph for execution id=${tasksGraphParams.execution_id}.`;
                         logger.info(message);
                         res.status(404).send({ message });
                         return;

--- a/widgets/executions/src/tasksGraph/GraphNode.js
+++ b/widgets/executions/src/tasksGraph/GraphNode.js
@@ -123,7 +123,7 @@ GraphNode.propTypes = {
     graphNode: PropTypes.shape({
         labels: PropTypes.arrayOf(
             PropTypes.shape({
-                display_text: PropTypes.arrayOf(PropTypes.string),
+                display_text: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
                 display_title: PropTypes.arrayOf(PropTypes.string),
                 text: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
                 state: PropTypes.string,

--- a/widgets/executions/src/tasksGraph/GraphNode.js
+++ b/widgets/executions/src/tasksGraph/GraphNode.js
@@ -123,9 +123,9 @@ GraphNode.propTypes = {
     graphNode: PropTypes.shape({
         labels: PropTypes.arrayOf(
             PropTypes.shape({
-                display_text: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
+                display_text: Stage.PropTypes.StringOrArray,
                 display_title: PropTypes.arrayOf(PropTypes.string),
-                text: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
+                text: Stage.PropTypes.StringOrArray,
                 state: PropTypes.string,
                 retry: PropTypes.number
             })

--- a/widgets/executions/widget.css
+++ b/widgets/executions/widget.css
@@ -1,8 +1,4 @@
 /* Tasks Graph */
-#graphContainerLoading {
-    height: 200px;
-}
-
 .executionsWidget svg g, .ui.modal svg g {
     pointer-events: all !important;
 }


### PR DESCRIPTION
### Main changes:
- Fixed fetching tasks graph (fetching is not stopped on tasks graph not present as it was before)
- Improved backend part of tasks graph poller (it fails quickly right now without trying to fetch not existing data)
- Improved fetching tasks graph (now we fetch tasks graph with interval depending on execution status - for active executions we poll data every 3 seconds, for inactive executions we poll data every 6 seconds)
- Updated layout for single execution view (to include status no matter if the graph is present)
- Reviewed and updated tests

### Chore:
- Fixed `makeCancelable` function to allow proper handling of failed promises
- Fixed GraphNode prop types
- Improved logging in backend part of tasks graph poller (using internal logger instead of console calls)