### PR TITLE
CY-3642 - Filter agents list by agent state

### DIFF
--- a/widgets/agents/src/widget.jsx
+++ b/widgets/agents/src/widget.jsx
@@ -12,7 +12,7 @@ Stage.defineWidget({
     initialWidth: 12,
     initialHeight: 24,
     color: 'olive',
-    fetchUrl: '[manager]/agents?[params:gridParams,deployment_id,node_ids,node_instance_ids,install_methods]',
+    fetchUrl: '[manager]/agents?[params:gridParams,deployment_id,node_ids,node_instance_ids,install_methods,state]',
     isReact: true,
     hasReadme: true,
     permission: Stage.GenericConfig.WIDGET_PERMISSION('agents'),
@@ -47,13 +47,16 @@ Stage.defineWidget({
     ],
 
     fetchParams(widget, toolbox) {
+        const agentStartedState = 'started';
+
         return {
             deployment_id: toolbox.getContext().getValue('deploymentId'),
             node_ids: toolbox.getContext().getValue('nodeId'),
             node_instance_ids: toolbox.getContext().getValue('nodeInstanceId'),
             install_methods: !_.isEmpty(widget.configuration.installMethods)
                 ? _.reject(widget.configuration.installMethods, _.isEmpty)
-                : undefined
+                : undefined,
+            state: agentStartedState
         };
     },
 


### PR DESCRIPTION
According to the description provided in the https://cloudifysource.atlassian.net/browse/CY-3642 comment I just added a query parameter to `GET /agents` request. The solution is aligned with CLI's `cfy agents list` command right now.

Unfortunately `state` field is not present in the response, so I don't see any reasonable way of testing it. 
I'm not familiar with setting up environment which provides different agents, so I asked issue reported. He promised to set up something today, so I'm going to do manual tests there.

This video shows that `state=started` is added to the URL:

https://user-images.githubusercontent.com/5202105/111127599-4c6f5f80-8574-11eb-86d3-f0c40aad222d.mp4


