### PR TITLE
RD-1648 - Update deployment's test case after changes in the REST API

### DIFF
--- a/test/cypress/integration/widgets/deployment_button_spec.js
+++ b/test/cypress/integration/widgets/deployment_button_spec.js
@@ -218,7 +218,7 @@ describe('Create Deployment Button widget', () => {
             cy.wait('@deployBlueprint');
 
             cy.get('div.error.message > ul > li').should(
-                'have.text',
+                'contain.text',
                 'Value CentOS 7.6 of input string_constraint_pattern violates ' +
                     'constraint pattern(Ubuntu \\d{2}\\.\\d{2}) operator.'
             );

--- a/test/cypress/integration/widgets/deployment_button_spec.js
+++ b/test/cypress/integration/widgets/deployment_button_spec.js
@@ -196,8 +196,7 @@ describe('Create Deployment Button widget', () => {
         it('parses constraint error message from /deployments REST API', () => {
             selectBlueprintInModal('string');
 
-            const deploymentName = 'test';
-
+            const deploymentName = `${resourcePrefix}constraintError`;
             cy.interceptSp('PUT', `/deployments/${deploymentName}`).as('deployBlueprint');
 
             cy.get('input[name="deploymentName"]').type(deploymentName);


### PR DESCRIPTION
https://github.com/cloudify-cosmo/cloudify-manager/pull/2766 changed the following:
1. Reverted constraint validation in deployment API
2. Introduced a small change in the error message for the constraint validation. 

This PR adjusts our test code for the second change.

Error message is now prefixed with `dsl_parser.exceptions.ConstraintException:`:
![image](https://user-images.githubusercontent.com/5202105/110923825-9ad8f000-8321-11eb-8c75-2a406e7230ac.png)

I think we can keep that prefix. I don't think that cutting it on the UI side is good idea.
Our Stage System Tests should all pass after this PR is merged.