### PR TITLE
RD-1822 Keep deployment selection after executing workflows

### DIFF
--- a/test/cypress/integration/widgets/deployment_actions_spec.js
+++ b/test/cypress/integration/widgets/deployment_actions_spec.js
@@ -19,7 +19,7 @@ describe('Deployment Action Buttons widget', () => {
     });
 
     describe('when deploymentId is set in the context', () => {
-        beforeEach(() => cy.setDeploymentContext(deploymentName));
+        beforeEach(() => cy.clearDeploymentContext().setDeploymentContext(deploymentName));
 
         it('should allow to execute a workflow', () => {
             cy.interceptSp('POST', `/executions`).as('executeWorkflow');

--- a/test/cypress/integration/widgets/deployments_view_spec.ts
+++ b/test/cypress/integration/widgets/deployments_view_spec.ts
@@ -126,6 +126,7 @@ describe('Deployments View widget', () => {
             cy.root().parents('body').contains('a', 'Restart').click();
             cy.root().parents('body').find('.modal').contains('button', 'Execute').click();
             cy.wait('@restartDeployment');
+            cy.contains('Last Execution');
         });
     });
 

--- a/widgets/common/src/ExecuteDeploymentModal.jsx
+++ b/widgets/common/src/ExecuteDeploymentModal.jsx
@@ -153,7 +153,8 @@ export default function ExecuteDeploymentModal({
                 clearErrors();
                 onHide();
                 toolbox.getEventBus().trigger('executions:refresh');
-                toolbox.getEventBus().trigger('deployments:refresh');
+                // NOTE: pass id to keep the current deployment selected
+                toolbox.getEventBus().trigger('deployments:refresh', id);
             });
         });
 


### PR DESCRIPTION
This PR fixes the selection of deployments in the Deployments View widget. It builds on #1267.

Previously, the selection was set to `null` after executing a workflow. This happened because:
1. The `deployments:refresh` event was triggered without any arguments
2. The Resource Filter widget was listening on that event and when it fired, it set the `deploymentId` to whatever was the argument of the event

    https://github.com/cloudify-cosmo/cloudify-stage/blob/6514122edaad401b6b0592c770a287b95f206844/widgets/filter/src/Filter.jsx#L79-L85

    Since the argument was `undefined`, `deploymentId` in that function was set to the default `null` value.

Adding the `deploymentId` preserves the selection when executing workflows.

The problem only happens when the Resource Filter widget is present on the same page (e.g. in tests).

## Video

https://user-images.githubusercontent.com/889383/112172092-b206c000-8bf4-11eb-8864-3f2d883b7990.mp4

Notice that the right pane was kept as-is, and was not reset to the "unknown selection" state.


## System tests

https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/339/pipeline

Ran 2021-03-26 11:44 CET