### PR TITLE
RD-1803 - Fix Deployment Action Buttons widget test

### DIFF
--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -465,7 +465,7 @@
                 "newValue": "New value",
                 "valuePlaceholder": "Select or type in a value",
                 "validationError": "Only letters, digits and the characters \"-\", \".\" and \"_\" are allowed and it must begin with a letter.",
-                "invalidKeyError": "Allowed `{{ keyPrefix }}` prefixed labels are: {{ reservedKeys }}. All other `{{ keyPrefix }}` prefixed labels are reserved for internal use and cannot be added.",
+                "invalidKeyError": "All labels starting with `{{ keyPrefix }}` are reserved for internal usage and should not be used unless there is a need to override default functionality. The following labels are allowed for such override: {{ reservedKeys }}.",
                 "input": {
                     "label": "Labels",
                     "help": "A list of labels - key-value pairs - that can be assigned with a deployment"

--- a/test/cypress/integration/widgets/deployment_actions_spec.js
+++ b/test/cypress/integration/widgets/deployment_actions_spec.js
@@ -147,10 +147,7 @@ describe('Deployment Action Buttons widget', () => {
 
         it('prevents adding label with not permitted key', () => {
             function checkIfInternalKeyIsNotPermitted(key) {
-                checkIfPopupIsDisplayed(
-                    key,
-                    'All other `csys-` prefixed labels are reserved for internal use and cannot be added.'
-                );
+                checkIfPopupIsDisplayed(key, 'All labels starting with `csys-` are reserved for internal usage');
                 typeLabelValue('a');
                 cy.get('button[aria-label=Add]').should('have.attr', 'disabled');
             }


### PR DESCRIPTION
Tested locally. All green in `test/cypress/integration/widgets/deployment_actions_spec.js`.