### PR TITLE
RD-1591 Add tests for rendering widgets recursively

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,163 @@
         "warning": "^4.0.3"
       }
     },
+    "@babel/cli": {
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.13.10.tgz",
+      "integrity": "sha512-lYSBC7B4B9hJ7sv0Ojx1BrGhuzCoOIYfLjd+Xpd4rOzdS+a47yi8voV8vFkfjlZR1N5qZO7ixOCbobUdT304PQ==",
+      "dev": true,
+      "requires": {
+        "@nicolo-ribaudo/chokidar-2": "2.1.8-no-fsevents",
+        "chokidar": "^3.4.0",
+        "commander": "^4.0.1",
+        "convert-source-map": "^1.1.0",
+        "fs-readdir-recursive": "^1.1.0",
+        "glob": "^7.0.0",
+        "lodash": "^4.17.19",
+        "make-dir": "^2.1.0",
+        "slash": "^2.0.0",
+        "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "anymatch": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+          "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "normalize-path": "^3.0.0",
+            "picomatch": "^2.0.4"
+          }
+        },
+        "binary-extensions": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+          "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+          "dev": true,
+          "optional": true
+        },
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "chokidar": {
+          "version": "3.5.1",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
+          "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "anymatch": "~3.1.1",
+            "braces": "~3.0.2",
+            "fsevents": "~2.3.1",
+            "glob-parent": "~5.1.0",
+            "is-binary-path": "~2.1.0",
+            "is-glob": "~4.0.1",
+            "normalize-path": "~3.0.0",
+            "readdirp": "~3.5.0"
+          }
+        },
+        "commander": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+          "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+          "dev": true
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "fsevents": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+          "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+          "dev": true,
+          "optional": true
+        },
+        "glob-parent": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        },
+        "is-binary-path": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+          "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "binary-extensions": "^2.0.0"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true,
+          "optional": true
+        },
+        "make-dir": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+          "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+          "dev": true,
+          "requires": {
+            "pify": "^4.0.1",
+            "semver": "^5.6.0"
+          }
+        },
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+          "dev": true
+        },
+        "readdirp": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
+          "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "picomatch": "^2.2.1"
+          }
+        },
+        "slash": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+          "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+          "dev": true
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        }
+      }
+    },
     "@babel/code-frame": {
       "version": "7.5.5",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
@@ -6033,6 +6190,26 @@
           "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
           "dev": true
         }
