### PR TITLE
RD-1743 Use existing table features in Deployments View table

### DIFF
--- a/app/components/WidgetDynamicContent.jsx
+++ b/app/components/WidgetDynamicContent.jsx
@@ -296,7 +296,7 @@ export default class WidgetDynamicContent extends Component {
         const { loading } = this.state;
         const baseWidgetContentClassName = combineClassNames([
             'widgetContent',
-            widget.definition.showHeader ? '' : 'noHeader'
+            !widget.definition.showHeader && 'noHeader'
         ]);
 
         return (
@@ -313,7 +313,7 @@ export default class WidgetDynamicContent extends Component {
                     <div
                         className={combineClassNames([
                             baseWidgetContentClassName,
-                            widget.definition.showBorder ? '' : 'noBorder'
+                            !widget.definition.showBorder && 'noBorder'
                         ])}
                     >
                         {this.renderReact()}

--- a/app/components/WidgetDynamicContent.jsx
+++ b/app/components/WidgetDynamicContent.jsx
@@ -11,6 +11,7 @@ import { getToolbox } from '../utils/Toolbox';
 import WidgetParamsHandler from '../utils/WidgetParamsHandler';
 import { ErrorMessage } from './basic';
 import WidgetPropType from '../utils/props/WidgetPropType';
+import combineClassNames from '../utils/shared/combineClassNames';
 
 export default class WidgetDynamicContent extends Component {
     constructor(props) {
@@ -293,25 +294,33 @@ export default class WidgetDynamicContent extends Component {
     render() {
         const { widget } = this.props;
         const { loading } = this.state;
+        const baseWidgetContentClassName = combineClassNames([
+            'widgetContent',
+            widget.definition.showHeader ? '' : 'noHeader'
+        ]);
+
         return (
             <div>
                 <div
-                    className={`ui ${loading ? 'active' : ''} small inline loader widgetLoader ${
+                    className={combineClassNames([
+                        'ui small inline loader widgetLoader',
+                        loading && 'active',
                         widget.definition.showHeader ? 'header' : 'noheader'
-                    }`}
+                    ])}
                 />
 
                 {widget.definition.isReact ? (
                     <div
-                        className={`widgetContent${widget.definition.showHeader ? '' : ' noHeader '}${
-                            widget.definition.showBorder ? '' : ' noBorder '
-                        }`}
+                        className={combineClassNames([
+                            baseWidgetContentClassName,
+                            widget.definition.showBorder ? '' : 'noBorder'
+                        ])}
                     >
                         {this.renderReact()}
                     </div>
                 ) : (
                     <div
-                        className={`widgetContent${widget.definition.showHeader ? '' : ' noHeader'}`}
+                        className={baseWidgetContentClassName}
                         /* eslint-disable-next-line react/no-danger */
                         dangerouslySetInnerHTML={this.renderWidget()}
                         ref={container => this.attachEvents(container)}

--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -583,7 +583,8 @@
                     "name": "Subservices",
                     "tooltip": "Services (Total)"
                 }
-            }
+            },
+            "noDataMessage": "No Results Found. Try changing the filter's parameters"
         },
         "labels": {
             "name": "Labels",

--- a/widgets/deploymentsView/src/columns.tsx
+++ b/widgets/deploymentsView/src/columns.tsx
@@ -87,7 +87,7 @@ const partialDeploymentsViewColumnDefinitions: Record<
         label: <Stage.Basic.Icon name="object group" />,
         width: '1em',
         render() {
-            // TODO(RD-1224): display correct number of subenvironments
+            // TODO(RD-1742): display correct number of subenvironments and their status
             return '0';
         }
     },
@@ -95,7 +95,7 @@ const partialDeploymentsViewColumnDefinitions: Record<
         label: <Stage.Basic.Icon name="cube" />,
         width: '1em',
         render() {
-            // TODO(RD-1224): display correct number of subservices
+            // TODO(RD-1742): display correct number of subservices and their status
             return '0';
         }
     }

--- a/widgets/deploymentsView/src/renderDeploymentRow.tsx
+++ b/widgets/deploymentsView/src/renderDeploymentRow.tsx
@@ -32,7 +32,7 @@ export default renderDeploymentRow;
 
 function getDeploymentProgressUnderline(_deployment: any): ReactNode {
     if (Math.random() < 0.5) {
-        // TODO(RD-1224): adjust states to match the ones returned from API
+        // TODO(RD-1741): adjust states to match the ones returned from API
         const deploymentStates = ['in-progress', 'pending', 'failure'];
         // NOTE: random state for now
         const state = deploymentStates[Math.floor(Math.random() * deploymentStates.length)];

--- a/widgets/deploymentsView/src/styles.scss
+++ b/widgets/deploymentsView/src/styles.scss
@@ -1,4 +1,4 @@
-/* TODO(RD-1224): adjust states to match the API ones */
+/* TODO(RD-1741): adjust states to match the API ones */
 $deploymentStateColors: (
     'good': green,
     'in-progress': orange,

--- a/widgets/deploymentsView/src/widget.tsx
+++ b/widgets/deploymentsView/src/widget.tsx
@@ -113,6 +113,7 @@ if (process.env.NODE_ENV === 'development' || process.env.TEST) {
                     // TODO(RD-1787): adjust `noDataMessage` to show the image
                     noDataMessage={Stage.i18n.t(`${i18nPrefix}.noDataMessage`)}
                     totalSize={data.metadata.pagination.total}
+                    searchable
                 >
                     {deploymentsViewColumnIds.map(columnId => {
                         const columnDefinition = deploymentsViewColumnDefinitions[columnId];

--- a/widgets/deploymentsView/src/widget.tsx
+++ b/widgets/deploymentsView/src/widget.tsx
@@ -73,7 +73,7 @@ if (process.env.NODE_ENV === 'development' || process.env.TEST) {
         permission: Stage.GenericConfig.WIDGET_PERMISSION('deploymentsView'),
 
         fetchData(_widget, toolbox, params: GridParams) {
-            // TODO(RD-1224): add resolving `filterRules` if they are not fetched (after RD-377)
+            // TODO(RD-1530): add resolving `filterRules` if they are not fetched (after RD-377)
             return toolbox
                 .getManager()
                 .doGet('/deployments', params)

--- a/widgets/deploymentsView/src/widget.tsx
+++ b/widgets/deploymentsView/src/widget.tsx
@@ -11,7 +11,13 @@ interface GridParams {
 
 interface DeploymentsResponse {
     items: Deployment[];
-    metadata: any;
+    metadata: {
+        pagination: {
+            offset: number;
+            size: number;
+            total: number;
+        };
+    };
 }
 
 interface DeploymentsViewWidgetConfiguration {
@@ -98,9 +104,16 @@ if (process.env.NODE_ENV === 'development' || process.env.TEST) {
                 return <Loading />;
             }
 
-            // TODO(RD-1224): add `noDataMessage`
             return (
-                <DataTable fetchData={toolbox.refresh} pageSize={pageSize} selectable sizeMultiplier={20}>
+                <DataTable
+                    fetchData={toolbox.refresh}
+                    pageSize={pageSize}
+                    selectable
+                    sizeMultiplier={20}
+                    // TODO(RD-1787): adjust `noDataMessage` to show the image
+                    noDataMessage={Stage.i18n.t(`${i18nPrefix}.noDataMessage`)}
+                    totalSize={data.metadata.pagination.total}
+                >
                     {deploymentsViewColumnIds.map(columnId => {
                         const columnDefinition = deploymentsViewColumnDefinitions[columnId];
                         return (


### PR DESCRIPTION
This PR is a base for #1267  and includes standalone changes that I have separated out to make the code review a bit easier.

Notable changes:
1. Add `searchable`, `noDataMessage`, and `sortable` to the table
2. Refactor the way class names are combined in `WidgetDynamicContext` (non-breaking change, and will be useful in future PRs to combine 1 more class)

## Video

https://user-images.githubusercontent.com/889383/112164892-8e407b80-8bee-11eb-85be-a084f35b65e7.mp4

## System tests

I will run system tests for #1267, which builds upon this one, to avoid having to run system tests for a linear path of branches