### PR TITLE
RD-877 Fix for non-tree component graphs

### DIFF
--- a/widgets/topology/src/widget.jsx
+++ b/widgets/topology/src/widget.jsx
@@ -67,7 +67,7 @@ Stage.defineWidget({
                             );
                         })
                     )
-            ).then(componentDeploymentsData => _.merge(...componentDeploymentsData));
+            ).then(componentDeploymentsData => Object.assign({}, ...componentDeploymentsData));
         }
 
         return DataFetcher.fetch(toolbox, blueprintId, deploymentId, true)


### PR DESCRIPTION
This fix addresses both issues reported in the ticket.
Recursive `_.merge` was used where what we actually need is a shallow merge.