### PR TITLE
RD-795 - Fix for stage-backend crash upon downloading huge files

### DIFF
--- a/backend/routes/ServerProxy.js
+++ b/backend/routes/ServerProxy.js
@@ -26,7 +26,9 @@ function errorHandler(url, res, err) {
     }
 
     logger.error(`${urlMsg} ${exMsg}`, err);
-    res.status(500).send({ message: `${urlMsg} ${exMsg}` });
+    if (!res.headersSent) {
+        res.status(500).send({ message: `${urlMsg} ${exMsg}` });
+    }
 }
 
 function buildManagerUrl(req, res, next) {


### PR DESCRIPTION
This PR provide fix for the most important issue reported within RD-795 - fixes stage-backend crashes by preventing sending headers from `ServerProxy` route when they already have been sent. This happens when e.g. timeout occurs after download has started. Timeout can occur when there is no response from the server (no more bytes sent) during 10 seconds period of time (that is default setting for GET request we have right now).