### PR TITLE
CY-3558 - Fix handling HTTP 204 No Content responses

### DIFF
--- a/app/utils/External.js
+++ b/app/utils/External.js
@@ -199,7 +199,9 @@ export default class External {
             .then(response => {
                 if (parseResponse) {
                     const contentType = _.toLower(response.headers.get('content-type'));
-                    return contentType.indexOf('application/json') >= 0 ? response.json() : response.text();
+                    return response.status !== 204 && contentType.indexOf('application/json') >= 0
+                        ? response.json()
+                        : response.text();
                 }
                 return response;
             });


### PR DESCRIPTION
The issue with Resource Filter widget test started occurring after implementation of **CY-3420 Make DELETEs return 204** within this PR: https://github.com/cloudify-cosmo/cloudify-premium/pull/682 .

The direct reason for failure was rejected promise (blueprint DELETE request) which caused stop of the promise chain and no trigger for refreshing Resource Filter widget.