### PR TITLE
CY-3130 - Execute workflows menu improvements

### DIFF
--- a/widgets/common/src/WorkflowsMenu.js
+++ b/widgets/common/src/WorkflowsMenu.js
@@ -2,6 +2,18 @@
  * Created by jakubniezgoda on 31/01/2019.
  */
 
+function StyledTitle({ name, bold }) {
+    const displayName = _.capitalize(_.lowerCase(name));
+    return <span style={bold ? { fontWeight: 'bold' } : {}}>{displayName}</span>;
+}
+StyledTitle.propTypes = {
+    name: PropTypes.string.isRequired,
+    bold: PropTypes.bool
+};
+StyledTitle.defaultProps = {
+    bold: false
+};
+
 class WorkflowsMenuItems extends React.Component {
     static propTypes = {
         workflows: PropTypes.arrayOf(PropTypes.shape({ name: PropTypes.string })).isRequired,
@@ -19,7 +31,7 @@ class WorkflowsMenuItems extends React.Component {
         return _.map(workflows, workflow => (
             <Menu.Item
                 name={workflow.name}
-                content={_.capitalize(_.lowerCase(workflow.name))}
+                content={<StyledTitle name={workflow.name} />}
                 key={workflow.name}
                 onClick={() => onClick(workflow)}
             />
@@ -65,6 +77,8 @@ class AccordionWorkflowsMenu extends React.Component {
         const { workflowsGroups, onClick } = this.props;
         const { activeGroup } = this.state;
 
+        const defaultGroupName = 'default_workflows';
+
         return (
             <Accordion as={Menu} vertical style={{ boxShadow: 'none' }}>
                 {_.map(workflowsGroups, group => (
@@ -72,7 +86,7 @@ class AccordionWorkflowsMenu extends React.Component {
                         <Accordion.Title
                             active={activeGroup === group.name}
                             index={group.name}
-                            content={_.capitalize(_.lowerCase(group.name))}
+                            content={<StyledTitle bold={group.name === defaultGroupName} name={group.name} />}
                             onClick={this.onGroupClick.bind(this)}
                         />
                         <Accordion.Content active={activeGroup === group.name}>

--- a/widgets/deployments/src/MenuAction.js
+++ b/widgets/deployments/src/MenuAction.js
@@ -28,6 +28,9 @@ export default class MenuAction extends React.Component {
         const { PopupMenu, Menu } = Stage.Basic;
         const { WorkflowsMenu } = Stage.Common;
 
+        const installWorkflow = _.find(item.workflows, ['name', 'install']);
+        const uninstallWorkflow = _.find(item.workflows, ['name', 'uninstall']);
+
         return (
             <PopupMenu className="menuAction segmentMenuAction">
                 <Menu pointing vertical>
@@ -42,6 +45,7 @@ export default class MenuAction extends React.Component {
                             />
                         </Menu.Menu>
                     </Menu.Item>
+                    <Menu.Item icon="play" content="Install" onClick={() => this.workflowClick(installWorkflow)} />
                     <Menu.Item
                         icon="edit"
                         content="Update"
@@ -53,6 +57,11 @@ export default class MenuAction extends React.Component {
                         content="Set Site"
                         name={MenuAction.SET_SITE_ACTION}
                         onClick={this.actionClick.bind(this)}
+                    />
+                    <Menu.Item
+                        icon="recycle"
+                        content="Uninstall"
+                        onClick={() => this.workflowClick(uninstallWorkflow)}
                     />
                     <Menu.Item
                         icon="trash alternate"


### PR DESCRIPTION
### Changes
* Added Install and Uninstall options to Deployments widget action menu
* Marked Default workflows as bold in workflows menu

### Screenshots
* Deployments widget - action menu
  * Deployment with grouped workflows
    ![DeploymentMenu_GroupedWorkflows](https://user-images.githubusercontent.com/5202105/88791775-884ae580-d19a-11ea-9924-e2961b63b8e1.png)
  * Deployment with only default workflows
    ![DeploymentMenu_OnlyDefaultWorkflows](https://user-images.githubusercontent.com/5202105/88791776-88e37c00-d19a-11ea-9eca-12c7cdf5540a.png)
* Deployment Action Buttons widget - Execute workflow button
  * Deployment with grouped workflows
    ![ExecuteWorkflow_GroupedWorkflows](https://user-images.githubusercontent.com/5202105/88791780-897c1280-d19a-11ea-8c0a-8fd416b7ba1c.png)
  * Deployment with only default workflows
    ![ExecuteWorkflow_OnlyDefaultWorkflows](https://user-images.githubusercontent.com/5202105/88791782-8a14a900-d19a-11ea-942b-47d3ffccffc3.png)





