### PR TITLE
RD-1358 - Prevent overriding app.json when uploading stage package

### DIFF
--- a/scripts/uploadPackage.sh
+++ b/scripts/uploadPackage.sh
@@ -23,7 +23,7 @@ COMMANDS_FOR_TAR_GZ="
   ${PRE_COMMANDS}
   rm -rf cloudify-stage;
   tar xzf ${STAGE_PACKAGE};
-  sudo cp /opt/cloudify-stage/conf/manager.json cloudify-stage/conf;
+  sudo cp /opt/cloudify-stage/conf/{app.json,manager.json} cloudify-stage/conf;
   sudo rm -rf /opt/cloudify-stage/;
   sudo cp -r cloudify-stage /opt/;
   sudo chown -R stage_user:stage_group /opt/cloudify-stage;


### PR DESCRIPTION
It solves the issue with `sites_spec` and `sites_map_spec`.
See: https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/150:
```
[2021-02-09T11:21:30.070Z]        Spec                                              Tests  Passing  Failing  Pending  Skipped  
[2021-02-09T11:21:30.070Z]   ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
[2021-02-09T11:21:30.070Z]   │ ✔  widgets/sites_map_spec.js                00:10        3        3        -        -        - │
[2021-02-09T11:21:30.070Z]   ├────────────────────────────────────────────────────────────────────────────────────────────────┤
[2021-02-09T11:21:30.071Z]   │ ✔  widgets/sites_spec.js                    00:20       12       12        -        -        - │
[2021-02-09T11:21:30.071Z]   └────────────────────────────────────────────────────────────────────────────────────────────────┘
[2021-02-09T11:21:30.071Z]     ✔  All specs passed!                        00:30       15       15        -        -        -  
```