### PR TITLE
RD-1751 Add basic tests for Deployments View widget

### DIFF
--- a/app/typings/stage-api.d.ts
+++ b/app/typings/stage-api.d.ts
@@ -26,7 +26,8 @@ declare global {
 
     export const process: {
         env: {
-            NODE_ENV: string;
+            NODE_ENV: 'production' | 'development';
+            TEST: string;
             [key: string]: unknown;
         };
     };

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "docWidgets": "node scripts/updateReadmes.js",
     "e2e": "cypress run -C node_modules/cloudify-ui-common/cypress/cypress.json",
     "e2e:open": "cypress open -C node_modules/cloudify-ui-common/cypress/cypress.json",
-    "e2e:ci": "npm run beforebuild && run-system-tests ${TEST_SPEC}",
+    "e2e:ci": "npm run beforebuild && cross-env TEST=1 run-system-tests ${TEST_SPEC}",
     "lint": "eslint --cache --ignore-path .gitignore --ext js,jsx,ts,tsx --max-warnings 10 .",
     "size": "[ -d \"dist\" ] && size-limit",
     "test": "npm run test:frontend && npm run test:backend",

--- a/test/cypress/fixtures/deployments/various-statuses.json
+++ b/test/cypress/fixtures/deployments/various-statuses.json
@@ -1,0 +1,1460 @@
+{
+    "metadata": {
+        "pagination": {
+            "total": 3,
+            "size": 100,
+            "offset": 0
+        },
+        "filtered": null
+    },
+    "items": [
+        {
+            "id": "deployments_view_test_deployment",
+            "visibility": "tenant",
+            "created_at": "2021-03-18T16:40:42.323Z",
+            "description": null,
+            "inputs": {
+                "webserver_port": 9123
+            },
+            "groups": {},
+            "permalink": null,
+            "policy_triggers": {
+                "cloudify.policies.triggers.execute_workflow": {
+                    "parameters": {
+                        "workflow": {
+                            "description": "Workflow name to execute"
+                        },
+                        "workflow_parameters": {
+                            "default": {},
+                            "description": "Workflow paramters"
+                        },
+                        "force": {
+                            "default": false,
+                            "description": "Should the workflow be executed even when another execution\nfor the same workflow is currently in progress\n"
+                        },
+                        "allow_custom_parameters": {
+                            "default": false,
+                            "description": "Should parameters not defined in the workflow parameters\nschema be accepted\n"
+                        },
+                        "socket_timeout": {
+                            "default": 1000,
+                            "description": "Socket timeout when making request to manager REST in ms"
+                        },
+                        "conn_timeout": {
+                            "default": 1000,
+                            "description": "Connection timeout when making request to manager REST in ms"
+                        }
+                    },
+                    "source": "file:///opt/manager/resources/cloudify/triggers/execute_workflow.clj"
+                }
+            },
+            "policy_types": {
+                "cloudify.policies.types.host_failure": {
+                    "properties": {
+                        "policy_operates_on_group": {
+                            "default": false,
+                            "description": "If the policy should maintain its state for the whole group\nor each node instance individually.\n"
+                        },
+                        "is_node_started_before_workflow": {
+                            "default": true,
+                            "description": "Before triggering workflow, check if the node state is started"
+                        },
+                        "interval_between_workflows": {
+                            "default": 300,
+                            "description": "Trigger workflow only if the last workflow was triggered earlier than interval-between-workflows seconds ago.\nif < 0  workflows can run concurrently.\n"
+                        },
+                        "service": {
+                            "default": ["service"],
+                            "description": "Service names whose events should be taken into consideration"
+                        }
+                    },
+                    "source": "file:///opt/manager/resources/cloudify/policies/host_failure.clj"
+                },
+                "cloudify.policies.types.threshold": {
+                    "properties": {
+                        "policy_operates_on_group": {
+                            "default": false,
+                            "description": "If the policy should maintain its state for the whole group\nor each node instance individually.\n"
+                        },
+                        "is_node_started_before_workflow": {
+                            "default": true,
+                            "description": "Before triggering workflow, check if the node state is started"
+                        },
+                        "interval_between_workflows": {
+                            "default": 300,
+                            "description": "Trigger workflow only if the last workflow was triggered earlier than interval-between-workflows seconds ago.\nif < 0  workflows can run concurrently.\n"
+                        },
+                        "service": {
+                            "default": "service",
+                            "description": "The service name"
+                        },
+                        "threshold": {
+                            "description": "The metric threshold value"
+                        },
+                        "upper_bound": {
+                            "default": true,
+                            "description": "boolean value for describing the semantics of the threshold.\nif 'true': metrics whose value is bigger than the threshold will cause the triggers to be processed.\nif 'false': metrics with values lower than the threshold will do so.\n"
+                        },
+                        "stability_time": {
+                            "default": 0,
+                            "description": "How long a threshold must be breached before the triggers will be processed"
+                        }
+                    },
+                    "source": "file:///opt/manager/resources/cloudify/policies/threshold.clj"
+                },
+                "cloudify.policies.types.ewma_stabilized": {
+                    "properties": {
+                        "policy_operates_on_group": {
+                            "default": false,
+                            "description": "If the policy should maintain its state for the whole group\nor each node instance individually.\n"
+                        },
+                        "is_node_started_before_workflow": {
+                            "default": true,
+                            "description": "Before triggering workflow, check if the node state is started"
+                        },
+                        "interval_between_workflows": {
+                            "default": 300,
+                            "description": "Trigger workflow only if the last workflow was triggered earlier than interval-between-workflows seconds ago.\nif < 0  workflows can run concurrently.\n"
+                        },
+                        "service": {
+                            "default": "service",
+                            "description": "The service name"
+                        },
+                        "threshold": {
+                            "description": "The metric threshold value"
+                        },
+                        "upper_bound": {
+                            "default": true,
+                            "description": "boolean value for describing the semantics of the threshold.\nif 'true': metrics whose value is bigger than the threshold will cause the triggers to be processed.\nif 'false': metrics with values lower than the threshold will do so.\n"
+                        },
+                        "stability_time": {
+                            "default": 0,
+                            "description": "How long a threshold must be breached before the triggers will be processed"
+                        },
+                        "ewma_timeless_r": {
+                            "default": 0.5,
+                            "description": "r is the ratio between successive events. The smaller it is, the smaller impact on the computed value the most recent event has.\n"
+                        }
+                    },
+                    "source": "file:///opt/manager/resources/cloudify/policies/ewma_stabilized.clj"
+                }
+            },
+            "outputs": {
+                "application_endpoint": {
+                    "description": "The external endpoint of the application.",
+                    "value": {
+                        "concat": [
+                            "http://",
+                            {
+                                "get_attribute": ["http_web_server", "ip"]
+                            },
+                            ":",
+                            9123
+                        ]
+                    }
+                }
+            },
+            "capabilities": {},
+            "scaling_groups": {},
+            "updated_at": "2021-03-18T16:40:42.323Z",
+            "workflows": [
+                {
+                    "name": "install",
+                    "created_at": null,
+                    "plugin": "default_workflows",
+                    "operation": "cloudify.plugins.workflows.install",
+                    "parameters": {}
+                },
+                {
+                    "name": "update",
+                    "created_at": null,
+                    "plugin": "default_workflows",
+                    "operation": "cloudify.plugins.workflows.update",
+                    "parameters": {
+                        "update_id": {
+                            "default": ""
+                        },
+                        "skip_install": {
+                            "default": false
+                        },
+                        "skip_uninstall": {
+                            "default": false
+                        },
+                        "added_instance_ids": {
+                            "default": [],
+                            "type": "list"
+                        },
+                        "added_target_instances_ids": {
+                            "default": [],
+                            "type": "list"
+                        },
+                        "removed_instance_ids": {
+                            "default": [],
+                            "type": "list"
+                        },
+                        "remove_target_instance_ids": {
+                            "default": [],
+                            "type": "list"
+                        },
+                        "modified_entity_ids": {
+                            "default": [],
+                            "type": "list"
+                        },
+                        "extended_instance_ids": {
+                            "default": [],
+                            "type": "list"
+                        },
+                        "extend_target_instance_ids": {
+                            "default": [],
+                            "type": "list"
+                        },
+                        "reduced_instance_ids": {
+                            "default": [],
+                            "type": "list"
+                        },
+                        "reduce_target_instance_ids": {
+                            "default": [],
+                            "type": "list"
+                        },
+                        "ignore_failure": {
+                            "default": false,
+                            "type": "boolean"
+                        },
+                        "install_first": {
+                            "default": false,
+                            "type": "boolean"
+                        },
+                        "node_instances_to_reinstall": {
+                            "default": [],
+                            "type": "list"
+                        },
+                        "central_plugins_to_install": {
+                            "default": [],
+                            "type": "list"
+                        },
+                        "central_plugins_to_uninstall": {
+                            "default": [],
+                            "type": "list"
+                        },
+                        "update_plugins": {
+                            "default": true,
+                            "type": "boolean"
+                        }
+                    }
+                },
+                {
+                    "name": "uninstall",
+                    "created_at": null,
+                    "plugin": "default_workflows",
+                    "operation": "cloudify.plugins.workflows.uninstall",
+                    "parameters": {
+                        "ignore_failure": {
+                            "default": false,
+                            "type": "boolean"
+                        }
+                    }
+                },
+                {
+                    "name": "start",
+                    "created_at": null,
+                    "plugin": "default_workflows",
+                    "operation": "cloudify.plugins.workflows.start",
+                    "parameters": {
+                        "operation_parms": {
+                            "default": {}
+                        },
+                        "run_by_dependency_order": {
+                            "default": true
+                        },
+                        "type_names": {
+                            "default": []
+                        },
+                        "node_ids": {
+                            "default": []
+                        },
+                        "node_instance_ids": {
+                            "default": []
+                        }
+                    }
+                },
+                {
+                    "name": "stop",
+                    "created_at": null,
+                    "plugin": "default_workflows",
+                    "operation": "cloudify.plugins.workflows.stop",
+                    "parameters": {
+                        "operation_parms": {
+                            "default": {}
+                        },
+                        "run_by_dependency_order": {
+                            "default": true
+                        },
+                        "type_names": {
+                            "default": []
+                        },
+                        "node_ids": {
+                            "default": []
+                        },
+                        "node_instance_ids": {
+                            "default": []
+                        }
+                    }
+                },
+                {
+                    "name": "restart",
+                    "created_at": null,
+                    "plugin": "default_workflows",
+                    "operation": "cloudify.plugins.workflows.restart",
+                    "parameters": {
+                        "stop_parms": {
+                            "default": {}
+                        },
+                        "start_parms": {
+                            "default": {}
+                        },
+                        "run_by_dependency_order": {
+                            "default": true
+                        },
+                        "type_names": {
+                            "default": []
+                        },
+                        "node_ids": {
+                            "default": []
+                        },
+                        "node_instance_ids": {
+                            "default": []
+                        }
+                    }
+                },
+                {
+                    "name": "execute_operation",
+                    "created_at": null,
+                    "plugin": "default_workflows",
+                    "operation": "cloudify.plugins.workflows.execute_operation",
+                    "parameters": {
+                        "operation": {},
+                        "operation_kwargs": {
+                            "default": {}
+                        },
+                        "allow_kwargs_override": {
+                            "default": null
+                        },
+                        "run_by_dependency_order": {
+                            "default": false
+                        },
+                        "type_names": {
+                            "default": []
+                        },
+                        "node_ids": {
+                            "default": []
+                        },
+                        "node_instance_ids": {
+                            "default": []
+                        }
+                    }
+                },
+                {
+                    "name": "heal",
+                    "created_at": null,
+                    "plugin": "default_workflows",
+                    "operation": "cloudify.plugins.workflows.auto_heal_reinstall_node_subgraph",
+                    "parameters": {
+                        "node_instance_id": {
+                            "description": "Which node instance has failed"
+                        },
+                        "diagnose_value": {
+                            "default": "Not provided",
+                            "description": "Diagnosed reason of failure"
+                        },
+                        "ignore_failure": {
+                            "default": true,
+                            "type": "boolean"
+                        }
+                    }
+                },
+                {
+                    "name": "scale",
+                    "created_at": null,
+                    "plugin": "default_workflows",
+                    "operation": "cloudify.plugins.workflows.scale_entity",
+                    "parameters": {
+                        "scalable_entity_name": {
+                            "description": "Which node/group to scale. Note that the parameter specified should denote the node/group name and NOT the node/group instance id.\n"
+                        },
+                        "delta": {
+                            "default": 1,
+                            "description": "How many node/group instances should be added/removed. A positive number denotes increase of instances. A negative number denotes decrease of instances.\n",
+                            "type": "integer"
+                        },
+                        "scale_compute": {
+                            "default": false,
+                            "description": "If a node name is passed as the `scalable_entity_name` parameter and that node is contained (transitively) within a compute node and this property is 'true', operate on the compute node instead of the specified node.\n"
+                        },
+                        "include_instances": {
+                            "default": null,
+                            "description": "A node instance ID or list of node instance IDs to prioritise for scaling down. If a larger amount of included instances are provided than the delta then one of the included instances will be scaled down while the others will be ignored. If a smaller amount of included instances are provided than the delta then the remaining instances will be selected arbitrarily. This is only valid for scaling down and cannot be used with scale_compute set to true.\n"
+                        },
+                        "exclude_instances": {
+                            "default": null,
+                            "description": "A node instance ID or list of node instance IDs which must not be removed when scaling down. If the amount of excluded instances plus the absolute delta is equal to or greater than the total amount of instances then the scaling operation will fail and no nodes will be scaled down. This is only valid for scaling down and cannot be used with scale_compute set to true.\n"
+                        },
+                        "ignore_failure": {
+                            "default": false,
+                            "type": "boolean"
+                        },
+                        "rollback_if_failed": {
+                            "default": true,
+                            "description": "If this is False then no rollback will be triggered when an error occurs during the workflow, otherwise the rollback will be triggered.\n"
+                        },
+                        "abort_started": {
+                            "default": false,
+                            "description": "Remove any started deployment modifications created prior to the scaling workflow.\n",
+                            "type": "boolean"
+                        }
+                    }
+                },
+                {
+                    "name": "install_new_agents",
+                    "created_at": null,
+                    "plugin": "default_workflows",
+                    "operation": "cloudify.plugins.workflows.install_new_agents",
+                    "parameters": {
+                        "install_agent_timeout": {
+                            "default": 300
+                        },
+                        "node_ids": {
+                            "default": []
+                        },
+                        "node_instance_ids": {
+                            "default": []
+                        },
+                        "install_methods": {
+                            "default": null
+                        },
+                        "validate": {
+                            "default": true,
+                            "type": "boolean"
+                        },
+                        "install": {
+                            "default": true,
+                            "type": "boolean"
+                        },
+                        "install_script": {
+                            "default": ""
+                        },
+                        "manager_ip": {
+                            "default": "",
+                            "description": "The private ip of the new manager"
+                        },
+                        "manager_certificate": {
+                            "default": "",
+                            "description": "The cloudify_internal_ca_cert.pem of the new manager"
+                        },
+                        "stop_old_agent": {
+                            "default": false,
+                            "description": "Stop the old agent after the new agent is installed",
+                            "type": "boolean"
+                        }
+                    }
+                },
+                {
+                    "name": "validate_agents",
+                    "created_at": null,
+                    "plugin": "default_workflows",
+                    "operation": "cloudify.plugins.workflows.validate_agents",
+                    "parameters": {
+                        "node_ids": {
+                            "default": []
+                        },
+                        "node_instance_ids": {
+                            "default": []
+                        },
+                        "install_methods": {
+                            "default": null
+                        }
+                    }
+                }
+            ],
+            "runtime_only_evaluation": false,
+            "installation_status": "inactive",
+            "deployment_status": "requires_attention",
+            "blueprint_id": "deployments_view_test_blueprint",
+            "site_name": "Olsztyn",
+            "tenant_name": "default_tenant",
+            "created_by": "admin",
+            "resource_availability": "tenant",
+            "private_resource": false,
+            "labels": [],
+            "deployment_groups": [],
+            "latest_execution_status": "completed"
+        },
+
+        {
+            "id": "one-in-warsaw",
+            "visibility": "tenant",
+            "created_at": "2021-03-17T09:26:58.116Z",
+            "description": null,
+            "inputs": {
+                "webserver_port": 8000
+            },
+            "groups": {},
+            "permalink": null,
+            "policy_triggers": {
+                "cloudify.policies.triggers.execute_workflow": {
+                    "parameters": {
+                        "workflow": {
+                            "description": "Workflow name to execute"
+                        },
+                        "workflow_parameters": {
+                            "default": {},
+                            "description": "Workflow paramters"
+                        },
+                        "force": {
+                            "default": false,
+                            "description": "Should the workflow be executed even when another execution\nfor the same workflow is currently in progress\n"
+                        },
+                        "allow_custom_parameters": {
+                            "default": false,
+                            "description": "Should parameters not defined in the workflow parameters\nschema be accepted\n"
+                        },
+                        "socket_timeout": {
+                            "default": 1000,
+                            "description": "Socket timeout when making request to manager REST in ms"
+                        },
+                        "conn_timeout": {
+                            "default": 1000,
+                            "description": "Connection timeout when making request to manager REST in ms"
+                        }
+                    },
+                    "source": "file:///opt/manager/resources/cloudify/triggers/execute_workflow.clj"
+                }
+            },
+            "policy_types": {
+                "cloudify.policies.types.host_failure": {
+                    "properties": {
+                        "policy_operates_on_group": {
+                            "default": false,
+                            "description": "If the policy should maintain its state for the whole group\nor each node instance individually.\n"
+                        },
+                        "is_node_started_before_workflow": {
+                            "default": true,
+                            "description": "Before triggering workflow, check if the node state is started"
+                        },
+                        "interval_between_workflows": {
+                            "default": 300,
+                            "description": "Trigger workflow only if the last workflow was triggered earlier than interval-between-workflows seconds ago.\nif < 0  workflows can run concurrently.\n"
+                        },
+                        "service": {
+                            "default": ["service"],
+                            "description": "Service names whose events should be taken into consideration"
+                        }
+                    },
+                    "source": "file:///opt/manager/resources/cloudify/policies/host_failure.clj"
+                },
+                "cloudify.policies.types.threshold": {
+                    "properties": {
+                        "policy_operates_on_group": {
+                            "default": false,
+                            "description": "If the policy should maintain its state for the whole group\nor each node instance individually.\n"
+                        },
+                        "is_node_started_before_workflow": {
+                            "default": true,
+                            "description": "Before triggering workflow, check if the node state is started"
+                        },
+                        "interval_between_workflows": {
+                            "default": 300,
+                            "description": "Trigger workflow only if the last workflow was triggered earlier than interval-between-workflows seconds ago.\nif < 0  workflows can run concurrently.\n"
+                        },
+                        "service": {
+                            "default": "service",
+                            "description": "The service name"
+                        },
+                        "threshold": {
+                            "description": "The metric threshold value"
+                        },
+                        "upper_bound": {
+                            "default": true,
+                            "description": "boolean value for describing the semantics of the threshold.\nif 'true': metrics whose value is bigger than the threshold will cause the triggers to be processed.\nif 'false': metrics with values lower than the threshold will do so.\n"
+                        },
+                        "stability_time": {
+                            "default": 0,
+                            "description": "How long a threshold must be breached before the triggers will be processed"
+                        }
+                    },
+                    "source": "file:///opt/manager/resources/cloudify/policies/threshold.clj"
+                },
+                "cloudify.policies.types.ewma_stabilized": {
+                    "properties": {
+                        "policy_operates_on_group": {
+                            "default": false,
+                            "description": "If the policy should maintain its state for the whole group\nor each node instance individually.\n"
+                        },
+                        "is_node_started_before_workflow": {
+                            "default": true,
+                            "description": "Before triggering workflow, check if the node state is started"
+                        },
+                        "interval_between_workflows": {
+                            "default": 300,
+                            "description": "Trigger workflow only if the last workflow was triggered earlier than interval-between-workflows seconds ago.\nif < 0  workflows can run concurrently.\n"
+                        },
+                        "service": {
+                            "default": "service",
+                            "description": "The service name"
+                        },
+                        "threshold": {
+                            "description": "The metric threshold value"
+                        },
+                        "upper_bound": {
+                            "default": true,
+                            "description": "boolean value for describing the semantics of the threshold.\nif 'true': metrics whose value is bigger than the threshold will cause the triggers to be processed.\nif 'false': metrics with values lower than the threshold will do so.\n"
+                        },
+                        "stability_time": {
+                            "default": 0,
+                            "description": "How long a threshold must be breached before the triggers will be processed"
+                        },
+                        "ewma_timeless_r": {
+                            "default": 0.5,
+                            "description": "r is the ratio between successive events. The smaller it is, the smaller impact on the computed value the most recent event has.\n"
+                        }
+                    },
+                    "source": "file:///opt/manager/resources/cloudify/policies/ewma_stabilized.clj"
+                }
+            },
+            "outputs": {
+                "application_endpoint": {
+                    "description": "The external endpoint of the application.",
+                    "value": {
+                        "concat": [
+                            "http://",
+                            {
+                                "get_attribute": ["http_web_server", "ip"]
+                            },
+                            ":",
+                            8000
+                        ]
+                    }
+                }
+            },
+            "capabilities": {},
+            "scaling_groups": {},
+            "updated_at": "2021-03-17T09:26:58.116Z",
+            "workflows": [
+                {
+                    "name": "install",
+                    "created_at": null,
+                    "plugin": "default_workflows",
+                    "operation": "cloudify.plugins.workflows.install",
+                    "parameters": {}
+                },
+                {
+                    "name": "update",
+                    "created_at": null,
+                    "plugin": "default_workflows",
+                    "operation": "cloudify.plugins.workflows.update",
+                    "parameters": {
+                        "update_id": {
+                            "default": ""
+                        },
+                        "skip_install": {
+                            "default": false
+                        },
+                        "skip_uninstall": {
+                            "default": false
+                        },
+                        "added_instance_ids": {
+                            "default": [],
+                            "type": "list"
+                        },
+                        "added_target_instances_ids": {
+                            "default": [],
+                            "type": "list"
+                        },
+                        "removed_instance_ids": {
+                            "default": [],
+                            "type": "list"
+                        },
+                        "remove_target_instance_ids": {
+                            "default": [],
+                            "type": "list"
+                        },
+                        "modified_entity_ids": {
+                            "default": [],
+                            "type": "list"
+                        },
+                        "extended_instance_ids": {
+                            "default": [],
+                            "type": "list"
+                        },
+                        "extend_target_instance_ids": {
+                            "default": [],
+                            "type": "list"
+                        },
+                        "reduced_instance_ids": {
+                            "default": [],
+                            "type": "list"
+                        },
+                        "reduce_target_instance_ids": {
+                            "default": [],
+                            "type": "list"
+                        },
+                        "ignore_failure": {
+                            "default": false,
+                            "type": "boolean"
+                        },
+                        "install_first": {
+                            "default": false,
+                            "type": "boolean"
+                        },
+                        "node_instances_to_reinstall": {
+                            "default": [],
+                            "type": "list"
+                        },
+                        "central_plugins_to_install": {
+                            "default": [],
+                            "type": "list"
+                        },
+                        "central_plugins_to_uninstall": {
+                            "default": [],
+                            "type": "list"
+                        },
+                        "update_plugins": {
+                            "default": true,
+                            "type": "boolean"
+                        }
+                    }
+                },
+                {
+                    "name": "uninstall",
+                    "created_at": null,
+                    "plugin": "default_workflows",
+                    "operation": "cloudify.plugins.workflows.uninstall",
+                    "parameters": {
+                        "ignore_failure": {
+                            "default": false,
+                            "type": "boolean"
+                        }
+                    }
+                },
+                {
+                    "name": "start",
+                    "created_at": null,
+                    "plugin": "default_workflows",
+                    "operation": "cloudify.plugins.workflows.start",
+                    "parameters": {
+                        "operation_parms": {
+                            "default": {}
+                        },
+                        "run_by_dependency_order": {
+                            "default": true
+                        },
+                        "type_names": {
+                            "default": []
+                        },
+                        "node_ids": {
+                            "default": []
+                        },
+                        "node_instance_ids": {
+                            "default": []
+                        }
+                    }
+                },
+                {
+                    "name": "stop",
+                    "created_at": null,
+                    "plugin": "default_workflows",
+                    "operation": "cloudify.plugins.workflows.stop",
+                    "parameters": {
+                        "operation_parms": {
+                            "default": {}
+                        },
+                        "run_by_dependency_order": {
+                            "default": true
+                        },
+                        "type_names": {
+                            "default": []
+                        },
+                        "node_ids": {
+                            "default": []
+                        },
+                        "node_instance_ids": {
+                            "default": []
+                        }
+                    }
+                },
+                {
+                    "name": "restart",
+                    "created_at": null,
+                    "plugin": "default_workflows",
+                    "operation": "cloudify.plugins.workflows.restart",
+                    "parameters": {
+                        "stop_parms": {
+                            "default": {}
+                        },
+                        "start_parms": {
+                            "default": {}
+                        },
+                        "run_by_dependency_order": {
+                            "default": true
+                        },
+                        "type_names": {
+                            "default": []
+                        },
+                        "node_ids": {
+                            "default": []
+                        },
+                        "node_instance_ids": {
+                            "default": []
+                        }
+                    }
+                },
+                {
+                    "name": "execute_operation",
+                    "created_at": null,
+                    "plugin": "default_workflows",
+                    "operation": "cloudify.plugins.workflows.execute_operation",
+                    "parameters": {
+                        "operation": {},
+                        "operation_kwargs": {
+                            "default": {}
+                        },
+                        "allow_kwargs_override": {
+                            "default": null
+                        },
+                        "run_by_dependency_order": {
+                            "default": false
+                        },
+                        "type_names": {
+                            "default": []
+                        },
+                        "node_ids": {
+                            "default": []
+                        },
+                        "node_instance_ids": {
+                            "default": []
+                        }
+                    }
+                },
+                {
+                    "name": "heal",
+                    "created_at": null,
+                    "plugin": "default_workflows",
+                    "operation": "cloudify.plugins.workflows.auto_heal_reinstall_node_subgraph",
+                    "parameters": {
+                        "node_instance_id": {
+                            "description": "Which node instance has failed"
+                        },
+                        "diagnose_value": {
+                            "default": "Not provided",
+                            "description": "Diagnosed reason of failure"
+                        },
+                        "ignore_failure": {
+                            "default": true,
+                            "type": "boolean"
+                        }
+                    }
+                },
+                {
+                    "name": "scale",
+                    "created_at": null,
+                    "plugin": "default_workflows",
+                    "operation": "cloudify.plugins.workflows.scale_entity",
+                    "parameters": {
+                        "scalable_entity_name": {
+                            "description": "Which node/group to scale. Note that the parameter specified should denote the node/group name and NOT the node/group instance id.\n"
+                        },
+                        "delta": {
+                            "default": 1,
+                            "description": "How many node/group instances should be added/removed. A positive number denotes increase of instances. A negative number denotes decrease of instances.\n",
+                            "type": "integer"
+                        },
+                        "scale_compute": {
+                            "default": false,
+                            "description": "If a node name is passed as the `scalable_entity_name` parameter and that node is contained (transitively) within a compute node and this property is 'true', operate on the compute node instead of the specified node.\n"
+                        },
+                        "include_instances": {
+                            "default": null,
+                            "description": "A node instance ID or list of node instance IDs to prioritise for scaling down. If a larger amount of included instances are provided than the delta then one of the included instances will be scaled down while the others will be ignored. If a smaller amount of included instances are provided than the delta then the remaining instances will be selected arbitrarily. This is only valid for scaling down and cannot be used with scale_compute set to true.\n"
+                        },
+                        "exclude_instances": {
+                            "default": null,
+                            "description": "A node instance ID or list of node instance IDs which must not be removed when scaling down. If the amount of excluded instances plus the absolute delta is equal to or greater than the total amount of instances then the scaling operation will fail and no nodes will be scaled down. This is only valid for scaling down and cannot be used with scale_compute set to true.\n"
+                        },
+                        "ignore_failure": {
+                            "default": false,
+                            "type": "boolean"
+                        },
+                        "rollback_if_failed": {
+                            "default": true,
+                            "description": "If this is False then no rollback will be triggered when an error occurs during the workflow, otherwise the rollback will be triggered.\n"
+                        },
+                        "abort_started": {
+                            "default": false,
+                            "description": "Remove any started deployment modifications created prior to the scaling workflow.\n",
+                            "type": "boolean"
+                        }
+                    }
+                },
+                {
+                    "name": "install_new_agents",
+                    "created_at": null,
+                    "plugin": "default_workflows",
+                    "operation": "cloudify.plugins.workflows.install_new_agents",
+                    "parameters": {
+                        "install_agent_timeout": {
+                            "default": 300
+                        },
+                        "node_ids": {
+                            "default": []
+                        },
+                        "node_instance_ids": {
+                            "default": []
+                        },
+                        "install_methods": {
+                            "default": null
+                        },
+                        "validate": {
+                            "default": true,
+                            "type": "boolean"
+                        },
+                        "install": {
+                            "default": true,
+                            "type": "boolean"
+                        },
+                        "install_script": {
+                            "default": ""
+                        },
+                        "manager_ip": {
+                            "default": "",
+                            "description": "The private ip of the new manager"
+                        },
+                        "manager_certificate": {
+                            "default": "",
+                            "description": "The cloudify_internal_ca_cert.pem of the new manager"
+                        },
+                        "stop_old_agent": {
+                            "default": false,
+                            "description": "Stop the old agent after the new agent is installed",
+                            "type": "boolean"
+                        }
+                    }
+                },
+                {
+                    "name": "validate_agents",
+                    "created_at": null,
+                    "plugin": "default_workflows",
+                    "operation": "cloudify.plugins.workflows.validate_agents",
+                    "parameters": {
+                        "node_ids": {
+                            "default": []
+                        },
+                        "node_instance_ids": {
+                            "default": []
+                        },
+                        "install_methods": {
+                            "default": null
+                        }
+                    }
+                }
+            ],
+            "runtime_only_evaluation": false,
+            "installation_status": "active",
+            "deployment_status": "good",
+            "blueprint_id": "Cloudify-Hello-World",
+            "site_name": null,
+            "tenant_name": "default_tenant",
+            "created_by": "admin",
+            "resource_availability": "tenant",
+            "private_resource": false,
+            "labels": [
+                {
+                    "key": "abc",
+                    "value": "value",
+                    "created_at": "2021-03-17T09:26:58.136Z",
+                    "creator_id": 0
+                }
+            ],
+            "deployment_groups": [],
+            "latest_execution_status": "completed"
+        },
+        {
+            "id": "hello-world-one",
+            "visibility": "tenant",
+            "created_at": "2021-03-17T09:20:26.103Z",
+            "description": null,
+            "inputs": {
+                "webserver_port": 8000
+            },
+            "groups": {},
+            "permalink": null,
+            "policy_triggers": {
+                "cloudify.policies.triggers.execute_workflow": {
+                    "parameters": {
+                        "workflow": {
+                            "description": "Workflow name to execute"
+                        },
+                        "workflow_parameters": {
+                            "default": {},
+                            "description": "Workflow paramters"
+                        },
+                        "force": {
+                            "default": false,
+                            "description": "Should the workflow be executed even when another execution\nfor the same workflow is currently in progress\n"
+                        },
+                        "allow_custom_parameters": {
+                            "default": false,
+                            "description": "Should parameters not defined in the workflow parameters\nschema be accepted\n"
+                        },
+                        "socket_timeout": {
+                            "default": 1000,
+                            "description": "Socket timeout when making request to manager REST in ms"
+                        },
+                        "conn_timeout": {
+                            "default": 1000,
+                            "description": "Connection timeout when making request to manager REST in ms"
+                        }
+                    },
+                    "source": "file:///opt/manager/resources/cloudify/triggers/execute_workflow.clj"
+                }
+            },
+            "policy_types": {
+                "cloudify.policies.types.host_failure": {
+                    "properties": {
+                        "policy_operates_on_group": {
+                            "default": false,
+                            "description": "If the policy should maintain its state for the whole group\nor each node instance individually.\n"
+                        },
+                        "is_node_started_before_workflow": {
+                            "default": true,
+                            "description": "Before triggering workflow, check if the node state is started"
+                        },
+                        "interval_between_workflows": {
+                            "default": 300,
+                            "description": "Trigger workflow only if the last workflow was triggered earlier than interval-between-workflows seconds ago.\nif < 0  workflows can run concurrently.\n"
+                        },
+                        "service": {
+                            "default": ["service"],
+                            "description": "Service names whose events should be taken into consideration"
+                        }
+                    },
+                    "source": "file:///opt/manager/resources/cloudify/policies/host_failure.clj"
+                },
+                "cloudify.policies.types.threshold": {
+                    "properties": {
+                        "policy_operates_on_group": {
+                            "default": false,
+                            "description": "If the policy should maintain its state for the whole group\nor each node instance individually.\n"
+                        },
+                        "is_node_started_before_workflow": {
+                            "default": true,
+                            "description": "Before triggering workflow, check if the node state is started"
+                        },
+                        "interval_between_workflows": {
+                            "default": 300,
+                            "description": "Trigger workflow only if the last workflow was triggered earlier than interval-between-workflows seconds ago.\nif < 0  workflows can run concurrently.\n"
+                        },
+                        "service": {
+                            "default": "service",
+                            "description": "The service name"
+                        },
+                        "threshold": {
+                            "description": "The metric threshold value"
+                        },
+                        "upper_bound": {
+                            "default": true,
+                            "description": "boolean value for describing the semantics of the threshold.\nif 'true': metrics whose value is bigger than the threshold will cause the triggers to be processed.\nif 'false': metrics with values lower than the threshold will do so.\n"
+                        },
+                        "stability_time": {
+                            "default": 0,
+                            "description": "How long a threshold must be breached before the triggers will be processed"
+                        }
+                    },
+                    "source": "file:///opt/manager/resources/cloudify/policies/threshold.clj"
+                },
+                "cloudify.policies.types.ewma_stabilized": {
+                    "properties": {
+                        "policy_operates_on_group": {
+                            "default": false,
+                            "description": "If the policy should maintain its state for the whole group\nor each node instance individually.\n"
+                        },
+                        "is_node_started_before_workflow": {
+                            "default": true,
+                            "description": "Before triggering workflow, check if the node state is started"
+                        },
+                        "interval_between_workflows": {
+                            "default": 300,
+                            "description": "Trigger workflow only if the last workflow was triggered earlier than interval-between-workflows seconds ago.\nif < 0  workflows can run concurrently.\n"
+                        },
+                        "service": {
+                            "default": "service",
+                            "description": "The service name"
+                        },
+                        "threshold": {
+                            "description": "The metric threshold value"
+                        },
+                        "upper_bound": {
+                            "default": true,
+                            "description": "boolean value for describing the semantics of the threshold.\nif 'true': metrics whose value is bigger than the threshold will cause the triggers to be processed.\nif 'false': metrics with values lower than the threshold will do so.\n"
+                        },
+                        "stability_time": {
+                            "default": 0,
+                            "description": "How long a threshold must be breached before the triggers will be processed"
+                        },
+                        "ewma_timeless_r": {
+                            "default": 0.5,
+                            "description": "r is the ratio between successive events. The smaller it is, the smaller impact on the computed value the most recent event has.\n"
+                        }
+                    },
+                    "source": "file:///opt/manager/resources/cloudify/policies/ewma_stabilized.clj"
+                }
+            },
+            "outputs": {
+                "application_endpoint": {
+                    "description": "The external endpoint of the application.",
+                    "value": {
+                        "concat": [
+                            "http://",
+                            {
+                                "get_attribute": ["http_web_server", "ip"]
+                            },
+                            ":",
+                            8000
+                        ]
+                    }
+                }
+            },
+            "capabilities": {},
+            "scaling_groups": {},
+            "updated_at": "2021-03-17T09:20:26.103Z",
+            "workflows": [
+                {
+                    "name": "install",
+                    "created_at": null,
+                    "plugin": "default_workflows",
+                    "operation": "cloudify.plugins.workflows.install",
+                    "parameters": {}
+                },
+                {
+                    "name": "update",
+                    "created_at": null,
+                    "plugin": "default_workflows",
+                    "operation": "cloudify.plugins.workflows.update",
+                    "parameters": {
+                        "update_id": {
+                            "default": ""
+                        },
+                        "skip_install": {
+                            "default": false
+                        },
+                        "skip_uninstall": {
+                            "default": false
+                        },
+                        "added_instance_ids": {
+                            "default": [],
+                            "type": "list"
+                        },
+                        "added_target_instances_ids": {
+                            "default": [],
+                            "type": "list"
+                        },
+                        "removed_instance_ids": {
+                            "default": [],
+                            "type": "list"
+                        },
+                        "remove_target_instance_ids": {
+                            "default": [],
+                            "type": "list"
+                        },
+                        "modified_entity_ids": {
+                            "default": [],
+                            "type": "list"
+                        },
+                        "extended_instance_ids": {
+                            "default": [],
+                            "type": "list"
+                        },
+                        "extend_target_instance_ids": {
+                            "default": [],
+                            "type": "list"
+                        },
+                        "reduced_instance_ids": {
+                            "default": [],
+                            "type": "list"
+                        },
+                        "reduce_target_instance_ids": {
+                            "default": [],
+                            "type": "list"
+                        },
+                        "ignore_failure": {
+                            "default": false,
+                            "type": "boolean"
+                        },
+                        "install_first": {
+                            "default": false,
+                            "type": "boolean"
+                        },
+                        "node_instances_to_reinstall": {
+                            "default": [],
+                            "type": "list"
+                        },
+                        "central_plugins_to_install": {
+                            "default": [],
+                            "type": "list"
+                        },
+                        "central_plugins_to_uninstall": {
+                            "default": [],
+                            "type": "list"
+                        },
+                        "update_plugins": {
+                            "default": true,
+                            "type": "boolean"
+                        }
+                    }
+                },
+                {
+                    "name": "uninstall",
+                    "created_at": null,
+                    "plugin": "default_workflows",
+                    "operation": "cloudify.plugins.workflows.uninstall",
+                    "parameters": {
+                        "ignore_failure": {
+                            "default": false,
+                            "type": "boolean"
+                        }
+                    }
+                },
+                {
+                    "name": "start",
+                    "created_at": null,
+                    "plugin": "default_workflows",
+                    "operation": "cloudify.plugins.workflows.start",
+                    "parameters": {
+                        "operation_parms": {
+                            "default": {}
+                        },
+                        "run_by_dependency_order": {
+                            "default": true
+                        },
+                        "type_names": {
+                            "default": []
+                        },
+                        "node_ids": {
+                            "default": []
+                        },
+                        "node_instance_ids": {
+                            "default": []
+                        }
+                    }
+                },
+                {
+                    "name": "stop",
+                    "created_at": null,
+                    "plugin": "default_workflows",
+                    "operation": "cloudify.plugins.workflows.stop",
+                    "parameters": {
+                        "operation_parms": {
+                            "default": {}
+                        },
+                        "run_by_dependency_order": {
+                            "default": true
+                        },
+                        "type_names": {
+                            "default": []
+                        },
+                        "node_ids": {
+                            "default": []
+                        },
+                        "node_instance_ids": {
+                            "default": []
+                        }
+                    }
+                },
+                {
+                    "name": "restart",
+                    "created_at": null,
+                    "plugin": "default_workflows",
+                    "operation": "cloudify.plugins.workflows.restart",
+                    "parameters": {
+                        "stop_parms": {
+                            "default": {}
+                        },
+                        "start_parms": {
+                            "default": {}
+                        },
+                        "run_by_dependency_order": {
+                            "default": true
+                        },
+                        "type_names": {
+                            "default": []
+                        },
+                        "node_ids": {
+                            "default": []
+                        },
+                        "node_instance_ids": {
+                            "default": []
+                        }
+                    }
+                },
+                {
+                    "name": "execute_operation",
+                    "created_at": null,
+                    "plugin": "default_workflows",
+                    "operation": "cloudify.plugins.workflows.execute_operation",
+                    "parameters": {
+                        "operation": {},
+                        "operation_kwargs": {
+                            "default": {}
+                        },
+                        "allow_kwargs_override": {
+                            "default": null
+                        },
+                        "run_by_dependency_order": {
+                            "default": false
+                        },
+                        "type_names": {
+                            "default": []
+                        },
+                        "node_ids": {
+                            "default": []
+                        },
+                        "node_instance_ids": {
+                            "default": []
+                        }
+                    }
+                },
+                {
+                    "name": "heal",
+                    "created_at": null,
+                    "plugin": "default_workflows",
+                    "operation": "cloudify.plugins.workflows.auto_heal_reinstall_node_subgraph",
+                    "parameters": {
+                        "node_instance_id": {
+                            "description": "Which node instance has failed"
+                        },
+                        "diagnose_value": {
+                            "default": "Not provided",
+                            "description": "Diagnosed reason of failure"
+                        },
+                        "ignore_failure": {
+                            "default": true,
+                            "type": "boolean"
+                        }
+                    }
+                },
+                {
+                    "name": "scale",
+                    "created_at": null,
+                    "plugin": "default_workflows",
+                    "operation": "cloudify.plugins.workflows.scale_entity",
+                    "parameters": {
+                        "scalable_entity_name": {
+                            "description": "Which node/group to scale. Note that the parameter specified should denote the node/group name and NOT the node/group instance id.\n"
+                        },
+                        "delta": {
+                            "default": 1,
+                            "description": "How many node/group instances should be added/removed. A positive number denotes increase of instances. A negative number denotes decrease of instances.\n",
+                            "type": "integer"
+                        },
+                        "scale_compute": {
+                            "default": false,
+                            "description": "If a node name is passed as the `scalable_entity_name` parameter and that node is contained (transitively) within a compute node and this property is 'true', operate on the compute node instead of the specified node.\n"
+                        },
+                        "include_instances": {
+                            "default": null,
+                            "description": "A node instance ID or list of node instance IDs to prioritise for scaling down. If a larger amount of included instances are provided than the delta then one of the included instances will be scaled down while the others will be ignored. If a smaller amount of included instances are provided than the delta then the remaining instances will be selected arbitrarily. This is only valid for scaling down and cannot be used with scale_compute set to true.\n"
+                        },
+                        "exclude_instances": {
+                            "default": null,
+                            "description": "A node instance ID or list of node instance IDs which must not be removed when scaling down. If the amount of excluded instances plus the absolute delta is equal to or greater than the total amount of instances then the scaling operation will fail and no nodes will be scaled down. This is only valid for scaling down and cannot be used with scale_compute set to true.\n"
+                        },
+                        "ignore_failure": {
+                            "default": false,
+                            "type": "boolean"
+                        },
+                        "rollback_if_failed": {
+                            "default": true,
+                            "description": "If this is False then no rollback will be triggered when an error occurs during the workflow, otherwise the rollback will be triggered.\n"
+                        },
+                        "abort_started": {
+                            "default": false,
+                            "description": "Remove any started deployment modifications created prior to the scaling workflow.\n",
+                            "type": "boolean"
+                        }
+                    }
+                },
+                {
+                    "name": "install_new_agents",
+                    "created_at": null,
+                    "plugin": "default_workflows",
+                    "operation": "cloudify.plugins.workflows.install_new_agents",
+                    "parameters": {
+                        "install_agent_timeout": {
+                            "default": 300
+                        },
+                        "node_ids": {
+                            "default": []
+                        },
+                        "node_instance_ids": {
+                            "default": []
+                        },
+                        "install_methods": {
+                            "default": null
+                        },
+                        "validate": {
+                            "default": true,
+                            "type": "boolean"
+                        },
+                        "install": {
+                            "default": true,
+                            "type": "boolean"
+                        },
+                        "install_script": {
+                            "default": ""
+                        },
+                        "manager_ip": {
+                            "default": "",
+                            "description": "The private ip of the new manager"
+                        },
+                        "manager_certificate": {
+                            "default": "",
+                            "description": "The cloudify_internal_ca_cert.pem of the new manager"
+                        },
+                        "stop_old_agent": {
+                            "default": false,
+                            "description": "Stop the old agent after the new agent is installed",
+                            "type": "boolean"
+                        }
+                    }
+                },
+                {
+                    "name": "validate_agents",
+                    "created_at": null,
+                    "plugin": "default_workflows",
+                    "operation": "cloudify.plugins.workflows.validate_agents",
+                    "parameters": {
+                        "node_ids": {
+                            "default": []
+                        },
+                        "node_instance_ids": {
+                            "default": []
+                        },
+                        "install_methods": {
+                            "default": null
+                        }
+                    }
+                }
+            ],
+            "runtime_only_evaluation": false,
+            "installation_status": "active",
+            "deployment_status": "in_progress",
+            "blueprint_id": "Cloudify-Hello-World",
+            "site_name": null,
+            "tenant_name": "default_tenant",
+            "created_by": "admin",
+            "resource_availability": "tenant",
+            "private_resource": false,
+            "labels": [],
+            "deployment_groups": [],
+            "latest_execution_status": "completed"
+        }
+    ]
+}

--- a/test/cypress/integration/widgets/deployments_view_spec.ts
+++ b/test/cypress/integration/widgets/deployments_view_spec.ts
@@ -1,0 +1,36 @@
+describe('Deployments View widget', () => {
+    const blueprintName = 'deployments_view_test';
+    const deploymentName = 'deployments_view_test_dep';
+    const siteName = 'Olsztyn';
+    const blueprintUrl =
+        'https://github.com/cloudify-community/blueprint-examples/releases/download/latest/simple-hello-world-example.zip';
+
+    before(() => {
+        cy.activate()
+            .deleteSites(siteName)
+            .deleteDeployments(deploymentName, true)
+            .deleteBlueprints(blueprintName, true)
+            .uploadBlueprint(blueprintUrl, blueprintName)
+            .deployBlueprint(blueprintName, deploymentName, { webserver_port: 9123 })
+            .createSite({ name: siteName })
+            .setSite(deploymentName, siteName);
+    });
+
+    beforeEach(() => {
+        cy.interceptSp('GET', 'deployments').as('deployments');
+        // NOTE: add widget through Edit Mode to apply default configuration automatically
+        cy.usePageMock([], {}, ['deploymentsView']).mockLogin().addWidget('deploymentsView');
+    });
+
+    // TODO: test changing the visible columns in the configuration
+
+    it('should display the deployments', () => {
+        cy.wait('@deployments');
+
+        cy.get('tr').within(() => {
+            cy.contains(deploymentName);
+            cy.contains(blueprintName);
+            cy.contains(siteName);
+        });
+    });
+});

--- a/test/cypress/integration/widgets/deployments_view_spec.ts
+++ b/test/cypress/integration/widgets/deployments_view_spec.ts
@@ -10,8 +10,8 @@ describe('Deployments View widget', () => {
 
     before(() => {
         cy.activate()
-            .deleteSites(siteName)
             .deleteDeployments(deploymentName, true)
+            .deleteSites(siteName)
             .deleteBlueprints(blueprintName, true)
             .uploadBlueprint(blueprintUrl, blueprintName)
             .deployBlueprint(blueprintName, deploymentName, { webserver_port: 9123 })

--- a/test/cypress/integration/widgets/deployments_view_spec.ts
+++ b/test/cypress/integration/widgets/deployments_view_spec.ts
@@ -77,5 +77,29 @@ describe('Deployments View widget', () => {
         });
     });
 
-    it('should display various deployment statuses', () => {});
+    it('should display various deployment statuses', () => {
+        useDeploymentsViewWidget({
+            fixture: 'deployments/various-statuses.json'
+        });
+
+        getDeploymentsViewTable().within(() => {
+            cy.contains('deployments_view_test_deployment')
+                .parents('tr')
+                .find('i.exclamation[aria-label="Requires attention"]')
+                .as('requiresAttentionIcon')
+                .trigger('mouseover');
+            cy.root().parents('body').find('.popup').contains('Requires attention');
+            cy.get('@requiresAttentionIcon').trigger('mouseout');
+
+            cy.contains('hello-world-one')
+                .parents('tr')
+                .find('i.spinner[aria-label="In progress"]')
+                .as('inProgressIcon')
+                .trigger('mouseover');
+            cy.root().parents('body').find('.popup').contains('In progress');
+            cy.get('@inProgressIcon').trigger('mouseout');
+
+            cy.contains('one-in-warsaw').parents('tr').find('td:nth-child(1) i').should('not.exist');
+        });
+    });
 });

--- a/test/cypress/integration/widgets/deployments_view_spec.ts
+++ b/test/cypress/integration/widgets/deployments_view_spec.ts
@@ -7,6 +7,14 @@ describe('Deployments View widget', () => {
     const siteName = 'Olsztyn';
     const blueprintUrl =
         'https://github.com/cloudify-community/blueprint-examples/releases/download/latest/simple-hello-world-example.zip';
+    const widgetConfiguration = {
+        filterByParentDeployment: false,
+        fieldsToShow: ['status', 'name', 'blueprintName', 'location', 'subenvironmentsCount', 'subservicesCount'],
+        pageSize: 100,
+        pollingTime: 10,
+        sortColumn: 'created_at',
+        sortAscending: false
+    };
 
     before(() => {
         cy.activate()
@@ -21,12 +29,11 @@ describe('Deployments View widget', () => {
 
     const useDeploymentsViewWidget = (routeHandler?: RouteHandler) => {
         cy.interceptSp('GET', 'deployments', routeHandler).as('deployments');
-        // NOTE: add widget through Edit Mode to apply default configuration automatically
-        cy.usePageMock([], {}, [widgetId]).mockLogin().addWidget(widgetId);
+        cy.usePageMock([widgetId], widgetConfiguration).mockLogin();
         cy.wait('@deployments');
     };
 
-    const getDeploymentsViewTable = () => cy.contains('Deployments view').parents('.widgetItem');
+    const getDeploymentsViewTable = () => cy.get('.deploymentsViewWidget .widgetItem');
 
     describe('configuration', () => {
         const getFieldsDropdown = () =>

--- a/test/cypress/support/commands.ts
+++ b/test/cypress/support/commands.ts
@@ -176,13 +176,14 @@ const commands = {
         }
         cy.waitUntilPageLoaded();
     },
-    usePageMock: (widgetIds?: string | string[], widgetConfiguration: any = {}) => {
+    usePageMock: (
+        widgetIds?: string | string[],
+        widgetConfiguration: any = {},
+        additionalWidgetIdsToLoad: string[] = []
+    ) => {
         const widgetIdsArray = _.castArray(widgetIds);
-        cy.intercept(
-            'GET',
-            '/console/widgets/list',
-            widgetIds ? [...widgetIdsArray, 'filter', 'pluginsCatalog'].map(toIdObj) : []
-        );
+        const widgetIdsToLoad = [...widgetIdsArray, 'filter', 'pluginsCatalog', ...additionalWidgetIdsToLoad];
+        cy.intercept('GET', '/console/widgets/list', widgetIdsToLoad.map(toIdObj));
         // required for drill-down testing
         cy.intercept('GET', '/console/templates/pages', widgetIds ? ['blueprint', 'deployment'].map(toIdObj) : []);
         cy.intercept('GET', '/console/templates', []);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -120,7 +120,8 @@ module.exports = (env, argv) => {
                   })
               ];
     const environmentPlugin = new webpack.EnvironmentPlugin({
-        NODE_ENV: 'development'
+        NODE_ENV: 'production',
+        TEST: ''
     });
 
     if (isProduction && fs.existsSync(outputPath)) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -217,9 +217,9 @@ module.exports = (env, argv) => {
                             }
                         }
                     }),
+                    environmentPlugin,
                     isProduction && getProductionPlugins(env && env.analyse === 'main')
-                ]),
-                environmentPlugin
+                ])
             )
         },
         {
@@ -269,9 +269,9 @@ module.exports = (env, argv) => {
                             }
                         }
                     }),
