### PR TITLE
RD-1142 Respect filters in Deployments View

### DIFF
--- a/app/components/shared/widgets/WidgetsList.tsx
+++ b/app/components/shared/widgets/WidgetsList.tsx
@@ -37,7 +37,7 @@ export default function WidgetsList({ onWidgetUpdated, onWidgetRemoved, isEditMo
 WidgetsList.propTypes = {
     widgets: PropTypes.arrayOf(PropTypes.shape({})),
     onWidgetRemoved: PropTypes.func.isRequired,
-    onWidgetUpdated: PropTypes.func.isRequired,
+    onWidgetUpdated: PropTypes.func,
     isEditMode: PropTypes.bool.isRequired
 };
 

--- a/test/cypress/integration/widgets/deployments_view_spec.ts
+++ b/test/cypress/integration/widgets/deployments_view_spec.ts
@@ -1,6 +1,5 @@
 import type { RouteHandler } from 'cypress/types/net-stubbing';
 import { without } from 'lodash';
-import { FilterResource } from '../../support/filters';
 
 describe('Deployments View widget', () => {
     const widgetId = 'deploymentsView';
@@ -148,8 +147,8 @@ describe('Deployments View widget', () => {
     describe('with filters', () => {
         const filterId = 'only-precious';
         before(() => {
-            cy.deleteFilter(FilterResource.Deployments, filterId, { ignoreFailure: true })
-                .createFilter(FilterResource.Deployments, filterId, [
+            cy.deleteDeploymentsFilter(filterId, { ignoreFailure: true })
+                .createDeploymentsFilter(filterId, [
                     { type: 'label', key: 'precious', values: ['yes'], operator: 'any_of' }
                 ])
                 .deployBlueprint(blueprintName, deploymentNameThatMatchesFilter, { webserver_port: 9124 })

--- a/test/cypress/integration/widgets/deployments_view_spec.ts
+++ b/test/cypress/integration/widgets/deployments_view_spec.ts
@@ -54,7 +54,7 @@ describe('Deployments View widget', () => {
         routeHandler,
         configurationOverrides = {}
     }: { routeHandler?: RouteHandler; configurationOverrides?: Record<string, any> } = {}) => {
-        cy.interceptSp('GET', /^\/deployments/, routeHandler).as('deployments');
+        cy.interceptSp('POST', /^\/searches\/deployments/, routeHandler).as('deployments');
         // NOTE: larger viewport since the widget requires more width to be comfortable to use
         cy.viewport(1600, 900)
             .usePageMock(

--- a/test/cypress/integration/widgets/deployments_view_spec.ts
+++ b/test/cypress/integration/widgets/deployments_view_spec.ts
@@ -1,5 +1,6 @@
 import type { RouteHandler } from 'cypress/types/net-stubbing';
 import { without } from 'lodash';
+import { FilterResource } from '../../support/filters';
 
 describe('Deployments View widget', () => {
     const widgetId = 'deploymentsView';
@@ -42,7 +43,6 @@ describe('Deployments View widget', () => {
 
     before(() => {
         cy.activate()
-            // NOTE: will remove all deployments used in this test spec
             .deleteDeployments(specPrefix, true)
             .deleteSites(siteName)
             .deleteBlueprints(blueprintName, true)
@@ -148,13 +148,10 @@ describe('Deployments View widget', () => {
     describe('with filters', () => {
         const filterId = 'only-precious';
         before(() => {
-            cy.deleteFilter('deployments', filterId, { ignoreFailure: true })
-                .createFilter({
-                    id: filterId,
-                    rules: [{ type: 'label', key: 'precious', values: ['yes'], operator: 'any_of' }],
-                    resource: 'deployments'
-                })
-                .deleteDeployments(deploymentNameThatMatchesFilter, true)
+            cy.deleteFilter(FilterResource.Deployments, filterId, { ignoreFailure: true })
+                .createFilter(FilterResource.Deployments, filterId, [
+                    { type: 'label', key: 'precious', values: ['yes'], operator: 'any_of' }
+                ])
                 .deployBlueprint(blueprintName, deploymentNameThatMatchesFilter, { webserver_port: 9124 })
                 .setLabels(deploymentNameThatMatchesFilter, [{ precious: 'yes' }]);
         });

--- a/test/cypress/integration/widgets/deployments_view_spec.ts
+++ b/test/cypress/integration/widgets/deployments_view_spec.ts
@@ -162,7 +162,7 @@ describe('Deployments View widget', () => {
         const getFilterIdInput = () =>
             cy.contains('Name of the saved filter to apply').parent().get('input[type="text"]');
 
-        it('should take the fiter into account when displaying deployments', () => {
+        it('should take the filter into account when displaying deployments', () => {
             useDeploymentsViewWidget({ configurationOverrides: { filterId } });
 
             cy.log('Show only precious deployments');

--- a/test/cypress/support/commands.ts
+++ b/test/cypress/support/commands.ts
@@ -24,6 +24,7 @@ import './editMode';
 import './widgets';
 import './secrets';
 import './snapshots';
+import './filters';
 import { addCommands, GetCypressChainableFromCommands } from 'cloudify-ui-common/cypress/support';
 
 let token = '';

--- a/test/cypress/support/filters.ts
+++ b/test/cypress/support/filters.ts
@@ -8,9 +8,7 @@ declare global {
     }
 }
 
-/**
- * @see https://cloudifysource.atlassian.net/wiki/spaces/WR/pages/1657405459/Complex+Filters+Design+Document
- */
+/** @see https://docs.cloudify.co/api/v3.1/#the-filter-resource */
 export interface FilterRule {
     key: string;
     values: string[];

--- a/test/cypress/support/filters.ts
+++ b/test/cypress/support/filters.ts
@@ -1,0 +1,48 @@
+import { addCommands, GetCypressChainableFromCommands } from 'cloudify-ui-common/cypress/support';
+
+declare global {
+    namespace Cypress {
+        // NOTE: necessary for extending the Cypress API
+        // eslint-disable-next-line @typescript-eslint/no-empty-interface
+        export interface Chainable extends GetCypressChainableFromCommands<typeof commands> {}
+    }
+}
+
+/**
+ * @see https://cloudifysource.atlassian.net/wiki/spaces/WR/pages/1657405459/Complex+Filters+Design+Document
+ */
+export interface FilterRule {
+    key: string;
+    values: string[];
+    operator: string;
+    type: 'label' | 'attribute';
+}
+
+export interface Filter {
+    id: string;
+    resource: 'deployments' | 'blueprints';
+    rules: FilterRule[];
+    visibility?: string;
+}
+
+const commands = {
+    createFilter: (filter: Filter) => {
+        const payload = {
+            filter_rules: filter.rules,
+            visibility: filter.visibility
+        };
+
+        return cy.cfyRequest(`/filters/${filter.resource}/${filter.id}`, 'PUT', null, payload);
+    },
+
+    deleteFilter: (
+        resource: Filter['resource'],
+        filterId: string,
+        { ignoreFailure }: { ignoreFailure?: boolean } = {}
+    ) =>
+        cy.cfyRequest(`/filters/${resource}/${filterId}`, 'DELETE', undefined, undefined, {
+            failOnStatusCode: !ignoreFailure
+        })
+};
+
+addCommands(commands);

--- a/test/cypress/support/filters.ts
+++ b/test/cypress/support/filters.ts
@@ -16,28 +16,16 @@ export interface FilterRule {
     type: 'label' | 'attribute';
 }
 
-export interface Filter {
-    id: string;
-    resource: 'deployments' | 'blueprints';
-    rules: FilterRule[];
-    visibility?: string;
+export enum FilterResource {
+    Deployments = 'deployments',
+    Blueprints = 'blueprints'
 }
 
 const commands = {
-    createFilter: (filter: Filter) => {
-        const payload = {
-            filter_rules: filter.rules,
-            visibility: filter.visibility
-        };
+    createFilter: (resource: FilterResource, id: string, rules: FilterRule[]) =>
+        cy.cfyRequest(`/filters/${resource}/${id}`, 'PUT', null, { filter_rules: rules }),
 
-        return cy.cfyRequest(`/filters/${filter.resource}/${filter.id}`, 'PUT', null, payload);
-    },
-
-    deleteFilter: (
-        resource: Filter['resource'],
-        filterId: string,
-        { ignoreFailure }: { ignoreFailure?: boolean } = {}
-    ) =>
+    deleteFilter: (resource: FilterResource, filterId: string, { ignoreFailure }: { ignoreFailure?: boolean } = {}) =>
         cy.cfyRequest(`/filters/${resource}/${filterId}`, 'DELETE', undefined, undefined, {
             failOnStatusCode: !ignoreFailure
         })

--- a/test/cypress/support/filters.ts
+++ b/test/cypress/support/filters.ts
@@ -16,17 +16,12 @@ export interface FilterRule {
     type: 'label' | 'attribute';
 }
 
-export enum FilterResource {
-    Deployments = 'deployments',
-    Blueprints = 'blueprints'
-}
-
 const commands = {
-    createFilter: (resource: FilterResource, id: string, rules: FilterRule[]) =>
-        cy.cfyRequest(`/filters/${resource}/${id}`, 'PUT', null, { filter_rules: rules }),
+    createDeploymentsFilter: (id: string, rules: FilterRule[]) =>
+        cy.cfyRequest(`/filters/deployments/${id}`, 'PUT', null, { filter_rules: rules }),
 
-    deleteFilter: (resource: FilterResource, filterId: string, { ignoreFailure }: { ignoreFailure?: boolean } = {}) =>
-        cy.cfyRequest(`/filters/${resource}/${filterId}`, 'DELETE', undefined, undefined, {
+    deleteDeploymentsFilter: (filterId: string, { ignoreFailure }: { ignoreFailure?: boolean } = {}) =>
+        cy.cfyRequest(`/filters/deployments/${filterId}`, 'DELETE', undefined, undefined, {
             failOnStatusCode: !ignoreFailure
         })
 };

--- a/widgets/deploymentsView/src/widget.tsx
+++ b/widgets/deploymentsView/src/widget.tsx
@@ -38,12 +38,13 @@ if (process.env.NODE_ENV === 'development' || process.env.TEST) {
         initialConfiguration: [
             Stage.GenericConfig.POLLING_TIME_CONFIG(10),
             {
-                // TODO: Requires RD-377 to add support for filters
                 id: 'filterId',
+                // TODO(RD-1851): add autocomplete instead of plain text input
                 type: Stage.Basic.GenericField.STRING_TYPE,
                 name: Stage.i18n.t(`${i18nPrefix}.configuration.filterId.name`)
             },
             {
+                // TODO(RD-1853): handle filtering by parent deployment
                 id: 'filterByParentDeployment',
                 type: Stage.Basic.GenericField.BOOLEAN_TYPE,
                 name: Stage.i18n.t(`${i18nPrefix}.configuration.filterByParentDeployment.name`),


### PR DESCRIPTION
This PR adds handling filters in Deployments View in a very basic way:
* filter rules are fetched every time before fetching the deployments
* there is no caching of filter rules. That will come in RD-1852 or RD-1854 (I'm thinking about using [react-query](https://react-query.tanstack.com/overview) instead of writing the logic for polling and aborting requests myself)

The tests need to create filters to be used for the test, so I added necessary commands that facilitate that too.

## Video

https://user-images.githubusercontent.com/889383/112830684-2927d280-9093-11eb-9f19-f1bdd3a68cc4.mp4

## System tests

https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/357/pipeline

Ran 2021-03-30 15:23 CEST