### PR TITLE
RD-1853 Filter by parent deployment in Deployments View

### DIFF
--- a/app/actions/drilldownPage.js
+++ b/app/actions/drilldownPage.js
@@ -2,6 +2,7 @@ import _ from 'lodash';
 import * as types from './types';
 import { drillDownWarning } from './templateManagement';
 import { createDrilldownPage, selectPage, addLayoutToPage } from './page';
+import { setDrilldownContext } from './drilldownContext';
 
 export function addWidgetDrilldownPage(widgetId, drillDownName, drillDownPageId) {
     return {
@@ -33,6 +34,15 @@ export function drillDownToPage(widget, defaultTemplate, drilldownContext, drill
             dispatch(addWidgetDrilldownPage(widget.id, defaultTemplate.name, newPageId));
             pageId = newPageId;
         }
+
+        // Refresh the drilldown context for the current page
+        const updatedDrilldownContext = getState().drilldownContext.slice();
+        const currentPageDrilldownContext = updatedDrilldownContext.pop() || {};
+        updatedDrilldownContext.push({
+            ...currentPageDrilldownContext,
+            context: getState().context
+        });
+        dispatch(setDrilldownContext(updatedDrilldownContext));
 
         return dispatch(selectPage(pageId, true, drilldownContext, drilldownPageName));
     };

--- a/app/actions/page.ts
+++ b/app/actions/page.ts
@@ -215,7 +215,7 @@ export function selectPage(
                     pageName: drilldownPageName
                 });
             } else {
-                throw new Error('Drilldown page name and context not provided while doing a drilldown');
+                throw new Error('Either drilldown page name or context have to be provided while doing a drilldown');
             }
 
             // eslint-disable-next-line scanjs-rules/assign_to_search

--- a/app/actions/page.ts
+++ b/app/actions/page.ts
@@ -16,6 +16,7 @@ import Consts from '../utils/consts';
 import { NO_PAGES_FOR_TENANT_ERR } from '../utils/ErrorCodes';
 import type { Widget, WidgetDefinition } from '../utils/StageAPI';
 import type { ReduxState } from '../reducers';
+import type { DrilldownContext } from '../reducers/drilldownContextReducer';
 
 // TODO(RD-1645): rename type to Widget
 // TODO(RD-1649): rename the added field to `definitionId`
