### PR TITLE
RD-1819 Hide maximization buttons for nested widgets

### DIFF
--- a/app/components/Tabs.jsx
+++ b/app/components/Tabs.jsx
@@ -162,7 +162,7 @@ export default function Tabs({
 
 Tabs.propTypes = {
     tabs: PropTypes.arrayOf(PropTypes.shape({ widgets: PropTypes.arrayOf(PropTypes.shape({})) })).isRequired,
-    onWidgetUpdated: PropTypes.func.isRequired,
+    onWidgetUpdated: PropTypes.func,
     onWidgetRemoved: PropTypes.func.isRequired,
     onWidgetAdded: PropTypes.func.isRequired,
     onTabAdded: PropTypes.func.isRequired,
@@ -171,4 +171,8 @@ Tabs.propTypes = {
     onTabMoved: PropTypes.func.isRequired,
     onLayoutSectionRemoved: PropTypes.func.isRequired,
     isEditMode: PropTypes.bool.isRequired
+};
+
+Tabs.defaultProps = {
+    onWidgetUpdated: undefined
 };

--- a/app/components/shared/widgets/PageContent.jsx
+++ b/app/components/shared/widgets/PageContent.jsx
@@ -164,7 +164,7 @@ export default function PageContent({
 }
 
 PageContent.propTypes = {
-    onWidgetUpdated: PropTypes.func.isRequired,
+    onWidgetUpdated: PropTypes.func,
     onWidgetRemoved: PropTypes.func.isRequired,
     onWidgetAdded: PropTypes.func.isRequired,
     onTabAdded: PropTypes.func.isRequired,
@@ -178,4 +178,8 @@ PageContent.propTypes = {
         layout: LayoutPropType
     }).isRequired,
     isEditMode: PropTypes.bool.isRequired
+};
+
+PageContent.defaultProps = {
+    onWidgetUpdated: undefined
 };

--- a/app/components/shared/widgets/Widget.tsx
+++ b/app/components/shared/widgets/Widget.tsx
@@ -18,7 +18,10 @@ import { getWidgetDefinitionById, SimpleWidgetObj } from '../../../actions/page'
 
 export interface WidgetOwnProps<Configuration> {
     isEditMode: boolean;
-    onWidgetUpdated: (widgetId: string, params: Partial<WidgetObj<Configuration>>) => void;
+    /**
+     * Called when the widget configuration is changed or the widget is maximized or minimized.
+     */
+    onWidgetUpdated?: (widgetId: string, params: Partial<WidgetObj<Configuration>>) => void;
     onWidgetRemoved: (widgetId: string) => void;
     widget: SimpleWidgetObj;
     /**
@@ -73,14 +76,14 @@ class Widget<Configuration> extends Component<WidgetProps<Configuration>, Widget
         const escapeKeyCode = 27;
 
         if (event.keyCode === escapeKeyCode) {
-            onWidgetUpdated(widget.id, { maximized: false });
+            onWidgetUpdated?.(widget.id, { maximized: false });
         }
     };
 
     widgetConfigUpdate = (config: Partial<Configuration>) => {
         const { onWidgetUpdated, widget } = this.props;
         if (config) {
-            onWidgetUpdated(widget.id, { configuration: { ...widget.configuration, ...config } });
+            onWidgetUpdated?.(widget.id, { configuration: { ...widget.configuration, ...config } });
         }
     };
 
@@ -193,7 +196,7 @@ class Widget<Configuration> extends Component<WidgetProps<Configuration>, Widget
                                 placeholder="Widget header"
                                 enabled={isEditMode}
                                 className="widgetName"
-                                onChange={name => onWidgetUpdated(widget.id, { name })}
+                                onChange={name => onWidgetUpdated?.(widget.id, { name })}
                             />
                         </Header>
                     )}
@@ -202,11 +205,13 @@ class Widget<Configuration> extends Component<WidgetProps<Configuration>, Widget
                     <div className="widgetButtons" onMouseDown={e => e.stopPropagation()}>
                         {isEditMode && (
                             <div className="widgetEditButtons">
-                                <EditWidget
-                                    widget={widget}
-                                    onWidgetEdited={onWidgetUpdated}
-                                    iconSize={widgetIconButtonSize}
-                                />
+                                {onWidgetUpdated && (
+                                    <EditWidget
+                                        widget={widget}
+                                        onWidgetEdited={onWidgetUpdated}
+                                        iconSize={widgetIconButtonSize}
+                                    />
+                                )}
                                 {helpIcon()}
                                 <Icon
                                     name="remove"
@@ -220,12 +225,14 @@ class Widget<Configuration> extends Component<WidgetProps<Configuration>, Widget
                             (widget.definition.showHeader ? (
                                 <div className={`widgetViewButtons ${widget.maximized ? 'alwaysOnTop' : ''}`}>
                                     {helpIcon()}
-                                    <Icon
-                                        name={widget.maximized ? 'compress' : 'expand'}
-                                        link
-                                        size={widgetIconButtonSize}
-                                        onClick={() => onWidgetUpdated(widget.id, { maximized: !widget.maximized })}
-                                    />
+                                    {onWidgetUpdated && (
+                                        <Icon
+                                            name={widget.maximized ? 'compress' : 'expand'}
+                                            link
+                                            size={widgetIconButtonSize}
+                                            onClick={() => onWidgetUpdated(widget.id, { maximized: !widget.maximized })}
+                                        />
+                                    )}
                                 </div>
                             ) : (
                                 <div className="widgetViewButtons">{helpIcon()}</div>

--- a/app/components/shared/widgets/WidgetsList.tsx
+++ b/app/components/shared/widgets/WidgetsList.tsx
@@ -14,7 +14,12 @@ export default function WidgetsList({ onWidgetUpdated, onWidgetRemoved, isEditMo
     return (
         <Grid
             isEditMode={isEditMode}
-            onGridDataChange={onWidgetUpdated}
+            onGridDataChange={
+                onWidgetUpdated ??
+                (() => {
+                    throw new Error('onWidgetUpdated must be provided in edit mode');
+                })
+            }
             style={{ zIndex: _(widgets).filter({ maximized: true }).size() }}
         >
             {widgets.map(widget =>

--- a/test/cypress/integration/widgets/deployments_view_spec.ts
+++ b/test/cypress/integration/widgets/deployments_view_spec.ts
@@ -112,6 +112,11 @@ describe('Deployments View widget', () => {
                 });
         });
 
+        cy.log('Check for maximization buttons');
+        // NOTE: there should be only the maximization button for the main widget.
+        // Widgets in the details pane should not have them, since they would be noops.
+        getDeploymentsViewWidget().find('i.expand').should('have.length', 1);
+
         cy.log('Verify details pane');
         getDeploymentsViewDetailsPane().within(() => {
             cy.contains('Deployment Info').click();

--- a/widgets/deploymentsView/src/detailsPane/widgets.tsx
+++ b/widgets/deploymentsView/src/detailsPane/widgets.tsx
@@ -13,7 +13,6 @@ const DetailsPaneWidgets: FunctionComponent = () => {
                 page={pageLayout as any}
                 // NOTE: No need to handle the events below since edit mode is always off
                 onWidgetRemoved={noop}
-                onWidgetUpdated={noop}
                 onTabAdded={noop}
                 onTabRemoved={noop}
                 onTabUpdated={noop}


### PR DESCRIPTION
This PR hides useless maximization buttons for nested widgets. It uses the fact that `onWidgetUpdated` would not do anything for nested widgets, so instead of passing `noop`, I changed it to pass `undefined`. This avoids having a new prop that determines whether maximization buttons should be shown or not.

The maximization button is only shown for the top-level widget.

This PR builds on #1267 

## Screenshot

![image](https://user-images.githubusercontent.com/889383/112170992-c9917900-8bf3-11eb-89c6-0e66004357ec.png)

## System tests

https://jenkins.cloudify.co/job/Stage-UI-System-Test/333/

Ran 2021-03-25 15:11 CET