### PR TITLE
RD-1835 - Improve deployment_actions_spec to be more robust

### DIFF
--- a/test/cypress/integration/widgets/deployment_actions_spec.js
+++ b/test/cypress/integration/widgets/deployment_actions_spec.js
@@ -62,9 +62,14 @@ describe('Deployment Action Buttons widget', () => {
             cy.get('div[name=labelValue] > input').clear().type(value);
         }
         function addLabel(key, value) {
+            cy.interceptSp('GET', `/labels/deployments/${key}?_search=${value}`).as('fetchLabel');
+
             typeLabelKey(key);
             typeLabelValue(value);
             cy.get('button[aria-label=Add]').click();
+
+            cy.wait('@fetchLabel');
+            cy.contains('a.label', `${key} ${value}`).should('exist');
         }
         function checkIfPopupIsDisplayed(key, popupContent) {
             typeLabelKey(key);
@@ -100,8 +105,6 @@ describe('Deployment Action Buttons widget', () => {
         it('adds new label by typing', () => {
             cy.get('.modal').within(() => {
                 addLabel('sample_key', 'sample_value');
-
-                cy.contains('a.label', 'sample_key sample_value').should('be.visible');
             });
         });
 


### PR DESCRIPTION
This is a simple change to make `deployment_actions_spec` more robust by:
* waiting for "labels existence check" request to be send
* waiting for the label to be added to the labels list

before starting the next actions.

In my local environment test is passing. CI (only deployment_actions_spec) results will be here: https://jenkins.cloudify.co/view/UI%20Health%20View/job/Stage-UI-System-Test/330

See RD-1835 for more details.