### PR TITLE
Rd 1846 getting started model can be seen only for sys admin v2

### DIFF
--- a/app/components/GettingStartedModal/GettingStartedModal.tsx
+++ b/app/components/GettingStartedModal/GettingStartedModal.tsx
@@ -1,7 +1,10 @@
 import React, { memo, useState, useMemo } from 'react';
 import i18n from 'i18next';
 import log from 'loglevel';
+import { useSelector } from 'react-redux';
 
+import { ReduxState } from '../../reducers';
+import stageUtils from '../../utils/stageUtils';
 import EventBus from '../../utils/EventBus';
 import useInput from '../../utils/hooks/useInput';
 import useResettableState from '../../utils/hooks/useResettableState';
@@ -27,6 +30,7 @@ const castedGettingStartedSchema = gettingStartedSchema as GettingStartedSchema;
 const GettingStartedModal = () => {
     const [modalOpen, setModalOpen] = useState(() => isGettingStartedModalDisabledInLocalStorage());
 
+    const manager = useSelector((state: ReduxState) => state.manager);
     const [stepName, setStepName] = useState(StepName.Technologies);
     const [stepErrors, setStepErrors, resetStepErrors] = useResettableState<string[]>([]);
     const [technologiesStepData, setTechnologiesStepData] = useState<GettingStartedTechnologiesData>({});
@@ -40,6 +44,10 @@ const GettingStartedModal = () => {
         () => createTechnologiesGroups(castedGettingStartedSchema.filter(items => technologiesStepData[items.name])), // steps with unique secrets for selected technologies
         [technologiesStepData]
     );
+
+    if (!stageUtils.isUserAuthorized('getting_started', manager)) {
+        return null;
+    }
 
     const secretsStepSchema = secretsStepsSchemas[secretsStepIndex] as GettingStartedSchemaItem | undefined;
     const secretsStepData = secretsStepSchema ? secretsStepsData[secretsStepSchema.name] : undefined;

--- a/app/components/Home.jsx
+++ b/app/components/Home.jsx
@@ -7,7 +7,6 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import i18n from 'i18next';
 
-import stageUtils from '../utils/stageUtils';
 import SideBar from '../containers/SideBar';
 import Page from './Page';
 import ToursButton from '../containers/ToursButton';


### PR DESCRIPTION
In this PR some condition that checks if the current user role has permissions to display getting started modal was added.
Task link: https://cloudifysource.atlassian.net/browse/RD-1846

This PR is related with: 
https://github.com/cloudify-cosmo/cloudify-manager-install/pull/1107