### PR TITLE
RD-916 - Add security attributes to all used cookies

### DIFF
--- a/backend/routes/Auth.js
+++ b/backend/routes/Auth.js
@@ -22,7 +22,7 @@ router.use(bodyParser.urlencoded({ extended: true }));
 router.post('/login', (req, res) =>
     AuthHandler.getToken(req.headers.authorization)
         .then(token => {
-            res.cookie(Consts.TOKEN_COOKIE_NAME, token.value);
+            res.cookie(Consts.TOKEN_COOKIE_NAME, token.value, { sameSite: 'strict' });
             res.send({ role: token.role });
         })
         .catch(err => {
@@ -44,9 +44,9 @@ router.post('/saml/callback', passport.authenticate('saml', { session: false }),
         logger.debug('Received SAML Response for user', req.user);
         AuthHandler.getTokenViaSamlResponse(req.body.SAMLResponse)
             .then(token => {
-                res.cookie(Consts.TOKEN_COOKIE_NAME, token.value);
-                res.cookie(Consts.USERNAME_COOKIE_NAME, req.user.username);
-                res.cookie(Consts.ROLE_COOKIE_NAME, token.role);
+                res.cookie(Consts.TOKEN_COOKIE_NAME, token.value, { sameSite: 'strict' });
+                res.cookie(Consts.USERNAME_COOKIE_NAME, req.user.username, { sameSite: 'strict' });
+                res.cookie(Consts.ROLE_COOKIE_NAME, token.role, { sameSite: 'strict' });
                 res.redirect(Consts.CONTEXT_PATH);
             })
             .catch(err => {

--- a/backend/routes/Auth.js
+++ b/backend/routes/Auth.js
@@ -20,7 +20,7 @@ router.use(bodyParser.json());
 router.use(bodyParser.urlencoded({ extended: true }));
 
 function getCookieOptions(req) {
-    const httpsUsed = req.headers['X-Scheme'] === 'https';
+    const httpsUsed = req.header('X-Scheme') === 'https';
     return { sameSite: 'strict', secure: httpsUsed };
 }
 

--- a/backend/test/routes/Auth.test.js
+++ b/backend/test/routes/Auth.test.js
@@ -176,9 +176,9 @@ describe('/auth endpoint', () => {
                     const { location, 'set-cookie': setCookie } = response.headers;
                     expect(location).toEqual('/console');
                     expect(setCookie).toEqual([
-                        'XSRF-TOKEN=token-content; Path=/',
-                        'USERNAME=testuser; Path=/',
-                        'ROLE=sys_admin; Path=/'
+                        'XSRF-TOKEN=token-content; Path=/; SameSite=Strict',
+                        'USERNAME=testuser; Path=/; SameSite=Strict',
+                        'ROLE=sys_admin; Path=/; SameSite=Strict'
                     ]);
                 });
         });


### PR DESCRIPTION
This PR adds security-related attributes to all cookies we create inside Stage app:
* `SameSite=Strict`
* `Secure` if Cloudify is in SSL mode. On the frontend side we check that using `X-Scheme` header.
NOTE: `X-Scheme` header is only available in production environment (with nginx web server). 

More about SSL mode in Cloudify: https://docs.cloudify.co/latest/install_maintain/manager_architecture/security/#ssl-mode-for-external-communication.

Cookies in SSL mode with Okta authentication enabled:
![image](https://user-images.githubusercontent.com/5202105/112149149-f8e9bb00-8bde-11eb-891d-8dd4e885cb5c.png)


TODO:
* [x] Run Stage System Tests
* [x] Run Composer System Tests
* [x] Manually check Okta integration
* [x] Manually verify solution on Cloudify Manager in SSL mode