### PR TITLE
RD-1786 Show Environment Type column

### DIFF
--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -557,7 +557,7 @@
             },
             "columns": {
                 "status": {
-                    "name": "",
+                    "name": "Status",
                     "iconLabels": {
                         "inProgress": "In progress",
                         "requiresAttention": "Requires attention"

--- a/test/cypress/fixtures/deployments/various-statuses.json
+++ b/test/cypress/fixtures/deployments/various-statuses.json
@@ -486,7 +486,8 @@
             "private_resource": false,
             "labels": [],
             "deployment_groups": [],
-            "latest_execution_status": "completed"
+            "latest_execution_status": "completed",
+            "environment_type": "controller"
         },
 
         {
@@ -974,7 +975,8 @@
                 }
             ],
             "deployment_groups": [],
-            "latest_execution_status": "completed"
+            "latest_execution_status": "completed",
+            "environment_type": "subcloud"
         },
         {
             "id": "hello-world-one",
@@ -1454,7 +1456,8 @@
             "private_resource": false,
             "labels": [],
             "deployment_groups": [],
-            "latest_execution_status": "completed"
+            "latest_execution_status": "completed",
+            "environment_type": "acidic"
         }
     ]
 }

--- a/test/cypress/integration/widgets/deployments_view_spec.ts
+++ b/test/cypress/integration/widgets/deployments_view_spec.ts
@@ -85,7 +85,7 @@ describe('Deployments View widget', () => {
         });
     });
 
