### PR TITLE
RD-1859 - Expose styled-components through Stage global

### DIFF
--- a/app/utils/StageAPI.ts
+++ b/app/utils/StageAPI.ts
@@ -239,6 +239,7 @@ declare global {
         }
 
         const i18n: typeof import('i18next').default;
+        const styled: typeof import('styled-components').default;
 
         /**
          * A namespace that exists for storing reusable TypeScript types

--- a/app/utils/widgetDefinitionsLoader.ts
+++ b/app/utils/widgetDefinitionsLoader.ts
@@ -2,16 +2,16 @@ import i18n from 'i18next';
 import _ from 'lodash';
 import log from 'loglevel';
 import { renderToString } from 'react-dom/server';
+import styled from 'styled-components';
+import 'd3';
+
 import Internal from './Internal';
 import ScriptLoader from './scriptLoader';
 import StyleLoader from './StyleLoader';
-import 'd3';
-
 import * as Basic from '../components/basic';
 import * as Shared from '../components/shared';
 import StageUtils from './stageUtils';
 import LoaderUtils from './LoaderUtils';
-
 import GenericConfig from './GenericConfig';
 import * as PropTypes from './props';
 import * as Hooks from './hooks';
@@ -77,7 +77,8 @@ export default class WidgetDefinitionsLoader {
                 Object.assign(window.Stage.Hooks, def);
             },
 
-            i18n
+            i18n,
+            styled
         };
         window.Stage = stageAPI;
     }


### PR DESCRIPTION
Added `styled` to `Stage` global.

Works fine:
![demo](https://user-images.githubusercontent.com/5202105/112794881-f87e7380-9067-11eb-95a9-ec53a6dcb3f7.png)
