### PR TITLE
RD-1335 RD-1356 (master) Fix data fetching issues in DynamicDropdown component and in system tests

### DIFF
--- a/test/cypress/integration/widgets/blueprints_spec.js
+++ b/test/cypress/integration/widgets/blueprints_spec.js
@@ -1,17 +1,18 @@
 describe('Blueprints widget', () => {
     const blueprintNamePrefix = 'blueprints_test';
     const emptyBlueprintName = `${blueprintNamePrefix}_empty`;
+    const blueprintsWidgetConfiguration = { displayStyle: 'table', clickToDrillDown: true, pollingTime: 5 };
 
     before(() =>
         cy
             .activate('valid_trial_license')
             .deleteDeployments(blueprintNamePrefix, true)
             .deleteBlueprints(blueprintNamePrefix, true)
-            .usePageMock('blueprints', { displayStyle: 'table', clickToDrillDown: true })
+            .usePageMock('blueprints', blueprintsWidgetConfiguration)
             .mockLogin()
     );
 
-    beforeEach(() => cy.usePageMock('blueprints', { displayStyle: 'table', clickToDrillDown: true }).refreshTemplate());
+    beforeEach(() => cy.usePageMock('blueprints', blueprintsWidgetConfiguration).refreshTemplate());
 
     function getBlueprintRow(blueprintName) {
         cy.get('input[placeholder^=Search]').clear().type(blueprintName);

--- a/widgets/common/src/DynamicDropdown.jsx
+++ b/widgets/common/src/DynamicDropdown.jsx
@@ -102,12 +102,6 @@ function DynamicDropdown({
         }
     }, [loaderVisible]);
 
-    useEffect(() => {
-        if (fetchUrl) {
-            loadMore();
-        }
-    }, [fetchUrl]);
-
     const filteredOptions = _(options)
         .filter(option =>
             _(filter)


### PR DESCRIPTION
With https://github.com/cloudify-cosmo/cloudify-stage/pull/1157 I added `useEffect` for `fetchUrl` prop change. It was calling `loadMore()` method. This method is changing page (offset) and was designed to handle scrolling down in the dropdown to load more data. That resulted in problems in displaying list of options in dropdowns using DynamicDropdown component. Removing it for now as we don't need it, yet (Labels in UI feature is not going to be release in 5.2). 

It will be revisited how to handle changing `fetchUrl` within [RD-1271](https://cloudifysource.atlassian.net/browse/RD-1217).

This fix solves issues in the following specs:
1. widgets/filter_spec.js
2. widgets/blueprint_actions_spec.js
3. widgets/blueprint_info_spec.js
4. widgets/blueprint_sources_spec.js
5. widgets/blueprint_spec.js
6. widgets/deployment_info_spec.js
7. widgets/nodes_stats_spec.js
8. widgets/outputs_capabilities_spec.js

Once this is merged, I'll cherry pick commit from `master` branch and create PR for `5.2-build` branch.