-    it('should display various deployment statuses', () => {
+    it('should display various deployment information', () => {
         useDeploymentsViewWidget({
             routeHandler: {
                 fixture: 'deployments/various-statuses.json'
@@ -101,41 +101,45 @@ describe('Deployments View widget', () => {
             widgetConfiguration.toggleFieldsDropdown();
         });
 
-        getDeploymentsViewTable().within(() => {
-            cy.contains('deployments_view_test_deployment')
-                .parents('tr')
-                .find('i.exclamation[aria-label="Requires attention"]')
-                .as('requiresAttentionIcon')
-                .trigger('mouseover');
-            cy.root().parents('body').find('.popup').contains('Requires attention');
-            cy.get('@requiresAttentionIcon').trigger('mouseout');
-
-            cy.contains('hello-world-one')
-                .parents('tr')
-                .find('i.spinner[aria-label="In progress"]')
-                .as('inProgressIcon')
-                .trigger('mouseover');
-            cy.root().parents('body').find('.popup').contains('In progress');
-            cy.get('@inProgressIcon').trigger('mouseout');
-
-            cy.contains('one-in-warsaw').parents('tr').find('td:nth-child(1) i').should('not.exist');
-        });
+        const verifyDeploymentInformation = ({ environmentType }: { environmentType: string }) => {
+            cy.contains(environmentType);
+        };
 
         getDeploymentsViewTable().within(() => {
             cy.contains('deployments_view_test_deployment')
                 .parents('tr')
                 .within(() => {
-                    cy.contains('controller');
+                    cy.get('i.exclamation[aria-label="Requires attention"]')
+                        .as('requiresAttentionIcon')
+                        .trigger('mouseover');
+                    cy.root().parents('body').find('.popup').contains('Requires attention');
+                    cy.get('@requiresAttentionIcon').trigger('mouseout');
+
+                    verifyDeploymentInformation({
+                        environmentType: 'controller'
+                    });
                 });
+
+            cy.contains('hello-world-one')
+                .parents('tr')
+                .within(() => {
+                    cy.get('i.spinner[aria-label="In progress"]').as('inProgressIcon').trigger('mouseover');
+                    cy.root().parents('body').find('.popup').contains('In progress');
+                    cy.get('@inProgressIcon').trigger('mouseout');
+
+                    verifyDeploymentInformation({
+                        environmentType: 'acidic'
+                    });
+                });
+
             cy.contains('one-in-warsaw')
                 .parents('tr')
                 .within(() => {
-                    cy.contains('subcloud');
-                });
-            cy.contains('hello-world-one')
-                .parents('tr')
-                .within(() => {
-                    cy.contains('acidic');
+                    cy.get('td:nth-child(1) i').should('not.exist');
+
+                    verifyDeploymentInformation({
+                        environmentType: 'subcloud'
+                    });
                 });
         });
     });

--- a/test/cypress/integration/widgets/deployments_view_spec.ts
+++ b/test/cypress/integration/widgets/deployments_view_spec.ts
@@ -92,6 +92,15 @@ describe('Deployments View widget', () => {
             }
         });
 
+        cy.log('Show all columns');
+        cy.editWidgetConfiguration(widgetId, () => {
+            widgetConfiguration.toggleFieldsDropdown();
+            widgetConfiguration.getFieldsDropdown().within(() => {
+                cy.get('[role="option"]').contains('Environment Type').click();
+            });
+            widgetConfiguration.toggleFieldsDropdown();
+        });
+
         getDeploymentsViewTable().within(() => {
             cy.contains('deployments_view_test_deployment')
                 .parents('tr')
@@ -110,6 +119,24 @@ describe('Deployments View widget', () => {
             cy.get('@inProgressIcon').trigger('mouseout');
 
             cy.contains('one-in-warsaw').parents('tr').find('td:nth-child(1) i').should('not.exist');
+        });
+
+        getDeploymentsViewTable().within(() => {
+            cy.contains('deployments_view_test_deployment')
+                .parents('tr')
+                .within(() => {
+                    cy.contains('controller');
+                });
+            cy.contains('one-in-warsaw')
+                .parents('tr')
+                .within(() => {
+                    cy.contains('subcloud');
+                });
+            cy.contains('hello-world-one')
+                .parents('tr')
+                .within(() => {
+                    cy.contains('acidic');
+                });
         });
     });
 });

--- a/test/cypress/integration/widgets/deployments_view_spec.ts
+++ b/test/cypress/integration/widgets/deployments_view_spec.ts
@@ -39,11 +39,12 @@ describe('Deployments View widget', () => {
 
     const getDeploymentsViewTable = () => cy.get('.deploymentsViewWidget .widgetItem');
 
-    describe('configuration', () => {
-        const getFieldsDropdown = () =>
-            cy.contains('List of fields to show in the table').parent().find('[role="listbox"]');
-        const toggleFieldsDropdown = () => getFieldsDropdown().find('.dropdown.icon').click();
+    const widgetConfigurationHelpers = {
+        getFieldsDropdown: () => cy.contains('List of fields to show in the table').parent().find('[role="listbox"]'),
+        toggleFieldsDropdown: () => widgetConfigurationHelpers.getFieldsDropdown().find('.dropdown.icon').click()
+    };
 
+    describe('configuration', () => {
         it('should allow changing displayed columns', () => {
             useDeploymentsViewWidget({
                 configurationOverrides: {
@@ -59,11 +60,11 @@ describe('Deployments View widget', () => {
 
             cy.log('Show some columns');
             cy.editWidgetConfiguration(widgetId, () => {
-                toggleFieldsDropdown();
-                getFieldsDropdown().within(() => {
+                widgetConfigurationHelpers.toggleFieldsDropdown();
+                widgetConfigurationHelpers.getFieldsDropdown().within(() => {
                     cy.get('[role="option"]').contains('Blueprint Name').click();
                 });
-                toggleFieldsDropdown();
+                widgetConfigurationHelpers.toggleFieldsDropdown();
             });
 
             getDeploymentsViewTable().within(() => {

--- a/test/cypress/integration/widgets/deployments_view_spec.ts
+++ b/test/cypress/integration/widgets/deployments_view_spec.ts
@@ -94,11 +94,11 @@ describe('Deployments View widget', () => {
 
         cy.log('Show all columns');
         cy.editWidgetConfiguration(widgetId, () => {
-            widgetConfiguration.toggleFieldsDropdown();
-            widgetConfiguration.getFieldsDropdown().within(() => {
+            widgetConfigurationHelpers.toggleFieldsDropdown();
+            widgetConfigurationHelpers.getFieldsDropdown().within(() => {
                 cy.get('[role="option"]').contains('Environment Type').click();
             });
-            widgetConfiguration.toggleFieldsDropdown();
+            widgetConfigurationHelpers.toggleFieldsDropdown();
         });
 
         const verifyDeploymentInformation = ({ environmentType }: { environmentType: string }) => {

--- a/widgets/deploymentsView/src/columns.tsx
+++ b/widgets/deploymentsView/src/columns.tsx
@@ -55,7 +55,9 @@ const partialDeploymentsViewColumnDefinitions: Record<
                     {label}
                 </Popup>
             );
-        }
+        },
+        // NOTE: do not show the column label
+        label: ''
     },
     name: {
         sortFieldName: 'id',

--- a/widgets/deploymentsView/src/columns.tsx
+++ b/widgets/deploymentsView/src/columns.tsx
@@ -72,9 +72,9 @@ const partialDeploymentsViewColumnDefinitions: Record<
         }
     },
     environmentType: {
-        render(_deployment) {
-            // TODO(RD-1224): add rendering correct environment type
-            return 'Environment Type';
+        sortFieldName: 'environment_type',
+        render(deployment) {
+            return deployment.environment_type;
         }
     },
     location: {

--- a/widgets/deploymentsView/src/widget.tsx
+++ b/widgets/deploymentsView/src/widget.tsx
@@ -1,6 +1,7 @@
 import { deploymentsViewColumnDefinitions, DeploymentsViewColumnId, deploymentsViewColumnIds } from './columns';
 import renderDeploymentRow from './renderDeploymentRow';
 import './styles.scss';
+import type { Deployment } from './types';
 
 interface GridParams {
     _offset: number;
@@ -9,7 +10,7 @@ interface GridParams {
 }
 
 interface DeploymentsResponse {
-    items: any[];
+    items: Deployment[];
     metadata: any;
 }
 
@@ -114,7 +115,6 @@ if (process.env.NODE_ENV === 'development' || process.env.TEST) {
                         );
                     })}
 
-                    {/* TODO(RD-1224): add type for deployment */}
                     {data.items.flatMap(renderDeploymentRow(toolbox, fieldsToShow))}
                 </DataTable>
             );


### PR DESCRIPTION
This PR adds support for showing data in the Environment Type column in the Deployments View.

I hope the commit log gives enough guidance about the changes :slightly_smiling_face: 

One unrelated change was fixing the way the "Status" column was presented in the widget's configuration modal (it was empty).

The functionality is covered by a Cypress test. So far, the backend does not return the `environment_type` property, so it's tested only using the mocked fixture.

## System tests

https://jenkins.cloudify.co/job/Stage-UI-System-Test/301/

Ran 2021-03-19 16:50 CET