@@ -183,7 +184,7 @@ export function changePageDescription(pageId: string, newDescription: string) {
 export function selectPage(
     pageId: string,
     isDrilldown?: boolean,
-    drilldownContext?: any,
+    drilldownContext?: Record<string, any>,
     drilldownPageName?: string
 ): ThunkAction<void, ReduxState, never, AnyAction> {
     return (dispatch, getState) => {
@@ -195,6 +196,11 @@ export function selectPage(
         // Update context and location depending on page is drilldown
         if (!isDrilldown) {
             dispatch(clearContext());
+            if (drilldownContext) {
+                const newDrilldownContext: DrilldownContext[] = [{ context: drilldownContext }];
+                // eslint-disable-next-line scanjs-rules/assign_to_search
+                location.search = stringify({ c: JSON.stringify(newDrilldownContext) });
+            }
         } else {
             if (!_.isEmpty(drilldownPageName)) {
                 // eslint-disable-next-line scanjs-rules/assign_to_pathname

--- a/app/actions/page.ts
+++ b/app/actions/page.ts
@@ -233,13 +233,16 @@ export function selectPage(
     };
 }
 
-export function selectPageByName(pageName: string, context: any): ThunkAction<void, ReduxState, never, AnyAction> {
+export function selectPageByName(
+    pageName: string,
+    context: Record<string, any>
+): ThunkAction<void, ReduxState, never, AnyAction> {
     return dispatch => {
         if (context) {
             dispatch(clearContext());
         }
         const pageId = _.snakeCase(pageName);
-        dispatch(selectPage(pageId, context, context));
+        dispatch(selectPage(pageId, false, context));
     };
 }
 

--- a/app/actions/page.ts
+++ b/app/actions/page.ts
@@ -209,13 +209,6 @@ export function selectPage(
 
             const newDrilldownContext = (getState().drilldownContext || []).slice();
 
-            // Refresh the drilldown context for the current page
-            const currentPageDrilldownContext = newDrilldownContext.pop() || {};
-            newDrilldownContext.push({
-                ...currentPageDrilldownContext,
-                context: getState().context
-            });
-
             if (drilldownPageName || drilldownContext) {
                 newDrilldownContext.push({
                     context: drilldownContext || {},

--- a/app/actions/page.ts
+++ b/app/actions/page.ts
@@ -356,7 +356,6 @@ export function selectParentPage(): ThunkAction<void, ReduxState, never, AnyActi
             // NOTE: assume page is always found
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             const parentPage: PageDefinition = _.find(state.pages, { id: page.parent })!;
-            // NOTE: investigate. However, popping should not really matter
             dispatch(popDrilldownContext());
             dispatch(selectPage(parentPage.id, parentPage.isDrillDown));
         }

--- a/app/app.jsx
+++ b/app/app.jsx
@@ -31,8 +31,9 @@ import * as Leaflet from 'leaflet';
 import log from 'loglevel';
 import moment from 'moment';
 import * as ReactQuery from 'react-query';
+import { pick } from 'lodash';
 
-import { connect, Provider } from 'react-redux';
+import * as ReactRedux from 'react-redux';
 import { createBrowserHistory } from 'history';
 import { ConnectedRouter } from 'connected-react-router';
 import { Switch } from 'react-router-dom';
@@ -84,8 +85,9 @@ export default class app {
         window.PropTypes = PropTypes;
         window.L = Leaflet;
         window.log = log;
-        window.connectToStore = connect;
+        window.connectToStore = ReactRedux.connect;
         window.moment = moment;
+        window.ReactRedux = pick(ReactRedux, 'useSelector');
         window.ReactQuery = ReactQuery;
 
         log.setLevel(log.levels.WARN);
@@ -115,6 +117,8 @@ export default class app {
     }
 
     static start(store) {
+        const { Provider } = ReactRedux;
+
         ReactDOM.render(
             <Provider store={store}>
                 <ReactQuery.QueryClientProvider client={queryClient}>

--- a/app/components/Breadcrumbs.jsx
+++ b/app/components/Breadcrumbs.jsx
@@ -10,6 +10,7 @@ import { Breadcrumb, EditableLabel } from './basic';
 
 export default function Breadcrumbs({ isEditMode, onPageNameChange, onPageSelected, pagesList }) {
     const breadcrumbElements = [];
+    // TODO(RD-1982): use the regular, unreversed list
     const reversedPagesList = _([...pagesList])
         .reverse()
         .value();

--- a/app/components/Home.jsx
+++ b/app/components/Home.jsx
@@ -63,12 +63,13 @@ export default class Home extends Component {
         // Always clear the context. Whatever is relevant to the drilldown should be passed as drilldown context
         onClearContext();
 
-        // Go over all the drilldown context and set it all (from top down)
-        _.each(contextParams, cp => {
-            _.each(cp.context, (value, key) => {
+        if (contextParams) {
+            /** @type {import('../reducers/drilldownContextReducer').DrilldownContext} */
+            const currentPageContext = contextParams[contextParams.length - 1] || {};
+            _.each(currentPageContext.context, (value, key) => {
                 onSetContextValue(key, value);
             });
-        });
+        }
 
         onSetDrilldownContext(contextParams);
     }

--- a/app/components/Page.tsx
+++ b/app/components/Page.tsx
@@ -129,6 +129,7 @@ const buildPagesList = (pages: PageDefinition[], drilldownContextArray: Drilldow
      * pagesList should be from innermost to outermost pages.
      * Thus, the order is reversed.
      */
+    // TODO(RD-1982): build the pages list in the same order as drilldownContextArray
 
     const updatePagesListWith = (page: PageDefinition) => {
         const basePage = !page ? pages[0] : page;

--- a/app/components/Page.tsx
+++ b/app/components/Page.tsx
@@ -184,14 +184,14 @@ const mapDispatchToProps = (dispatch: ThunkDispatch<ReduxState, never, AnyAction
         },
         onPageSelected: (page: PageDefinitionWithContext, pagesList: PageDefinitionWithContext[], index: number) => {
             // NOTE: the pagesList are from outermost to innermost
-            const drilldownContext: DrilldownContext[] = [];
-            // Skip the last page, because we are sending the context of this one to the select page
-            for (let i = 0; i <= index - 1; i += 1) {
-                drilldownContext.push({
-                    pageName: pagesList[i].name,
-                    context: pagesList[i].context
-                });
-            }
+            // Skip the last page (copy up to index-1), because we are sending
+            // the context of this one to the select page
+            const drilldownContext = pagesList.slice(0, Math.max(0, index - 2)).map(
+                (pageInList): DrilldownContext => ({
+                    pageName: pageInList.name,
+                    context: pageInList.context
+                })
+            );
             dispatch(setDrilldownContext(drilldownContext));
             dispatch(selectPage(page.id, page.isDrillDown, page.context, page.name));
         },

--- a/app/components/Page.tsx
+++ b/app/components/Page.tsx
@@ -184,9 +184,7 @@ const mapDispatchToProps = (dispatch: ThunkDispatch<ReduxState, never, AnyAction
         },
         onPageSelected: (page: PageDefinitionWithContext, pagesList: PageDefinitionWithContext[], index: number) => {
             // NOTE: the pagesList are from outermost to innermost
-            // Skip the last page (copy up to index-1), because we are sending
-            // the context of this one to the select page
-            const drilldownContext = pagesList.slice(0, Math.max(0, index - 2)).map(
+            const drilldownContext = pagesList.slice(0, index).map(
                 (pageInList): DrilldownContext => ({
                     pageName: pageInList.name,
                     context: pageInList.context

--- a/app/components/Page.tsx
+++ b/app/components/Page.tsx
@@ -124,6 +124,11 @@ const buildPagesList = (pages: PageDefinition[], drilldownContextArray: Drilldow
     const pagesMap = createPagesMap(pages);
     const pagesList: PageDefinitionWithContext[] = [];
     let index = drilldownContextArray.length - 1;
+    /**
+     * NOTE: drilldownContextArray is from outermost to innermost pages
+     * pagesList should be from innermost to outermost pages.
+     * Thus, the order is reversed.
+     */
 
     const updatePagesListWith = (page: PageDefinition) => {
         const basePage = !page ? pages[0] : page;
@@ -177,10 +182,10 @@ const mapDispatchToProps = (dispatch: ThunkDispatch<ReduxState, never, AnyAction
             dispatch(changePageDescription(pageId, newDescription));
         },
         onPageSelected: (page: PageDefinitionWithContext, pagesList: PageDefinitionWithContext[], index: number) => {
+            // NOTE: the pagesList are from outermost to innermost
             const drilldownContext: DrilldownContext[] = [];
-            // Starting from 1 cause the first page doesnt have any context and shouldnt be in the context array (only drilldown pages)
-            // and also skip the last page, because we are sending the context of this one to the select page
-            for (let i = 1; i <= index - 1; i += 1) {
+            // Skip the last page, because we are sending the context of this one to the select page
+            for (let i = 0; i <= index - 1; i += 1) {
                 drilldownContext.push({
                     pageName: pagesList[i].name,
                     context: pagesList[i].context

--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -25,7 +25,7 @@
         "servicesStatus": "Services Status",
         "systemStatus": "System Status"
     },
-    "gettingStartedModal" : {
+    "gettingStartedModal": {
         "disableModalLabel": "Don't show next time",
         "titles": {
             "technologiesStep": "Getting Started",
@@ -629,7 +629,11 @@
                 "loadingFilterRules": "Loading filter rules",
                 "errorLoadingFilterRules": "Error when loading filter rules",
                 "loadingDeployments": "Loading deployments",
-                "errorLoadingDeployments": "Error when loading deployments"
+                "errorLoadingDeployments": "Error when loading deployments",
+                "missingParentDeploymentId": {
+                    "header": "Cannot filter by parent deployment",
+                    "message": "A selected deployment cannot be found in the parent page. Turn off the option in the configuration."
+                }
             }
         },
         "filters": {

--- a/app/typings/stage-api.d.ts
+++ b/app/typings/stage-api.d.ts
@@ -12,6 +12,7 @@ declare global {
     export const L: typeof import('leaflet');
     export const log: typeof import('loglevel');
     export const connectToStore: typeof import('react-redux').connect;
+    export const ReactRedux: Pick<typeof import('react-redux'), 'useSelector'>;
     export const ReactQuery: typeof import('react-query');
 
     interface Window {
@@ -23,6 +24,7 @@ declare global {
         L: typeof L;
         log: typeof log;
         connectToStore: typeof connectToStore;
+        ReactRedux: typeof ReactRedux;
         ReactQuery: typeof ReactQuery;
     }
 

--- a/app/utils/StageAPI.ts
+++ b/app/utils/StageAPI.ts
@@ -270,6 +270,7 @@ declare global {
                     };
                 };
             }
+            type ReduxState = import('../reducers').ReduxState;
         }
     }
 }

--- a/backend/package.json
+++ b/backend/package.json
@@ -15,7 +15,7 @@
     "db-migrate-down-to": "node migration downTo",
     "db-migrate-reset": "node migration reset",
     "db-migrate-status": "node migration status",
-    "startWithNodemon": "cross-env NODE_ENV=development nodemon --watch . --watch ../conf",
+    "startWithNodemon": "cross-env NODE_ENV=development NODE_TLS_REJECT_UNAUTHORIZED='0' nodemon --watch . --watch ../conf",
     "devDebug": "npm run startWithNodemon -- --inspect server.js",
     "devStart": "npm run startWithNodemon -- server.js",
     "devTrace": "npm run startWithNodemon -- --trace-warnings server.js",

--- a/test/jest/reducers/pagesReducer.test.js
+++ b/test/jest/reducers/pagesReducer.test.js
@@ -9,6 +9,7 @@ import thunk from 'redux-thunk';
 import { applyMiddleware, combineReducers, createStore } from 'redux';
 
 import pageReducer from 'reducers/pageReducer';
+import drilldownContextReducer from 'reducers/drilldownContextReducer';
 
 import { drillDownToPage } from 'actions/drilldownPage';
 import { changePageName, changePageDescription, removePage } from 'actions/page';
@@ -20,7 +21,7 @@ const mockStore = configureMockStore([thunk]);
 describe('(Reducer) Pages', () => {
     describe('Drilldown to page actions', () => {
         it('create a drilldown page if it doesnt exist', () => {
-            const initialState = { widgetDefinitions: [{ id: 'widget1' }] };
+            const initialState = { widgetDefinitions: [{ id: 'widget1' }], drilldownContext: [] };
 
             const store = mockStore(initialState);
 
@@ -65,6 +66,7 @@ describe('(Reducer) Pages', () => {
                     widgetId: '1',
                     drillDownName: 'tmp1'
                 },
+                { type: types.SET_DRILLDOWN_CONTEXT, drilldownContext: [{ context: undefined }] },
                 { type: types.WIDGET_DATA_CLEAR },
                 { type: 'router action' }
             ];
@@ -93,7 +95,7 @@ describe('(Reducer) Pages', () => {
                     }
                 ]
             };
-            store.dispatch(drillDownToPage(widget, pageDef));
+            store.dispatch(drillDownToPage(widget, pageDef, {}));
 
             const storeActions = store.getActions();
 
@@ -172,12 +174,16 @@ describe('(Reducer) Pages', () => {
 
             const store = mockStore(initialState);
 
-            const expectedActions = [{ type: types.WIDGET_DATA_CLEAR }, { type: 'router action' }];
+            const expectedActions = [
+                { type: types.WIDGET_DATA_CLEAR },
+                { type: types.SET_DRILLDOWN_CONTEXT, drilldownContext: [{ context: undefined }] },
+                { type: 'router action' }
+            ];
 
             const widget = initialState.pages[0].widgets[0];
             const defaultTemplate = initialState.templates.templatesDef.tmp1;
 
-            store.dispatch(drillDownToPage(widget, defaultTemplate));
+            store.dispatch(drillDownToPage(widget, defaultTemplate, {}));
 
             const storeActions = store.getActions();
 
@@ -255,7 +261,7 @@ describe('(Reducer) Pages', () => {
             );
 
             const storeActions = store.getActions();
-            const routeAction = storeActions[1];
+            const routeAction = storeActions[2];
 
             expect(routeAction.payload.args).toHaveLength(1);
             const query = parse(routeAction.payload.args[0].search);
@@ -284,12 +290,14 @@ describe('(Reducer) Pages', () => {
                         }
                     ]
                 }
-            ]
+            ],
+            drilldownContext: []
         };
 
         const store = createStore(
             combineReducers({
                 pages: pageReducer,
+                drilldownContext: drilldownContextReducer,
                 widgetDefinitions: pageReducer
             }),
             initialState,
@@ -316,7 +324,7 @@ describe('(Reducer) Pages', () => {
             ]
         };
 
-        store.dispatch(drillDownToPage(widget, pageDef));
+        store.dispatch(drillDownToPage(widget, pageDef, {}));
 
         const { pages } = store.getState();
         const parentPage = pages[0];
@@ -392,10 +400,15 @@ describe('(Reducer) Pages', () => {
                         }
                     ]
                 }
-            ]
+            ],
+            drilldownContext: []
         };
 
-        const store = createStore(combineReducers({ pages: pageReducer }), initialState, applyMiddleware(thunk));
+        const store = createStore(
+            combineReducers({ pages: pageReducer, drilldownContext: drilldownContextReducer }),
+            initialState,
+            applyMiddleware(thunk)
+        );
 
         const widget = initialState.pages[0].layout[0].content[0];
         const pageDef1 = {
@@ -434,8 +447,8 @@ describe('(Reducer) Pages', () => {
                 }
             ]
         };
-        store.dispatch(drillDownToPage(widget, pageDef1));
-        store.dispatch(drillDownToPage(widget, pageDef2));
+        store.dispatch(drillDownToPage(widget, pageDef1, {}));
+        store.dispatch(drillDownToPage(widget, pageDef2, {}));
 
         const { pages } = store.getState();
         const parentPage = pages[0];

--- a/widgets/deploymentsView/src/widget.tsx
+++ b/widgets/deploymentsView/src/widget.tsx
@@ -146,6 +146,17 @@ const DeploymentsView: FunctionComponent<DeploymentsViewProps> = ({ widget, tool
         }
     );
 
+    if (filterByParentDeployment && !parentDeploymentId) {
+        const i18nMissingParentDeploymentPrefix = `${i18nMessagesPrefix}.missingParentDeploymentId`;
+
+        return (
+            <ErrorMessage
+                header={i18n.t(`${i18nMissingParentDeploymentPrefix}.header`)}
+                error={i18n.t(`${i18nMissingParentDeploymentPrefix}.message`)}
+            />
+        );
+    }
+
     if (filterRulesResult.isLoading) {
         return <Loading message={i18n.t(`${i18nMessagesPrefix}.loadingFilterRules`)} />;
     }

--- a/widgets/deploymentsView/src/widget.tsx
+++ b/widgets/deploymentsView/src/widget.tsx
@@ -31,7 +31,7 @@ if (process.env.NODE_ENV === 'development' || process.env.TEST) {
         name: Stage.i18n.t(`${i18nPrefix}.name`),
         description: Stage.i18n.t(`${i18nPrefix}.description`),
         initialWidth: 12,
-        initialHeight: 40,
+        initialHeight: 28,
         color: 'purple',
         categories: [Stage.GenericConfig.CATEGORY.DEPLOYMENTS],
 

--- a/widgets/deploymentsView/src/widget.tsx
+++ b/widgets/deploymentsView/src/widget.tsx
@@ -24,63 +24,61 @@ interface DeploymentsViewWidgetConfiguration {
     sortAscending: string;
 }
 
-// TODO(RD-1226): remove environment check
-if (process.env.NODE_ENV === 'development' || process.env.TEST) {
-    Stage.defineWidget<never, never, DeploymentsViewWidgetConfiguration>({
-        id: 'deploymentsView',
-        name: Stage.i18n.t(`${i18nPrefix}.name`),
-        description: Stage.i18n.t(`${i18nPrefix}.description`),
-        initialWidth: 12,
-        initialHeight: 28,
-        color: 'purple',
-        categories: [Stage.GenericConfig.CATEGORY.DEPLOYMENTS],
+Stage.defineWidget<never, never, DeploymentsViewWidgetConfiguration>({
+    id: 'deploymentsView',
+    name: Stage.i18n.t(`${i18nPrefix}.name`),
+    description: Stage.i18n.t(`${i18nPrefix}.description`),
+    initialWidth: 12,
+    initialHeight: 28,
+    color: 'purple',
+    categories: [Stage.GenericConfig.CATEGORY.DEPLOYMENTS],
 
-        initialConfiguration: [
-            {
-                ...Stage.GenericConfig.POLLING_TIME_CONFIG(10),
-                // NOTE: polling is handled by react-query, thus, use a different ID
-                id: 'customPollingTime'
-            },
-            {
-                id: 'filterId',
-                // TODO(RD-1851): add autocomplete instead of plain text input
-                type: Stage.Basic.GenericField.STRING_TYPE,
-                name: Stage.i18n.t(`${i18nPrefix}.configuration.filterId.name`)
-            },
-            {
-                // TODO(RD-1853): handle filtering by parent deployment
-                id: 'filterByParentDeployment',
-                type: Stage.Basic.GenericField.BOOLEAN_TYPE,
-                name: Stage.i18n.t(`${i18nPrefix}.configuration.filterByParentDeployment.name`),
-                description: Stage.i18n.t(`${i18nPrefix}.configuration.filterByParentDeployment.description`),
-                default: false
-            },
-            // TODO(RD-1225): add map configuration
-            {
-                id: 'fieldsToShow',
-                name: Stage.i18n.t(`${i18nPrefix}.configuration.fieldsToShow.name`),
-                placeHolder: Stage.i18n.t(`${i18nPrefix}.configuration.fieldsToShow.placeholder`),
-                items: deploymentsViewColumnIds.map(columnId => ({
-                    name: deploymentsViewColumnDefinitions[columnId].name,
-                    value: columnId
-                })),
-                default: deploymentsViewColumnIds.filter(columnId => columnId !== 'environmentType'),
-                type: Stage.Basic.GenericField.MULTI_SELECT_LIST_TYPE
-            },
-            Stage.GenericConfig.PAGE_SIZE_CONFIG(100),
-            Stage.GenericConfig.SORT_COLUMN_CONFIG('created_at'),
-            Stage.GenericConfig.SORT_ASCENDING_CONFIG(false)
-        ],
-        isReact: true,
-        hasReadme: true,
-        hasStyle: false,
-        permission: Stage.GenericConfig.WIDGET_PERMISSION('deploymentsView'),
+    initialConfiguration: [
+        {
+            ...Stage.GenericConfig.POLLING_TIME_CONFIG(10),
+            // NOTE: polling is handled by react-query, thus, use a different ID
+            id: 'customPollingTime'
+        },
+        {
+            id: 'filterId',
+            // TODO(RD-1851): add autocomplete instead of plain text input
+            type: Stage.Basic.GenericField.STRING_TYPE,
+            name: Stage.i18n.t(`${i18nPrefix}.configuration.filterId.name`)
+        },
+        {
+            // TODO(RD-1853): handle filtering by parent deployment
+            id: 'filterByParentDeployment',
+            type: Stage.Basic.GenericField.BOOLEAN_TYPE,
+            name: Stage.i18n.t(`${i18nPrefix}.configuration.filterByParentDeployment.name`),
+            description: Stage.i18n.t(`${i18nPrefix}.configuration.filterByParentDeployment.description`),
+            default: false
+        },
+        // TODO(RD-1225): add map configuration
+        {
+            id: 'fieldsToShow',
+            name: Stage.i18n.t(`${i18nPrefix}.configuration.fieldsToShow.name`),
+            placeHolder: Stage.i18n.t(`${i18nPrefix}.configuration.fieldsToShow.placeholder`),
+            items: deploymentsViewColumnIds.map(columnId => ({
+                name: deploymentsViewColumnDefinitions[columnId].name,
+                value: columnId
+            })),
+            default: deploymentsViewColumnIds.filter(columnId => columnId !== 'environmentType'),
+            type: Stage.Basic.GenericField.MULTI_SELECT_LIST_TYPE
+        },
+        Stage.GenericConfig.PAGE_SIZE_CONFIG(100),
+        Stage.GenericConfig.SORT_COLUMN_CONFIG('created_at'),
+        Stage.GenericConfig.SORT_ASCENDING_CONFIG(false)
+    ],
+    isReact: true,
+    // TOOD(RD-1532): enable readme after filling it in
+    hasReadme: false,
+    hasStyle: false,
+    permission: Stage.GenericConfig.WIDGET_PERMISSION('deploymentsView'),
 
-        render(widget, _data, _error, toolbox) {
-            return <DeploymentsView widget={widget} toolbox={toolbox} />;
-        }
-    });
-}
+    render(widget, _data, _error, toolbox) {
+        return <DeploymentsView widget={widget} toolbox={toolbox} />;
+    }
+});
 
 const i18nMessagesPrefix = `${i18nPrefix}.messages`;
 


### PR DESCRIPTION
This PR adds filtering by parent deployment in the Deployments View widget. It covers RD-1853

Some of the changes to the core of the application result from the fact that `drilldownContext` only contained entries for each drill-down page, but not the topmost page. This would make it impossible to filter by the deployment selected on the topmost Environments/Services page because the selected deployment would be gone. Now, all pages, no matter if drilled-down, or top-level, are present in the `drilldownContext` array in the store.

As a side effect, when going back to some predecessor page by clicking the breadcrumbs, the context is now restored. If you set some configuration option on the top-level page (e.g. set a filter), drill down, and go back to that top-level page, the filter will be restored. IMO that's a nice UX improvement.

There is a known issue and incompatibility between the _Deployments_ and the _Deployments View_ widget in how they handle the `deploymentId` context. See RD-1984 for more details.

Some of the problems I tackled in this PR could have been solved in RD-1226, but then I would not be able to confidently tell that the functionality of filtering by parent deployment is working :smile: 

## Video and how to test

I found it easiest to test the functionality in the following manner:
1. Have the following structure of pages when drilling-down in the Deployments widget:
    1. Top-level page with Deployments widget.
    2. A drilled-down page, with Deployments widget and with Deployments View widget configured to filter by parent deployment.
    3. A drilled-down page, with Deployments widget and with Deployments View widget configured to filter by parent deployment.
2. On the top-level page, select a deployment that has children. In my video, that's `app-env`
3. In the first drill-down page, notice that there is a warning that there is no parent deployment. This is expected due to RD-1984 (`deploymentId` is set not on the parent page, but on the current page).
4. On that first drill-down page, select any deployment. In my video, that's `db-1` (but it does not matter)
5. In the second drill-down page, notice that the Deployments View widget shows the deployments that are directly connected to `app-env` (the parent deployment, meaning the `deploymentId` set on the parent (first drill-down) page). Those deployments are `db-env` and `web-app`. This is expected.

Additionally, notice that when going to the top-level page, the blueprint filter is restored :slightly_smiling_face: 

https://user-images.githubusercontent.com/889383/113746901-20747380-9707-11eb-9831-9748f698b932.mp4

## Videos from all `toolbox.drillDown` calls

I have verified all the places that use `toolbox.drillDown` to make sure there are no regressions. I did not find any.

<details>
<summary>Click to expand videos</summary>

### Deploy blueprint modal (in 3 places) & Blueprints

https://user-images.githubusercontent.com/889383/113869010-8b2db980-97b0-11eb-8cae-a1124b1ad49e.mp4

### Last execution logs


https://user-images.githubusercontent.com/889383/113869085-9d0f5c80-97b0-11eb-98e3-51f46b081f20.mp4

### Agents modals (install & validate)


https://user-images.githubusercontent.com/889383/113869124-a7315b00-97b0-11eb-853a-16208cb445df.mp4


https://user-images.githubusercontent.com/889383/113869135-a8fb1e80-97b0-11eb-894b-36e4097ed396.mp4


### Deployments


https://user-images.githubusercontent.com/889383/113869195-b912fe00-97b0-11eb-95c3-4a5b6ee2b014.mp4

### Deployment wizard

I thought the component was stuck due to some JS errors, but after I come back to the browser in the end, I got to the correct drill-down page :slightly_smiling_face: 

https://user-images.githubusercontent.com/889383/113869293-d5169f80-97b0-11eb-90f7-9baa681aeb93.mp4

### Topology (drill-down to deployment node)

I could not test this functionality, because I do not know how to show a deployment node in the topology. Let me know how to get https://github.com/cloudify-cosmo/cloudify-stage/blob/master/widgets/topology/src/Topology.jsx#L314-L319 to run


</details>

## System tests

The feature will be automatically tested when doing RD-1226.

Here's a run of system tests to catch possible regressions:

https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/402/pipeline

Ran 2021-04-07 9:27 CEST