+                    environmentPlugin,
                     isProduction && getProductionPlugins(env && env.analyse === 'widgets')
-                ]),
-                environmentPlugin
+                ])
             ),
             externals
         },
@@ -294,8 +294,8 @@ module.exports = (env, argv) => {
             },
             module,
             plugins: [
-                ...(isProduction ? getProductionPlugins(env && env.analyse === 'widgets-common') : []),
-                environmentPlugin
+                environmentPlugin,
+                ...(isProduction ? getProductionPlugins(env && env.analyse === 'widgets-common') : [])
             ],
             externals
         }

--- a/widgets/deploymentsView/src/widget.tsx
+++ b/widgets/deploymentsView/src/widget.tsx
@@ -59,7 +59,7 @@ if (process.env.NODE_ENV === 'development' || process.env.TEST) {
                     name: deploymentsViewColumnDefinitions[columnId].name,
                     value: columnId
                 })),
-                default: Object.values(deploymentsViewColumnIds).filter(columnId => columnId !== 'environmentType'),
+                default: deploymentsViewColumnIds.filter(columnId => columnId !== 'environmentType'),
                 type: Stage.Basic.GenericField.MULTI_SELECT_LIST_TYPE
             },
             Stage.GenericConfig.PAGE_SIZE_CONFIG(100),

