### PR TITLE
RD-754 - Fix setting deploymentLabels passed to DeploymentActions.doSetLabels function

### DIFF
--- a/widgets/common/src/ManageLabelsModal.jsx
+++ b/widgets/common/src/ManageLabelsModal.jsx
@@ -40,8 +40,9 @@ function ManageLabelsModal({ deploymentId, existingLabels, header, applyButtonCo
         clearErrors();
         setLoading();
 
+        const deploymentLabels = existingLabels ? [...existingLabels, ...labels] : labels;
         actions
-            .doSetLabels(deploymentId, [...existingLabels, ...labels])
+            .doSetLabels(deploymentId, deploymentLabels)
             .then(() => {
                 // State updates should be done before calling `onHide` to avoid React errors:
                 // "Warning: Can't perform a React state update on an unmounted component"


### PR DESCRIPTION
The most recent failures in UI system tests - Deployments widget test suite - was due to an issue in `ManageLabelsModal` component.

The following error was presented in the browser console:
```
VM6267 nonIterableSpread.js:2 Uncaught TypeError: Invalid attempt to spread non-iterable instance.
In order to be iterable, non-array objects must have a [Symbol.iterator]() method.
    at _nonIterableSpread (VM3753 nonIterableSpread.js:2)
    at _toConsumableArray (VM3748 toConsumableArray.js:10)
    at Object.onApply [as onClick] (ManageLabelsModal.jsx?2976:43)
    at apply (_apply.js?798f:15)
    at baseInvoke (_baseInvoke.js?a8a3:21)
    at apply (_apply.js?798f:16)
    at eval (_overRest.js?f40b:32)
    at Button._this.handleClick (Button.js?5945:63)
    at HTMLUnknownElement.callCallback (react-dom.development.js?e444:336)
    at Object.invokeGuardedCallbackDev (react-dom.development.js?e444:385)
```

The reason for that was using spread operator on `existingLabels` prop with default value (`null`).