### PR TITLE
RD-1070 [5.1.2] Fix package versions

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "stage-backend",
-  "version": "5.1.2.dev1",
+  "version": "5.1.2-.dev1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stage-backend",
-  "version": "5.1.2.dev1",
+  "version": "5.1.2-.dev1",
   "description": "Cloudify Console Backend",
   "repository": "https://github.com/cloudify-cosmo/cloudify-stage/backend",
   "license": "Apache-2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudify-stage",
-  "version": "5.1.2.dev1",
+  "version": "5.1.2-.dev1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudify-stage",
-  "version": "5.1.2.dev1",
+  "version": "5.1.2-.dev1",
   "description": "Cloudify Console",
   "homepage": "https://github.com/cloudify-cosmo/cloudify-stage#readme",
   "repository": "https://github.com/cloudify-cosmo/cloudify-stage",


### PR DESCRIPTION
Package versions were not semver compliant.

Cherry pick of https://github.com/cloudify-cosmo/cloudify-stage/pull/1170 to 5.1.2