### PR TITLE
RD-1839 RD-1840 Use renamed and stable properties

### DIFF
--- a/app/utils/shared/ExecutionUtils.js
+++ b/app/utils/shared/ExecutionUtils.js
@@ -124,6 +124,9 @@ export default class ExecutionUtils {
         return ExecutionUtils.STATUS_ICON_PARAMS[ExecutionUtils.getExecutionStatusGroup(execution)];
     }
 
+    /**
+     * @param {{ total_operations: number, finished_operations: number }} execution
+     */
     static getProgress(execution) {
         const { finished_operations: finishedOperations, total_operations: totalOperations } = execution;
         const ratio = finishedOperations / totalOperations;

--- a/test/cypress/fixtures/deployments/various-statuses.json
+++ b/test/cypress/fixtures/deployments/various-statuses.json
@@ -492,8 +492,8 @@
             "deployment_groups": [],
             "latest_execution_status": "failed",
             "environment_type": "controller",
-            "total_operations": 10,
-            "finished_operations": 6
+            "latest_execution_total_operations": 10,
+            "latest_execution_finished_operations": 6
         },
 
         {
@@ -987,8 +987,8 @@
             "deployment_groups": [],
             "latest_execution_status": "completed",
             "environment_type": "subcloud",
-            "total_operations": 10,
-            "finished_operations": 10
+            "latest_execution_total_operations": 10,
+            "latest_execution_finished_operations": 10
         },
         {
             "id": "hello-world-one",
@@ -1474,8 +1474,8 @@
             "deployment_groups": [],
             "latest_execution_status": "in_progress",
             "environment_type": "acidic",
-            "total_operations": 10,
-            "finished_operations": 3
+            "latest_execution_total_operations": 10,
+            "latest_execution_finished_operations": 3
         }
     ]
 }

--- a/widgets/deploymentsView/src/table/columns.tsx
+++ b/widgets/deploymentsView/src/table/columns.tsx
@@ -107,9 +107,10 @@ const partialDeploymentsViewColumnDefinitions: Record<
         width: '1em',
         // NOTE: properties come from the API. They are not prop-types (false-positive)
         /* eslint-disable camelcase */
-        // TODO(RD-1839): remove default values
-        render({ sub_environments_count = 0, sub_environments_status = SubdeploymentStatus.Good }) {
-            const iconName = subdeploymentStatusToIconMapping[sub_environments_status];
+        render({ sub_environments_count, sub_environments_status }) {
+            // NOTE: handle possible `null`s
+            const status = sub_environments_status ?? SubdeploymentStatus.Good;
+            const iconName = subdeploymentStatusToIconMapping[status];
             const icon = iconName && renderStatusIcon(iconName);
 
             return (
@@ -122,9 +123,10 @@ const partialDeploymentsViewColumnDefinitions: Record<
     subservicesCount: {
         label: <Stage.Basic.Icon name="cube" />,
         width: '1em',
-        // TODO(RD-1839): remove default values
-        render({ sub_services_count = 0, sub_services_status = SubdeploymentStatus.Good }) {
-            const iconName = subdeploymentStatusToIconMapping[sub_services_status];
+        render({ sub_services_count, sub_services_status }) {
+            // NOTE: handle possible `null`s
+            const status = sub_services_status ?? SubdeploymentStatus.Good;
+            const iconName = subdeploymentStatusToIconMapping[status];
             const icon = iconName && renderStatusIcon(iconName);
 
             return (

--- a/widgets/deploymentsView/src/table/renderDeploymentRow.tsx
+++ b/widgets/deploymentsView/src/table/renderDeploymentRow.tsx
@@ -45,9 +45,10 @@ function getDeploymentProgressUnderline(deployment: Deployment): ReactNode {
         return null;
     }
 
-    const progressValue = Stage.Utils.Execution.getProgress(
-        pick(deployment, 'total_operations', 'finished_operations')
-    );
+    const progressValue = Stage.Utils.Execution.getProgress({
+        total_operations: deployment.latest_execution_total_operations,
+        finished_operations: deployment.latest_execution_finished_operations
+    });
 
     return (
         <div

--- a/widgets/deploymentsView/src/table/renderDeploymentRow.tsx
+++ b/widgets/deploymentsView/src/table/renderDeploymentRow.tsx
@@ -1,4 +1,3 @@
-import { pick } from 'lodash';
 import { ReactNode } from 'react';
 
 import { deploymentsViewColumnDefinitions, DeploymentsViewColumnId } from './columns';

--- a/widgets/deploymentsView/src/types.ts
+++ b/widgets/deploymentsView/src/types.ts
@@ -32,14 +32,13 @@ export interface Deployment {
     latest_execution_status: LatestExecutionStatus;
     deployment_status: DeploymentStatus;
     installation_status: InstallationStatus;
-    // TODO(RD-1839): make properties required after they are stable in the backend
-    environment_type?: string;
+    environment_type: string;
     latest_execution_total_operations: number;
     latest_execution_finished_operations: number;
-    sub_services_count?: number;
-    sub_services_status?: SubdeploymentStatus;
-    sub_environments_count?: number;
-    sub_environments_status?: SubdeploymentStatus;
+    sub_services_count: number;
+    sub_services_status: SubdeploymentStatus | null;
+    sub_environments_count: number;
+    sub_environments_status: SubdeploymentStatus | null;
     /* eslint-enable camelcase */
 }
 

--- a/widgets/deploymentsView/src/types.ts
+++ b/widgets/deploymentsView/src/types.ts
@@ -34,8 +34,8 @@ export interface Deployment {
     installation_status: InstallationStatus;
     // TODO(RD-1839): make properties required after they are stable in the backend
     environment_type?: string;
-    total_operations?: number;
-    finished_operations?: number;
+    latest_execution_total_operations: number;
+    latest_execution_finished_operations: number;
     sub_services_count?: number;
     sub_services_status?: SubdeploymentStatus;
     sub_environments_count?: number;


### PR DESCRIPTION
The recently-added environments-related deployment properties are now present in the API responses, so we can safely use them, thus, they no longer need to be optional (RD-1839)

The latest execution progress properties were prefixed with `latest_execution_`, so they had to be renamed in the fixture and the code (RD-1840)

## System tests

https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/406/pipeline

Ran 2021-04-07 13:22 CEST