+      }
+    },
+    "@nicolo-ribaudo/chokidar-2": {
+      "version": "2.1.8-no-fsevents",
+      "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.tgz",
+      "integrity": "sha512-+nb9vWloHNNMFHjGofEam3wopE3m1yuambrrd/fnPc+lFOMB9ROTqQlche9ByFWNkdNqfSgR/kkQtQ8DzEWt2w==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "anymatch": "^2.0.0",
+        "async-each": "^1.0.1",
+        "braces": "^2.3.2",
+        "glob-parent": "^3.1.0",
+        "inherits": "^2.0.3",
+        "is-binary-path": "^1.0.0",
+        "is-glob": "^4.0.0",
+        "normalize-path": "^3.0.0",
+        "path-is-absolute": "^1.0.0",
+        "readdirp": "^2.2.1",
+        "upath": "^1.1.1"
       }
     },
     "@nodelib/fs.scandir": {
@@ -16153,6 +16330,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.0.1.tgz",
       "integrity": "sha512-fcSa+wyTqZa46iWweI7/ZiUfegOZl0SG8+dltIwFXo7+zYU9J9kpS3NB6pZcSlJdhvIwp81Adx2XhZorncxiaA==",
+      "dev": true
+    },
+    "fs-readdir-recursive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
+      "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
       "dev": true
     },
     "fs-write-stream-atomic": {

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "uuid": "^3.3.2"
   },
   "devDependencies": {
+    "@babel/cli": "^7.13.10",
     "@babel/core": "^7.12.10",
     "@babel/plugin-proposal-class-properties": "^7.12.1",
     "@babel/plugin-transform-runtime": "^7.12.10",

--- a/test/cypress/fixtures/babel.config.js
+++ b/test/cypress/fixtures/babel.config.js
@@ -1,0 +1,7 @@
+const mainConfig = require('../../../babel.config');
+
+module.exports = {
+    ...mainConfig,
+    // NOTE: since the files are loaded into the browser as-is, `require` is not supported
+    plugins: mainConfig.plugins.filter(pluginName => pluginName !== '@babel/plugin-transform-runtime')
+};

--- a/test/cypress/fixtures/widgets/fibonacciSequenceWidget.tsx
+++ b/test/cypress/fixtures/widgets/fibonacciSequenceWidget.tsx
@@ -30,7 +30,7 @@ Stage.defineWidget<unknown, unknown, FibonacciSequenceWidgetConfiguration>({
         }
     ],
     render: widget => {
-        const { WidgetsList } = Stage.Common;
+        const { WidgetsList } = Stage.Shared.Widgets;
         const { targetSequenceLength, sequence = initialSequence } = widget.configuration;
 
         return (

--- a/test/cypress/fixtures/widgets/fibonacciSequenceWidget.tsx
+++ b/test/cypress/fixtures/widgets/fibonacciSequenceWidget.tsx
@@ -1,0 +1,72 @@
+interface FibonacciSequenceWidgetConfiguration {
+    targetSequenceLength: number;
+    sequence?: number[];
+}
+
+const initialSequence = [1, 1];
+const widgetId = 'fibonacci-sequence-widget';
+
+/**
+ * An example widget that renders itself recursively. Each widget computes the next number in the
+ * Fibonacci sequence and displays it, while passing the sequence to the next widget, until the
+ * target sequence length is reached.
+ */
+Stage.defineWidget<unknown, unknown, FibonacciSequenceWidgetConfiguration>({
+    id: widgetId,
+    name: 'Fibonacci sequence widget',
+    isReact: true,
+    initialConfiguration: [
+        {
+            id: 'targetSequenceLength',
+            name: 'Target sequence length',
+            default: 1,
+            type: Stage.Basic.GenericField.NUMBER_TYPE
+        },
+        {
+            id: 'sequence',
+            name: 'Sequence',
+            type: Stage.Basic.GenericField.NUMBER_LIST_TYPE,
+            default: initialSequence
+        }
+    ],
+    render: widget => {
+        const { WidgetsList } = Stage.Common;
+        const { targetSequenceLength, sequence = initialSequence } = widget.configuration;
+
+        return (
+            <div>
+                Current sequence: {JSON.stringify(sequence)}
+                {sequence.length < targetSequenceLength && (
+                    <WidgetsList
+                        isEditMode={false}
+                        onWidgetRemoved={_.noop}
+                        onWidgetUpdated={_.noop}
+                        widgets={[
+                            {
+                                id: widgetId,
+                                configuration: {
+                                    targetSequenceLength,
+                                    sequence: [...sequence, getNextFibonacciNumber(sequence)]
+                                },
+                                definition: widgetId,
+                                drillDownPages: {},
+                                height: 1,
+                                width: 12,
+                                maximized: false,
+                                name: `Sequence of length ${sequence.length + 1}`,
+                                x: 0,
+                                y: 0
+                            }
+                        ]}
+                    />
+                )}
+            </div>
+        );
+    }
+});
+
+const getNextFibonacciNumber = (sequence: number[]) => {
+    const len = sequence.length;
+
+    return sequence[len - 2] + sequence[len - 1];
+};

--- a/test/cypress/fixtures/widgets/splitViewWidget.tsx
+++ b/test/cypress/fixtures/widgets/splitViewWidget.tsx
@@ -3,7 +3,7 @@ Stage.defineWidget({
     name: 'Split view widget',
     isReact: true,
     render: () => {
-        const { WidgetsGrid } = Stage.Common;
+        const { WidgetsGrid } = Stage.Shared.Widgets;
 
         return (
             <div>

--- a/test/cypress/fixtures/widgets/splitViewWidget.tsx
+++ b/test/cypress/fixtures/widgets/splitViewWidget.tsx
@@ -1,0 +1,41 @@
+Stage.defineWidget({
+    id: 'split-view-widget',
+    name: 'Split view widget',
+    isReact: true,
+    render: () => {
+        const { WidgetsGrid } = Stage.Common;
+
+        return (
+            <div>
+                This is a split view widget
+                <WidgetsGrid isEditMode={false} onGridDataChange={_.noop}>
+                    <WidgetsGrid.Item height={4} width={4} key="content-left" id="content-left">
+                        Content on the left
+                    </WidgetsGrid.Item>
+                    <WidgetsGrid.Item height={4} width={4} x={10} key="content-right" id="content-right">
+                        Content on the right, above plugins catalog
+                    </WidgetsGrid.Item>
+                    {WidgetsGrid.renderWidgetGridItem({
+                        isEditMode: false,
+                        onWidgetRemoved: _.noop,
+                        onWidgetUpdated: _.noop,
+                        widget: {
+                            id: 'pluginsCatalog',
+                            configuration: {
+                                jsonPath: 'http://repository.cloudifysource.org/cloudify/wagons/plugins.json'
+                            },
+                            definition: 'pluginsCatalog',
+                            drillDownPages: {},
+                            height: 20,
+                            width: 10,
+                            maximized: false,
+                            name: 'Plugins Catalog',
+                            x: 0,
+                            y: 4
+                        }
+                    })}
+                </WidgetsGrid>
+            </div>
+        );
+    }
+});

--- a/test/cypress/integration/widgets/user_defined_widgets_spec.ts
+++ b/test/cypress/integration/widgets/user_defined_widgets_spec.ts
@@ -1,0 +1,28 @@
+describe('User-defined widgets', () => {
+    describe('Fibonacci sequence widget', () => {
+        before(cy.activate);
+
+        beforeEach(() => {
+            cy.compileScriptFixture('widgets/fibonacciSequenceWidget.tsx').then(compiledScriptSource =>
+                cy.interceptWidgetScript('fibonacci-sequence-widget', compiledScriptSource)
+            );
+        });
+        const initialSequence = [1, 1];
+
+        it('render itself once with the initial sequence', () => {
+            cy.usePageMock('fibonacci-sequence-widget', { targetSequenceLength: initialSequence.length }).mockLogin();
+
+            cy.contains(`Current sequence: ${JSON.stringify(initialSequence)}`);
+        });
+
+        it('render itself recursively with intermediate sequences', () => {
+            const sequence = [1, 1, 2, 3, 5, 8, 13, 21, 34];
+            cy.usePageMock('fibonacci-sequence-widget', { targetSequenceLength: sequence.length }).mockLogin();
+            const initialSequenceLength = initialSequence.length;
+
+            Array.from({ length: sequence.length - initialSequenceLength }).forEach((_, index) => {
+                cy.contains(`Current sequence: ${JSON.stringify(sequence.slice(0, initialSequenceLength + index))}`);
+            });
+        });
+    });
+});

--- a/test/cypress/integration/widgets/user_defined_widgets_spec.ts
+++ b/test/cypress/integration/widgets/user_defined_widgets_spec.ts
@@ -25,4 +25,24 @@ describe('User-defined widgets', () => {
             });
         });
     });
+
+    describe('Split view widget', () => {
+        before(cy.activate);
+
+        beforeEach(() => {
+            cy.compileScriptFixture('widgets/splitViewWidget.tsx').then(compiledScriptSource =>
+                cy.interceptWidgetScript('split-view-widget', compiledScriptSource)
+            );
+        });
+
+        it('should render itself and the nested Plugins Catalog widget', () => {
+            cy.usePageMock('split-view-widget').mockLogin();
+
+            cy.contains('Content on the left');
+            cy.contains('Content on the right');
+            cy.contains('Plugins Catalog');
+            // NOTE: make sure the content of the widget is rendered
+            cy.get('th').contains('Name');
+        });
+    });
 });

--- a/test/cypress/integration/widgets/user_defined_widgets_spec.ts
+++ b/test/cypress/integration/widgets/user_defined_widgets_spec.ts
@@ -2,22 +2,21 @@ describe('User-defined widgets', () => {
     before(cy.activate);
 
     describe('Fibonacci sequence widget', () => {
-        beforeEach(() => {
-            cy.compileScriptFixture('widgets/fibonacciSequenceWidget.tsx').then(compiledScriptSource =>
-                cy.interceptWidgetScript('fibonacci-sequence-widget', compiledScriptSource)
-            );
-        });
         const initialSequence = [1, 1];
+        const widgetFixturePath = 'widgets/fibonacciSequenceWidget.tsx';
+        const widgetId = 'fibonacci-sequence-widget';
 
         it('render itself once with the initial sequence', () => {
-            cy.usePageMock('fibonacci-sequence-widget', { targetSequenceLength: initialSequence.length }).mockLogin();
+            const widgetConfiguration = { targetSequenceLength: initialSequence.length };
+            useMockWidgetFixture(widgetFixturePath, widgetId, widgetConfiguration);
 
             cy.contains(`Current sequence: ${JSON.stringify(initialSequence)}`);
         });
 
         it('render itself recursively with intermediate sequences', () => {
             const sequence = [1, 1, 2, 3, 5, 8, 13, 21, 34];
-            cy.usePageMock('fibonacci-sequence-widget', { targetSequenceLength: sequence.length }).mockLogin();
+            const widgetConfiguration = { targetSequenceLength: sequence.length };
+            useMockWidgetFixture(widgetFixturePath, widgetId, widgetConfiguration);
             const initialSequenceLength = initialSequence.length;
 
             Array.from({ length: sequence.length - initialSequenceLength }).forEach((_, index) => {
@@ -27,14 +26,11 @@ describe('User-defined widgets', () => {
     });
 
     describe('Split view widget', () => {
-        beforeEach(() => {
-            cy.compileScriptFixture('widgets/splitViewWidget.tsx').then(compiledScriptSource =>
-                cy.interceptWidgetScript('split-view-widget', compiledScriptSource)
-            );
-        });
+        const widgetFixturePath = 'widgets/splitViewWidget.tsx';
+        const widgetId = 'split-view-widget';
 
         it('should render itself and the nested Plugins Catalog widget', () => {
-            cy.usePageMock('split-view-widget').mockLogin();
+            useMockWidgetFixture(widgetFixturePath, widgetId);
 
             cy.contains('Content on the left');
             cy.contains('Content on the right');
@@ -44,3 +40,10 @@ describe('User-defined widgets', () => {
         });
     });
 });
+
+function useMockWidgetFixture(widgetFixturePath: string, widgetId: string, widgetConfiguration?: Record<string, any>) {
+    cy.compileScriptFixture(widgetFixturePath).then(compiledScriptSource =>
+        cy.interceptWidgetScript(widgetId, compiledScriptSource)
+    );
+    cy.usePageMock(widgetId, widgetConfiguration).mockLogin();
+}

--- a/test/cypress/integration/widgets/user_defined_widgets_spec.ts
+++ b/test/cypress/integration/widgets/user_defined_widgets_spec.ts
@@ -1,7 +1,7 @@
 describe('User-defined widgets', () => {
-    describe('Fibonacci sequence widget', () => {
-        before(cy.activate);
+    before(cy.activate);
 
+    describe('Fibonacci sequence widget', () => {
         beforeEach(() => {
             cy.compileScriptFixture('widgets/fibonacciSequenceWidget.tsx').then(compiledScriptSource =>
                 cy.interceptWidgetScript('fibonacci-sequence-widget', compiledScriptSource)
@@ -27,8 +27,6 @@ describe('User-defined widgets', () => {
     });
 
     describe('Split view widget', () => {
-        before(cy.activate);
-
         beforeEach(() => {
             cy.compileScriptFixture('widgets/splitViewWidget.tsx').then(compiledScriptSource =>
                 cy.interceptWidgetScript('split-view-widget', compiledScriptSource)

--- a/test/cypress/support/commands.ts
+++ b/test/cypress/support/commands.ts
@@ -274,7 +274,23 @@ const commands = {
             },
             routeHandler
         ),
-    getByTestId: (id: string) => cy.get(`[data-testid=${id}]`)
+    getByTestId: (id: string) => cy.get(`[data-testid=${id}]`),
+
+    /**
+     * Compiles a script in the fixtures directory using babel
+     *
+     * @param fixturePath Path to script in the fixtures directory
+     * @returns The compiled source
+     */
+    compileScriptFixture: (fixturePath: string) => {
+        const { fixturesFolder } = Cypress.config();
+        const scriptPath = `${fixturesFolder}/${fixturePath}`;
+        const babelConfigPath = `${fixturesFolder}/babel.config.js`;
+
+        return cy
+            .exec(`./node_modules/.bin/babel --config-file ${babelConfigPath} ${scriptPath}`)
+            .then(commandResult => commandResult.stdout);
+    }
 };
 
 addCommands(commands);

--- a/test/cypress/support/widgets.ts
+++ b/test/cypress/support/widgets.ts
@@ -1,11 +1,25 @@
-Cypress.Commands.add('getWidgets', () => cy.stageRequest('/console/widgets/list'));
+import { addCommands, GetCypressChainableFromCommands } from 'cloudify-ui-common/cypress/support';
 
-Cypress.Commands.add('removeCustomWidgets', () => {
-    (cy as any).getWidgets().then((response: any) => {
-        response.body.forEach((widget: any) => {
-            if (widget.isCustom) {
-                cy.stageRequest(`/console/widgets/${widget.id}`, 'DELETE');
-            }
+declare global {
+    namespace Cypress {
+        // NOTE: necessary for extending the Cypress API
+        // eslint-disable-next-line @typescript-eslint/no-empty-interface
+        export interface Chainable extends GetCypressChainableFromCommands<typeof commands> {}
+    }
+}
+
+const commands = {
+    getWidgets: () => cy.stageRequest('/console/widgets/list'),
+
+    removeCustomWidgets: () => {
+        cy.getWidgets().then(response => {
+            response.body.forEach((widget: Stage.Types.WidgetDefinition) => {
+                if (widget.isCustom) {
+                    cy.stageRequest(`/console/widgets/${widget.id}`, 'DELETE');
+                }
+            });
         });
-    });
-});
+    }
+};
+
+addCommands(commands);

--- a/test/cypress/support/widgets.ts
+++ b/test/cypress/support/widgets.ts
@@ -19,7 +19,13 @@ const commands = {
                 }
             });
         });
-    }
+    },
+
+    interceptWidgetScript: (widgetId: string, scriptSource: string) =>
+        cy.intercept(`/console/appData/widgets/${widgetId}/widget.js`, {
+            body: scriptSource,
+            headers: { 'Content-Type': 'application/javascript' }
+        })
 };
 
 addCommands(commands);


### PR DESCRIPTION
This PR builds upon https://github.com/cloudify-cosmo/cloudify-stage/pull/1238 and adds the tests that verify rendering nested widgets.

The tests verify that:
1. Rendering nested widgets works
2. Nested widgets can make API requests, have their own data, etc (_Plugins Catalog_ fetches and displays the list of plugins)
3. Widgets can pass configuration to nested widgets

Additional checks I have done by hand:
1. Showing nested widget's readme works
2. Interacting with the nested widget works (I wanted to install some plugin using _Plugins Catalog_)

https://user-images.githubusercontent.com/889383/110922882-8ba57280-8320-11eb-8f44-768c22a229b2.mp4



### New patterns used in this PR
1. Widgets can be rendered inside other widgets, thanks to components exposed in https://github.com/cloudify-cosmo/cloudify-stage/pull/1238
2. Custom test-only widgets are defined in `fixtures/widgets` in TypeScript. They are compiled by babel before the test starts and the compiled script is injected in the intercepted request.
    This seems to work fine, have little overhead, and improve code explorability and maintainability (can view and modify source directly, instead of zipping it)

### Known issues
1. Maximizing the nested widgets does not work.

    Even when I simulated the `onWidgetUpdate` function and changed `maximized = true` when the maximization button is pressed, the icon changed, but the component was not maximized. I didn't see a way to mitigate it and actually allow nested widgets to be maximized (this is probably related to how maximization is handled in parent components, e.g. `Page`, `PageContent`).

    Thus, I left it intact. In RD-1224 I will most likely add some `Widget` prop to hide the maximization button when it does not make sense (when rendering nested widgets).
2. The nested grid does not seem to be aligned well.
    Upon initial render, the nested grid rendered inside `SplitViewWidget` is not aligned, even though all grid-related properties (`x`, `y`, `width`, `height`) are set.

    ![image](https://user-images.githubusercontent.com/889383/110922024-80057c00-831f-11eb-8f97-687cd875aeb0.png)


    I assume this is an issue with Cypress + react-grid-layout in combination.

    The problem goes away when I click the "Toggle device toolbar" in DevTools, or switch to another page and come back (which forces the grid to remount).

    Uploading recording-2021-03-12_10.43.19.mp4…

    Thus, this is probably an issue with the tests, and will not appear in the actual app.

## Cypress test run

https://user-images.githubusercontent.com/889383/110922216-b8a55580-831f-11eb-9aa6-1d257b018bd1.mp4

![image](https://user-images.githubusercontent.com/889383/110922385-ebe7e480-831f-11eb-8a90-b78e57f9653e.png)
the blue overlay comes from Cypress' pinning the UI state

![image](https://user-images.githubusercontent.com/889383/110922412-f1452f00-831f-11eb-8b0f-94f960d51566.png)

## System tests

https://jenkins.cloudify.co/job/Stage-UI-System-Test/283/

Run 2021-03-16 14:24 CET

(failed due to errors in the Manager - the nightly build failed too. See https://github.com/cloudify-cosmo/cloudify-stage/pull/1239#issuecomment-800876704 for more information)