### PR TITLE
RD-752 - Add Manage Labels modal

### DIFF
--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -375,7 +375,12 @@
                 "newValue": "New value",
                 "valuePlaceholder": "Select or type in a value",
                 "validationError": "Only letters, digits and the characters \"-\", \".\" and \"_\" are allowed and it must begin with a letter.",
-                "isLabelInSystemCheckError": "Cannot check is label already present in the system"
+                "inputName": "Labels list",
+                "inputHelp": "A list of labels - key-value pairs - that can be assigned with a deployment",
+                "isLabelInSystemCheckError": "Cannot check is label already present in the system",
+                "fetchingLabelsError": "Cannot fetch labels for deployment '{{deploymentId}}'",
+                "modalHeader": "Manage labels for deployment '{{deploymentId}}'",
+                "modalApplyButton": "Apply"
             },
             "readmes": {
                 "linksBasePath": "https://docs.cloudify.co/5.1",

--- a/widgets/common/src/DeploymentActions.js
+++ b/widgets/common/src/DeploymentActions.js
@@ -94,6 +94,18 @@ export default class DeploymentActions {
         return this.toolbox.getManager().doGet('/sites?_include=name&_sort=name');
     }
 
+    doSetLabels(deploymentId, deploymentLabels) {
+        const labels = _.map(deploymentLabels, ({ key, value }) => ({ [key]: value }));
+        return this.toolbox.getManager().doPatch(`/deployments/${deploymentId}`, null, { labels });
+    }
+
+    doGetLabels(deploymentId) {
+        return this.toolbox
+            .getManager()
+            .doGet(`/deployments/${deploymentId}?_include=labels`)
+            .then(({ labels }) => labels);
+    }
+
     async waitUntilCreated(deploymentId) {
         const { ExecutionActions, PollHelper } = Stage.Common;
 

--- a/widgets/common/src/ManageLabelsModal.jsx
+++ b/widgets/common/src/ManageLabelsModal.jsx
@@ -1,0 +1,84 @@
+function ManageLabelsModal({ deploymentId, open, onHide, toolbox }) {
+    const { i18n } = Stage;
+    const { ApproveButton, CancelButton, Form, Icon, Modal } = Stage.Basic;
+    const { DeploymentActions, LabelsInput } = Stage.Common;
+    const { useBoolean, useErrors, useOpenProp, useResettableState } = Stage.Hooks;
+    const actions = new DeploymentActions(toolbox);
+
+    const [isLoading, setLoading, unsetLoading] = useBoolean();
+    const { errors, clearErrors, setErrors, setMessageAsError } = useErrors();
+    const [labels, setLabels, resetLabels] = useResettableState([]);
+    const [initialLabels, setInitialLabels, resetInitialLabels] = useResettableState([]);
+
+    useOpenProp(open, () => {
+        clearErrors();
+        setLoading();
+        resetLabels();
+        resetInitialLabels();
+
+        actions
+            .doGetLabels(deploymentId)
+            .then(deploymentLabels => {
+                setLabels(deploymentLabels);
+                setInitialLabels(deploymentLabels);
+            })
+            .catch(error => {
+                log.error(error);
+                setErrors(i18n.t('widgets.common.labels.fetchingLabelsError', { deploymentId }));
+            })
+            .finally(unsetLoading);
+    });
+
+    function onChange(newLabels) {
+        clearErrors();
+        setLabels(newLabels);
+    }
+
+    function onApply() {
+        clearErrors();
+        setLoading();
+
+        actions.doSetLabels(deploymentId, labels).then(onHide).catch(setMessageAsError).finally(unsetLoading);
+    }
+
+    return (
+        <Modal open={open} onClose={onHide}>
+            <Modal.Header>
+                <Icon name="tags" /> {i18n.t('widgets.common.labels.modalHeader', { deploymentId })}
+            </Modal.Header>
+
+            <Modal.Content>
+                <Form loading={isLoading} errors={errors} scrollToError onErrorsDismiss={clearErrors}>
+                    <Form.Field
+                        label={i18n.t('widgets.common.labels.inputName')}
+                        help={i18n.t('widgets.common.labels.inputHelp')}
+                    >
+                        <LabelsInput initialLabels={initialLabels} onChange={onChange} toolbox={toolbox} />
+                    </Form.Field>
+                </Form>
+            </Modal.Content>
+
+            <Modal.Actions>
+                <CancelButton onClick={onHide} disabled={isLoading} />
+                <ApproveButton
+                    onClick={onApply}
+                    disabled={isLoading}
+                    content={i18n.t('widgets.common.labels.modalApplyButton')}
+                    color="green"
+                />
+            </Modal.Actions>
+        </Modal>
+    );
+}
+
+ManageLabelsModal.propTypes = {
+    deploymentId: PropTypes.string.isRequired,
+    open: PropTypes.bool.isRequired,
+    onHide: PropTypes.func.isRequired,
+    toolbox: Stage.PropTypes.Toolbox.isRequired
+};
+
+Stage.defineCommon({
+    name: 'ManageLabelsModal',
+    common: ManageLabelsModal
+});

--- a/widgets/common/src/labels/common.js
+++ b/widgets/common/src/labels/common.js
@@ -1,5 +1,5 @@
 // eslint-disable-next-line import/prefer-default-export
 export function addSearchToUrl(url, search) {
     const { appendQueryParam } = Stage.Utils.Url;
-    return search ? appendQueryParam(url, 'search', search) : url;
+    return search ? appendQueryParam(url, '_search', search) : url;
 }


### PR DESCRIPTION
https://user-images.githubusercontent.com/5202105/106861440-0cd86c80-66c6-11eb-90fa-a1f2f4ba799b.mp4

Added new component available through `Stage.Common`. It is not used anywhere yet. Manage labels button was created just for testing and video recording. Deployment labels fetch is done when modal gets opened. On Apply button click, deployment labels are updated according to changes user did. I'm planning to add Cypress tests in the next tasks when it would be accessible from the widgets.