### PR TITLE
RD-1949 Fix paths to GitHub blueprint artifacts in system tests

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -1,6 +1,6 @@
 {
-    "branches": 75,
-    "lines": 82,
+    "branches": 73,
+    "lines": 81,
     "functions": 77,
-    "statements": 82
+    "statements": 81
 }

--- a/test/cypress/integration/widgets/deployment_button_spec.js
+++ b/test/cypress/integration/widgets/deployment_button_spec.js
@@ -2,7 +2,7 @@ describe('Create Deployment Button widget', () => {
     const resourcePrefix = 'deploy_test_';
     const testBlueprintId = `${resourcePrefix}bp`;
     const testBlueprintUrl =
-        'https://github.com/cloudify-community/blueprint-examples/releases/download/latest/simple-hello-world-example.zip';
+        'https://github.com/cloudify-community/blueprint-examples/releases/latest/download/simple-hello-world-example.zip';
     const firstInputNthChild = 6;
 
     before(() => {

--- a/test/cypress/integration/widgets/deployment_button_spec.js
+++ b/test/cypress/integration/widgets/deployment_button_spec.js
@@ -1,8 +1,9 @@
+import { exampleBlueprintUrl } from '../../support/resource_urls';
+
 describe('Create Deployment Button widget', () => {
     const resourcePrefix = 'deploy_test_';
     const testBlueprintId = `${resourcePrefix}bp`;
-    const testBlueprintUrl =
-        'https://github.com/cloudify-community/blueprint-examples/releases/latest/download/simple-hello-world-example.zip';
+    const testBlueprintUrl = exampleBlueprintUrl;
     const firstInputNthChild = 6;
 
     before(() => {

--- a/test/cypress/integration/widgets/deployments_spec.js
+++ b/test/cypress/integration/widgets/deployments_spec.js
@@ -4,7 +4,7 @@ describe('Deployments widget', () => {
     const siteName = 'Zakopane';
     const site = { name: siteName };
     const blueprintUrl =
-        'https://github.com/cloudify-community/blueprint-examples/releases/download/latest/simple-hello-world-example.zip';
+        'https://github.com/cloudify-community/blueprint-examples/releases/latest/download/simple-hello-world-example.zip';
 
     const selectActionFromMenu = (deploymentId, menuClassName, action) => {
         cy.searchInDeploymentsWidget(deploymentId);

--- a/test/cypress/integration/widgets/deployments_spec.js
+++ b/test/cypress/integration/widgets/deployments_spec.js
@@ -1,10 +1,11 @@
+import { exampleBlueprintUrl } from '../../support/resource_urls';
+
 describe('Deployments widget', () => {
     const blueprintName = 'deployments_test_hw';
     const deploymentName = 'deployments_test_hw_dep';
     const siteName = 'Zakopane';
     const site = { name: siteName };
-    const blueprintUrl =
-        'https://github.com/cloudify-community/blueprint-examples/releases/latest/download/simple-hello-world-example.zip';
+    const blueprintUrl = exampleBlueprintUrl;
 
     const selectActionFromMenu = (deploymentId, menuClassName, action) => {
         cy.searchInDeploymentsWidget(deploymentId);

--- a/test/cypress/integration/widgets/deployments_view_spec.ts
+++ b/test/cypress/integration/widgets/deployments_view_spec.ts
@@ -9,7 +9,7 @@ describe('Deployments View widget', () => {
     const deploymentNameThatMatchesFilter = `${specPrefix}precious_deployment`;
     const siteName = 'Olsztyn';
     const blueprintUrl =
-        'https://github.com/cloudify-community/blueprint-examples/releases/download/latest/simple-hello-world-example.zip';
+        'https://github.com/cloudify-community/blueprint-examples/releases/latest/download/simple-hello-world-example.zip';
     const widgetConfiguration = {
         filterByParentDeployment: false,
         fieldsToShow: ['status', 'name', 'blueprintName', 'location', 'subenvironmentsCount', 'subservicesCount'],

--- a/test/cypress/integration/widgets/deployments_view_spec.ts
+++ b/test/cypress/integration/widgets/deployments_view_spec.ts
@@ -1,6 +1,8 @@
 import type { RouteHandler } from 'cypress/types/net-stubbing';
 import { without } from 'lodash';
 
+import { exampleBlueprintUrl } from '../../support/resource_urls';
+
 describe('Deployments View widget', () => {
     const widgetId = 'deploymentsView';
     const specPrefix = 'deployments_view_test_';
@@ -8,8 +10,7 @@ describe('Deployments View widget', () => {
     const deploymentName = `${specPrefix}deployment`;
     const deploymentNameThatMatchesFilter = `${specPrefix}precious_deployment`;
     const siteName = 'Olsztyn';
-    const blueprintUrl =
-        'https://github.com/cloudify-community/blueprint-examples/releases/latest/download/simple-hello-world-example.zip';
+    const blueprintUrl = exampleBlueprintUrl;
     const widgetConfiguration = {
         filterByParentDeployment: false,
         fieldsToShow: ['status', 'name', 'blueprintName', 'location', 'subenvironmentsCount', 'subservicesCount'],

--- a/test/cypress/support/resource_urls.ts
+++ b/test/cypress/support/resource_urls.ts
@@ -1,0 +1,3 @@
+// eslint-disable-next-line import/prefer-default-export
+export const exampleBlueprintUrl =
+    'https://github.com/cloudify-community/blueprint-examples/releases/latest/download/simple-hello-world-example.zip';


### PR DESCRIPTION
GitHub URL structure for accessing the artifacts of the latest release changed. It has to be reflected in the URLs used in tests.

## System tests

https://jenkins.cloudify.co/job/Stage-UI-System-Test/377/