### PR TITLE
CY-3693 & CY-3703 - Cluster Status widget update after cluster-status endpoint response changes

### DIFF
--- a/app/components/shared/cluster/ClusterServicesList.jsx
+++ b/app/components/shared/cluster/ClusterServicesList.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import { DataTable } from '../../basic';
-import IdPopup from '../IdPopup';
 import ClusterService from './ClusterService';
 import NodeStatus from './NodeStatus';
 import { nodeServicesPropType } from './NodeServices';
@@ -30,13 +29,12 @@ function ClusterServicesList({ services }) {
 
     return (
         <DataTable noDataMessage={noServicesMessage} noDataAvailable={_.isEmpty(services)} selectable>
-            <DataTable.Column label="Service Type" width="20%" />
+            <DataTable.Column label="Service Type" width="25%" />
             <DataTable.Column label="Node Name" width="25%" />
             <DataTable.Column label="Status" width="5%" />
             <DataTable.Column label="Private IP" width="15%" />
             <DataTable.Column label="Public IP / LB IP" width="15%" />
             <DataTable.Column label="Version" width="15%" />
-            <DataTable.Column label="" width="1%" />
 
             {_.map(services, (service, serviceName) => {
                 const numberOfNodes = _.size(service.nodes);
@@ -45,7 +43,7 @@ function ClusterServicesList({ services }) {
                     .map((node, nodeName) => ({ name: nodeName, ...node }))
                     .sortBy('name')
                     .map((node, index) => (
-                        <DataTable.Row key={`${serviceName}_${node.name}_${node.node_id}`}>
+                        <DataTable.Row key={`${serviceName}_${node.name}_${node.private_ip}`}>
                             {index === 0 && (
                                 <DataTable.Data
                                     rowSpan={numberOfNodes}
@@ -68,9 +66,6 @@ function ClusterServicesList({ services }) {
                                 <PublicIP ip={node.public_ip} serviceName={serviceName} />
                             </DataTable.Data>
                             <DataTable.Data>{node.version}</DataTable.Data>
-                            <DataTable.Data>
-                                <IdPopup selected id={node.node_id} buttonPosition="right" />
-                            </DataTable.Data>
                         </DataTable.Row>
                     ))
                     .value();
@@ -86,7 +81,6 @@ const clusterServiceProps = PropTypes.shape({
             status: PropTypes.oneOf(clusterNodeStatuses).isRequired,
             public_ip: PropTypes.string,
             version: PropTypes.string.isRequired,
-            node_id: PropTypes.string.isRequired,
             private_ip: PropTypes.string.isRequired,
             services: nodeServicesPropType
         })

--- a/app/components/shared/cluster/NodeServices.jsx
+++ b/app/components/shared/cluster/NodeServices.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { CopyToClipboardButton, Header, Icon, Popup, Table } from '../../basic';
+import { CopyToClipboardButton, Header, Icon, Table } from '../../basic';
 import JsonUtils from '../../../utils/shared/JsonUtils';
 
 import { clusterServiceEnum, clusterServices, nodeServiceStatusEnum, nodeServiceStatuses } from './consts';
@@ -25,19 +25,11 @@ StatusHeader.propTypes = {
     nodeType: PropTypes.oneOf(clusterServices).isRequired
 };
 
-const ServiceHeader = ({ name, description, isRemote }) => {
+const ServiceHeader = ({ name, description }) => {
     return (
         <Header size="tiny">
             <Header.Content>
-                {name}&nbsp;
-                {isRemote && (
-                    <Popup>
-                        <Popup.Trigger>
-                            <Icon name="external square" />
-                        </Popup.Trigger>
-                        <Popup.Content>Remote</Popup.Content>
-                    </Popup>
-                )}
+                {name}
                 {description && <Header.Subheader>{description}</Header.Subheader>}
             </Header.Content>
         </Header>
@@ -45,8 +37,7 @@ const ServiceHeader = ({ name, description, isRemote }) => {
 };
 ServiceHeader.propTypes = {
     name: PropTypes.string.isRequired,
-    description: PropTypes.string,
-    isRemote: PropTypes.bool.isRequired
+    description: PropTypes.string
 };
 ServiceHeader.defaultProps = {
     description: ''
@@ -76,7 +67,6 @@ export default function NodeServices({ name, type, services }) {
         .sort()
         .map(serviceName => ({
             name: serviceName,
-            isRemote: services[serviceName].is_remote,
             status: services[serviceName].status,
             description: _.get(services[serviceName], 'extra_info.systemd.instances[0].Description', ''),
             extraInfo: services[serviceName].extra_info
@@ -90,11 +80,11 @@ export default function NodeServices({ name, type, services }) {
             <Table celled basic="very" collapsing className="servicesData">
                 <Table.Body style={{ display: 'block', paddingRight: 10, maxHeight: '60vh', overflowY: 'auto' }}>
                     {_.map(formattedServices, service => {
-                        const { description, isRemote, name: serviceName, status: serviceStatus } = service;
+                        const { description, name: serviceName, status: serviceStatus } = service;
                         return (
                             <Table.Row key={serviceName}>
                                 <Table.Cell collapsing>
-                                    <ServiceHeader name={serviceName} description={description} isRemote={isRemote} />
+                                    <ServiceHeader name={serviceName} description={description} />
                                 </Table.Cell>
                                 <Table.Cell textAlign="center">
                                     <ServiceStatus status={serviceStatus} />
@@ -111,7 +101,6 @@ export default function NodeServices({ name, type, services }) {
 
 export const nodeServicesPropType = PropTypes.objectOf(
     PropTypes.shape({
-        is_remote: PropTypes.bool.isRequired,
         status: PropTypes.oneOf(nodeServiceStatuses).isRequired,
         extra_info: PropTypes.object
     })

--- a/test/cypress/fixtures/cluster_status/degraded.json
+++ b/test/cypress/fixtures/cluster_status/degraded.json
@@ -6,25 +6,22 @@
             "nodes": {
                 "manager_1": {
                     "status": "OK",
-                    "version": "5.0.5.dev1",
+                    "version": "5.2.0",
                     "public_ip": "10.239.3.98",
-                    "node_id": "ad54c867-6585-419f-a4ed-fa0f0e7a0447",
                     "private_ip": "172.16.4.26",
                     "services": {}
                 },
                 "manager_3": {
                     "status": "OK",
-                    "version": "5.0.5.dev1",
+                    "version": "5.2.0",
                     "public_ip": "10.239.3.100",
-                    "node_id": "1b68676a-b74b-4843-9542-cf33f401e73b",
                     "private_ip": "172.16.4.28",
                     "services": {}
                 },
                 "manager_2": {
                     "status": "OK",
-                    "version": "5.0.5.dev1",
+                    "version": "5.2.0",
                     "public_ip": "10.239.3.99",
-                    "node_id": "e2405374-701b-4e7a-a142-aec805543589",
                     "private_ip": "172.16.4.27",
                     "services": {}
                 }
@@ -36,25 +33,22 @@
             "nodes": {
                 "postgresql_3": {
                     "status": "OK",
-                    "version": "5.0.5.dev1",
+                    "version": "5.2.0",
                     "public_ip": null,
-                    "node_id": "dfa35159-62e5-4bd7-9e0a-ee4bc8ac06e6",
                     "private_ip": "172.16.4.31",
                     "services": {}
                 },
                 "postgresql_2": {
                     "status": "OK",
-                    "version": "5.0.5.dev1",
+                    "version": "5.2.0",
                     "public_ip": null,
-                    "node_id": "d31fa2df-da8e-4a18-8d5c-18355813c3ad",
                     "private_ip": "172.16.4.30",
                     "services": {}
                 },
                 "postgresql_1": {
                     "status": "OK",
-                    "version": "5.0.5.dev1",
+                    "version": "5.2.0",
                     "public_ip": null,
-                    "node_id": "1dddbd1c-0c4d-40be-9678-dd33735c8f9a",
                     "private_ip": "172.16.4.29",
                     "services": {}
                 }
@@ -66,25 +60,22 @@
             "nodes": {
                 "rabbitmq_1": {
                     "status": "OK",
-                    "version": "5.0.5.dev1",
+                    "version": "5.2.0",
                     "public_ip": null,
-                    "node_id": "c771ca92-a2b9-41e3-af03-85e48c951e5f",
                     "private_ip": "172.16.4.32",
                     "services": {}
                 },
                 "rabbitmq_3": {
                     "status": "OK",
-                    "version": "5.0.5.dev1",
+                    "version": "5.2.0",
                     "public_ip": null,
-                    "node_id": "6e0cb1a8-692a-47dd-899f-ca2e0970fb7b",
                     "private_ip": "172.16.4.34",
                     "services": {}
                 },
                 "rabbitmq_2": {
                     "status": "OK",
-                    "version": "5.0.5.dev1",
+                    "version": "5.2.0",
                     "public_ip": null,
-                    "node_id": "958508e5-e9e6-48a5-a509-e36bcff44a70",
                     "private_ip": "172.16.4.33",
                     "services": {}
                 }

--- a/test/cypress/fixtures/cluster_status/fail.json
+++ b/test/cypress/fixtures/cluster_status/fail.json
@@ -6,25 +6,22 @@
             "nodes": {
                 "manager_1": {
                     "status": "OK",
-                    "version": "5.0.5.dev1",
+                    "version": "5.2.0",
                     "public_ip": "10.239.3.98",
-                    "node_id": "ad54c867-6585-419f-a4ed-fa0f0e7a0447",
                     "private_ip": "172.16.4.26",
                     "services": {}
                 },
                 "manager_3": {
                     "status": "Fail",
-                    "version": "5.0.5.dev1",
+                    "version": "5.2.0",
                     "public_ip": "10.239.3.100",
-                    "node_id": "1b68676a-b74b-4843-9542-cf33f401e73b",
                     "private_ip": "172.16.4.28",
                     "services": {}
                 },
                 "manager_2": {
                     "status": "OK",
-                    "version": "5.0.5.dev1",
+                    "version": "5.2.0",
                     "public_ip": "10.239.3.99",
-                    "node_id": "e2405374-701b-4e7a-a142-aec805543589",
                     "private_ip": "172.16.4.27",
                     "services": {}
                 }
@@ -36,25 +33,22 @@
             "nodes": {
                 "postgresql_3": {
                     "status": "OK",
-                    "version": "5.0.5.dev1",
+                    "version": "5.2.0",
                     "public_ip": null,
-                    "node_id": "dfa35159-62e5-4bd7-9e0a-ee4bc8ac06e6",
                     "private_ip": "172.16.4.31",
                     "services": {}
                 },
                 "postgresql_2": {
                     "status": "OK",
-                    "version": "5.0.5.dev1",
+                    "version": "5.2.0",
                     "public_ip": null,
-                    "node_id": "d31fa2df-da8e-4a18-8d5c-18355813c3ad",
                     "private_ip": "172.16.4.30",
                     "services": {}
                 },
                 "postgresql_1": {
                     "status": "OK",
-                    "version": "5.0.5.dev1",
+                    "version": "5.2.0",
                     "public_ip": null,
-                    "node_id": "1dddbd1c-0c4d-40be-9678-dd33735c8f9a",
                     "private_ip": "172.16.4.29",
                     "services": {}
                 }
@@ -66,25 +60,22 @@
             "nodes": {
                 "rabbitmq_1": {
                     "status": "OK",
-                    "version": "5.0.5.dev1",
+                    "version": "5.2.0",
                     "public_ip": null,
-                    "node_id": "c771ca92-a2b9-41e3-af03-85e48c951e5f",
                     "private_ip": "172.16.4.32",
                     "services": {}
                 },
                 "rabbitmq_3": {
                     "status": "Fail",
-                    "version": "5.0.5.dev1",
+                    "version": "5.2.0",
                     "public_ip": null,
-                    "node_id": "6e0cb1a8-692a-47dd-899f-ca2e0970fb7b",
                     "private_ip": "172.16.4.34",
                     "services": {}
                 },
                 "rabbitmq_2": {
                     "status": "OK",
-                    "version": "5.0.5.dev1",
+                    "version": "5.2.0",
                     "public_ip": null,
-                    "node_id": "958508e5-e9e6-48a5-a509-e36bcff44a70",
                     "private_ip": "172.16.4.33",
                     "services": {}
                 }

--- a/test/cypress/fixtures/cluster_status/fail_with_services.json
+++ b/test/cypress/fixtures/cluster_status/fail_with_services.json
@@ -9,7 +9,7 @@
                     "status": "OK",
                     "public_ip": null,
                     "private_ip": "10.110.0.39",
-                    "version": "5.1.0.dev1",
+                    "version": "5.2.0",
                     "services": {
                         "PostgreSQL 9.5 database server": {
                             "status": "Active",
@@ -39,7 +39,7 @@
                     "status": "Fail",
                     "public_ip": "10.110.0.39",
                     "private_ip": "10.110.0.39",
-                    "version": "5.1.0.dev1",
+                    "version": "5.2.0",
                     "services": {
                         "Blackbox Exporter": {
                             "status": "Active",
@@ -245,7 +245,7 @@
                     "status": "OK",
                     "public_ip": null,
                     "private_ip": "10.110.0.39",
-                    "version": "5.1.0.dev1",
+                    "version": "5.2.0",
                     "services": {
                         "RabbitMQ Broker": {
                             "status": "Active",

--- a/test/cypress/fixtures/cluster_status/ok.json
+++ b/test/cypress/fixtures/cluster_status/ok.json
@@ -6,25 +6,22 @@
             "nodes": {
                 "manager_1": {
                     "status": "OK",
-                    "version": "5.0.5.dev1",
+                    "version": "5.2.0.dev1",
                     "public_ip": "10.239.3.98",
-                    "node_id": "ad54c867-6585-419f-a4ed-fa0f0e7a0447",
                     "private_ip": "172.16.4.26",
                     "services": {}
                 },
                 "manager_3": {
                     "status": "OK",
-                    "version": "5.0.5.dev1",
+                    "version": "5.2.0.dev1",
                     "public_ip": "10.239.3.100",
-                    "node_id": "1b68676a-b74b-4843-9542-cf33f401e73b",
                     "private_ip": "172.16.4.28",
                     "services": {}
                 },
                 "manager_2": {
                     "status": "OK",
-                    "version": "5.0.5.dev1",
+                    "version": "5.2.0.dev1",
                     "public_ip": "10.239.3.99",
-                    "node_id": "e2405374-701b-4e7a-a142-aec805543589",
                     "private_ip": "172.16.4.27",
                     "services": {}
                 }
@@ -36,25 +33,22 @@
             "nodes": {
                 "postgresql_3": {
                     "status": "OK",
-                    "version": "5.0.5.dev1",
+                    "version": "5.2.0.dev1",
                     "public_ip": null,
-                    "node_id": "dfa35159-62e5-4bd7-9e0a-ee4bc8ac06e6",
                     "private_ip": "172.16.4.31",
                     "services": {}
                 },
                 "postgresql_2": {
                     "status": "OK",
-                    "version": "5.0.5.dev1",
+                    "version": "5.2.0.dev1",
                     "public_ip": null,
-                    "node_id": "d31fa2df-da8e-4a18-8d5c-18355813c3ad",
                     "private_ip": "172.16.4.30",
                     "services": {}
                 },
                 "postgresql_1": {
                     "status": "OK",
-                    "version": "5.0.5.dev1",
+                    "version": "5.2.0.dev1",
                     "public_ip": null,
-                    "node_id": "1dddbd1c-0c4d-40be-9678-dd33735c8f9a",
                     "private_ip": "172.16.4.29",
                     "services": {}
                 }
@@ -66,25 +60,22 @@
             "nodes": {
                 "rabbitmq_1": {
                     "status": "OK",
-                    "version": "5.0.5.dev1",
+                    "version": "5.2.0.dev1",
                     "public_ip": null,
-                    "node_id": "c771ca92-a2b9-41e3-af03-85e48c951e5f",
                     "private_ip": "172.16.4.32",
                     "services": {}
                 },
                 "rabbitmq_3": {
                     "status": "OK",
-                    "version": "5.0.5.dev1",
+                    "version": "5.2.0.dev1",
                     "public_ip": null,
-                    "node_id": "6e0cb1a8-692a-47dd-899f-ca2e0970fb7b",
                     "private_ip": "172.16.4.34",
                     "services": {}
                 },
                 "rabbitmq_2": {
                     "status": "OK",
-                    "version": "5.0.5.dev1",
+                    "version": "5.2.0.dev1",
                     "public_ip": null,
-                    "node_id": "958508e5-e9e6-48a5-a509-e36bcff44a70",
                     "private_ip": "172.16.4.33",
                     "services": {}
                 }


### PR DESCRIPTION
### Changes
* Removed ID popup from Cluster Status widget (CY-3693)
* Removed `is_remote` from Cluster Status widget code (CY-3703)

### Before
![image](https://user-images.githubusercontent.com/5202105/96260738-b680da00-0fbf-11eb-8a64-ab31451401c8.png)

### After
![image](https://user-images.githubusercontent.com/5202105/96260659-9bae6580-0fbf-11eb-96b1-e5bec80aa748.png)