--- a/widgets/deploymentsView/src/widget.tsx
+++ b/widgets/deploymentsView/src/widget.tsx
@@ -24,8 +24,8 @@ interface DeploymentsViewWidgetConfiguration {
 
 const i18nPrefix = 'widgets.deploymentsView';
 
-// TODO(RD-1224): remove environment check
-if (process.env.NODE_ENV === 'development') {
+// TODO(RD-1226): remove environment check
+if (process.env.NODE_ENV === 'development' || process.env.TEST) {
     Stage.defineWidget<GridParams, DeploymentsResponse, DeploymentsViewWidgetConfiguration>({
         id: 'deploymentsView',
         name: Stage.i18n.t(`${i18nPrefix}.name`),


### PR DESCRIPTION
The PR adds a few basic tests for the Deployments View widget.

Don't be afraid by the number of lines added :smile: Most of them come from the test fixture for deployments

All passed locally:
![image](https://user-images.githubusercontent.com/889383/111670404-17833700-8818-11eb-90f9-5704aa994d0f.png)

## Changes in this PR

1. Migrate the sites commands to TypeScript

    Sites commands are used in the new test suite.

2. Basic tests:

    1. The created deployment is displayed in the table
    2. Hiding and showing columns (`fieldsToShow` in the widget configuration) is working correctly
    3. The deployment status icon is displayed correctly and has a popup

    I have tried to make the tests rely on accessible properties (`aria-label`, `role`, text), rather than classes. I think I managed to do that well, except for a few cases :slightly_smiling_face: 

    The added fixture will make it easier to test functionalities such as displaying the number and statuses of subdeployments, and the latest execution progress. Those will be implemented and tested in future tickets.

3. Add handling `process.env.TEST` (set to `'1'` during e2e tests)

    Necessary to get `deploymentsViewWidget` to render during system tests.

    I was hoping to set `process.env.NODE_ENV` to `test` during e2e tests, but webpack overrides `process.env.NODE_ENV` based on the `mode` it runs in. Thus, in e2e tests it always has `process.env.NODE_ENV === 'production'` :worried: 

    To verify that it does not break production, I ran the production build locally and here's the value of `process.env.TEST`:
    ![image](https://user-images.githubusercontent.com/889383/111771167-a4c39b80-88ab-11eb-9352-864cb143a6eb.png)


## System tests

https://jenkins.cloudify.co/job/Stage-UI-System-Test/315/

Ran 2021-03-23 10:56 CET