### PR TITLE
RD-2001 Add core drill-down functionality to Deployments View

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,11 +1,1 @@
-module.exports = {
-    ...require('./node_modules/cloudify-ui-common/configs/prettier-common.json'),
-    overrides: [
-        {
-            files: '*.json',
-            options: {
-                tabWidth: 2
-            }
-        }
-    ]
-};
+module.exports = require('./node_modules/cloudify-ui-common/configs/prettier-common.json');

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,1 +1,11 @@
-module.exports = require('./node_modules/cloudify-ui-common/configs/prettier-common.json');
+module.exports = {
+    ...require('./node_modules/cloudify-ui-common/configs/prettier-common.json'),
+    overrides: [
+        {
+            files: '*.json',
+            options: {
+                tabWidth: 2
+            }
+        }
+    ]
+};

--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -654,11 +654,11 @@
                     "services": "Services"
                 },
                 "buttons": {
-                    "subenvironments": {
+                    "environments": {
                         "label": "Subenvironments",
                         "title": "Drill down to subenvironments"
                     },
-                    "subservices": {
+                    "services": {
                         "label": "Services",
                         "title": "Drill down to subservices"
                     }

--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -648,6 +648,22 @@
                     "tooltip": "Services (Total)"
                 }
             },
+            "drillDown": {
+                "breadcrumbs": {
+                    "environments": "Environments",
+                    "services": "Services"
+                },
+                "buttons": {
+                    "subenvironments": {
+                        "label": "Subenvironments",
+                        "title": "Drill down to subenvironments"
+                    },
+                    "subservices": {
+                        "label": "Services",
+                        "title": "Drill down to subservices"
+                    }
+                }
+            },
             "messages": {
                 "noData": "No Results Found. Try changing the filter's parameters",
                 "loadingFilterRules": "Loading filter rules",

--- a/app/utils/StageAPI.ts
+++ b/app/utils/StageAPI.ts
@@ -55,6 +55,14 @@ interface StageWidget<Configuration = Record<string, unknown>> {
     configuration: Configuration;
     // TODO(RD-1649): consider renaming the field to resolvedDefinition
     definition: StageWidgetDefinition;
+    /**
+     * A mapping between the names (keys) and the IDs (values) of the pages
+     * that are possible to drill-down to from the widget.
+     *
+     * Added automatically when calling `toolbox.drillDown`
+     *
+     * @see {StageToolbox}
+     */
     drillDownPages: Record<string, string>;
     maximized: boolean;
 }

--- a/templates/pages/drilldownDeployments.json
+++ b/templates/pages/drilldownDeployments.json
@@ -1,0 +1,22 @@
+{
+  "name": "Subdeployments",
+  "layout": [
+    {
+      "type": "widgets",
+      "content": [
+        {
+          "name": "Deployments view",
+          "width": 12,
+          "height": 28,
+          "x": 0,
+          "y": 0,
+          "TODO(RD-2002)": "use the new drilled down widget",
+          "definition": "deploymentsView",
+          "configuration": {
+            "filterByParentDeployment": true
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/cypress/integration/templates/template_management_spec.js
+++ b/test/cypress/integration/templates/template_management_spec.js
@@ -34,6 +34,7 @@ describe('Template Management', () => {
         { id: 'catalog', name: 'Cloudify Catalog' },
         { id: 'deploy', name: 'Deployments' },
         { id: 'deployment', name: 'Deployment' },
+        { id: 'drilldownDeployments', name: 'Subdeployments' },
         { id: 'execution', name: 'Logs' },
         { id: 'ha', name: 'Admin Operations' },
         { id: 'logs', name: 'Logs' },

--- a/test/cypress/integration/widgets/deployments_view_spec.ts
+++ b/test/cypress/integration/widgets/deployments_view_spec.ts
@@ -1,6 +1,8 @@
 import type { RouteHandler } from 'cypress/types/net-stubbing';
 import { without } from 'lodash';
 
+import type { SystemLabel } from '../../support/deployments';
+
 import { exampleBlueprintUrl } from '../../support/resource_urls';
 
 describe('Deployments View widget', () => {
@@ -63,7 +65,7 @@ describe('Deployments View widget', () => {
             .usePageMock(
                 [widgetId],
                 { ...widgetConfiguration, ...configurationOverrides },
-                { additionalWidgetIdsToLoad, widgetsWidth: 12 }
+                { additionalWidgetIdsToLoad, widgetsWidth: 12, additionalPageTemplates: ['drilldownDeployments'] }
             )
             .mockLogin();
         cy.wait('@deployments');
@@ -294,6 +296,113 @@ describe('Deployments View widget', () => {
                         .next('tr')
                         .should('not.have.class', 'deployment-progress-row');
                 });
+        });
+    });
+
+    describe('drill-down functionality', () => {
+        // Graph of deployments used in the tests
+        // Generated using https://textik.com/
+        //
+        // All names are prefixed with `specPrefix`
+        //
+        //                app-env
+        //                  - -
+        //                -/   \-
+        //               /       \-
+        //             -/          \-
+        //            /              \
+        //         db-env           web-app
+        //          ---
+        //        -/   \-
+        //      -/       \
+        //   db-1        db-2
+
+        type DrilldownDeploymentName = 'app-env' | 'db-env' | 'db-1' | 'db-2' | 'web-app';
+        const getDeploymentFullName = (name: DrilldownDeploymentName) => `${specPrefix}_${name}`;
+        // NOTE: the order matters, because the deployments will be created in this order
+        const deployments: Record<DrilldownDeploymentName, SystemLabel[]> = {
+            'app-env': [{ 'csys-obj-type': 'environment' }],
+            'db-env': [{ 'csys-obj-type': 'environment' }, { 'csys-obj-parent': getDeploymentFullName('app-env') }],
+            'db-1': [{ 'csys-obj-parent': getDeploymentFullName('db-env') }],
+            'db-2': [{ 'csys-obj-parent': getDeploymentFullName('db-env') }],
+            'web-app': [{ 'csys-obj-parent': getDeploymentFullName('app-env') }]
+        };
+
+        before(() => {
+            cy.log('Creating multiple deployments for the drill-down tests');
+            Object.entries(deployments).forEach(([deploymentShortName, labels], index) => {
+                const deploymentFullName = getDeploymentFullName(deploymentShortName as keyof typeof deployments);
+                cy.deployBlueprint(blueprintName, deploymentFullName, { webserver_port: 9122 - index }).setLabels(
+                    deploymentFullName,
+                    labels
+                );
+            });
+        });
+
+        it('should support the drill-down workflow', () => {
+            useDeploymentsViewWidget({
+                configurationOverrides: {
+                    filterId: 'csys-environment-filter'
+                }
+            });
+
+            getDeploymentsViewTable().within(() => {
+                cy.log('Only top-level environments should be visible');
+                cy.contains('app-env').click();
+                cy.contains('db-env').should('not.exist');
+                cy.contains('db-1').should('not.exist');
+                cy.contains('db-2').should('not.exist');
+                cy.contains('web-app').should('not.exist');
+            });
+
+            const getSubenvironmentsButton = () => cy.get('button').contains('Subenvironments');
+            const getSubservicesButton = () => cy.get('button').contains('Services');
+            const getBreadcrumbs = () => cy.get('.breadcrumb');
+
+            getDeploymentsViewDetailsPane().within(() => {
+                // TODO(RD-2003): uncomment the line below
+                // getSubservicesButton().contains('1');
+                cy.log('Drill down to subenvironments of app-env');
+                getSubenvironmentsButton().contains('1').click();
+            });
+
+            getBreadcrumbs().contains('app-env [Environments]');
+
+            const verifySubdeploymentsOfAppEnv = () => {
+                getDeploymentsViewTable().within(() => {
+                    cy.log('Subenvironments of app-env should be visible (only db-env)');
+                    cy.contains('db-env').click();
+                    cy.contains('app-env').should('not.exist');
+                    cy.contains('db-1').should('not.exist');
+                    // TODO(RD-2004): uncomment the line below
+                    // cy.contains('web-app').should('not.exist');
+                });
+            };
+            verifySubdeploymentsOfAppEnv();
+
+            getDeploymentsViewDetailsPane().within(() => {
+                getSubenvironmentsButton().contains('0').should('be.disabled');
+                cy.log('Drill down to subservices of db-env');
+                getSubservicesButton().contains('2').click();
+            });
+
+            getBreadcrumbs().contains('db-env [Services]');
+            getBreadcrumbs().contains('app-env [Environments]');
+            getDeploymentsViewTable().within(() => {
+                cy.log('Subservices of db-env should be visible (db-1, db-2)');
+                cy.contains('db-1').click();
+                cy.contains('db-2');
+                cy.contains('db-env').should('not.exist');
+            });
+
+            getDeploymentsViewDetailsPane().within(() => {
+                getSubenvironmentsButton().contains('0').should('be.disabled');
+                getSubservicesButton().contains('0').should('be.disabled');
+            });
+
+            cy.log('Go back to the parent environment');
+            getBreadcrumbs().contains('app-env').click();
+            verifySubdeploymentsOfAppEnv();
         });
     });
 });

--- a/test/cypress/integration/widgets/deployments_view_spec.ts
+++ b/test/cypress/integration/widgets/deployments_view_spec.ts
@@ -11,11 +11,11 @@ describe('Deployments View widget', () => {
     const deploymentNameThatMatchesFilter = `${specPrefix}precious_deployment`;
     const siteName = 'Olsztyn';
     const blueprintUrl = exampleBlueprintUrl;
-    const widgetConfiguration = {
+    const widgetConfiguration: import('../../../../widgets/deploymentsView/src/widget').DeploymentsViewWidgetConfiguration = {
         filterByParentDeployment: false,
         fieldsToShow: ['status', 'name', 'blueprintName', 'location', 'subenvironmentsCount', 'subservicesCount'],
         pageSize: 100,
-        pollingTime: 10,
+        customPollingTime: 10,
         sortColumn: 'created_at',
         sortAscending: false
     };

--- a/test/cypress/support/commands.ts
+++ b/test/cypress/support/commands.ts
@@ -182,14 +182,19 @@ const commands = {
         widgetConfiguration: any = {},
         {
             widgetsWidth = 8,
-            additionalWidgetIdsToLoad = []
-        }: { widgetsWidth?: number; additionalWidgetIdsToLoad?: string[] } = {}
+            additionalWidgetIdsToLoad = [],
+            additionalPageTemplates = []
+        }: { widgetsWidth?: number; additionalWidgetIdsToLoad?: string[]; additionalPageTemplates?: string[] } = {}
     ) => {
         const widgetIdsArray = _.castArray(widgetIds);
         const widgetIdsToLoad = [...widgetIdsArray, 'filter', 'pluginsCatalog', ...additionalWidgetIdsToLoad];
         cy.intercept('GET', '/console/widgets/list', widgetIdsToLoad.map(toIdObj));
         // required for drill-down testing
-        cy.intercept('GET', '/console/templates/pages', widgetIds ? ['blueprint', 'deployment'].map(toIdObj) : []);
+        cy.intercept(
+            'GET',
+            '/console/templates/pages',
+            widgetIds ? ['blueprint', 'deployment', ...additionalPageTemplates].map(toIdObj) : []
+        );
         cy.intercept('GET', '/console/templates', []);
         cy.intercept('GET', '/console/ua', {
             appDataVersion: 4,

--- a/test/cypress/support/deployments.ts
+++ b/test/cypress/support/deployments.ts
@@ -9,6 +9,12 @@ declare global {
     }
 }
 
+/**
+ * Reserved system label keys. The list may be outdated, as it is defined in the Manager
+ * (`/labels/deployments?_reserved=true`)
+ *
+ * @link https://docs.cloudify.co/api/v3.1/#list-filters
+ */
 type SystemLabelKeys =
     | 'csys-obj-parent'
     | 'csys-obj-type'

--- a/test/cypress/support/deployments.ts
+++ b/test/cypress/support/deployments.ts
@@ -9,7 +9,18 @@ declare global {
     }
 }
 
-type Label = {
+type SystemLabelKeys =
+    | 'csys-obj-parent'
+    | 'csys-obj-type'
+    | 'csys-env-type'
+    | 'csys-location-long'
+    | 'csys-location-name'
+    | 'csys-obj-name'
+    | 'csys-wrcp-services'
+    | 'csys-location-lat';
+
+export type SystemLabel = Partial<Record<SystemLabelKeys, string | string[]>>;
+export type Label = SystemLabel & {
     [key: string]: string | string[];
 };
 

--- a/widgets/deploymentsView/src/common.ts
+++ b/widgets/deploymentsView/src/common.ts
@@ -1,2 +1,6 @@
-// eslint-disable-next-line import/prefer-default-export
+import type { SemanticICONS } from 'semantic-ui-react';
+
 export const i18nPrefix = 'widgets.deploymentsView';
+
+export const subenvironmentsIcon: SemanticICONS = 'object group';
+export const subservicesIcon: SemanticICONS = 'cube';

--- a/widgets/deploymentsView/src/detailsPane/DrilldownButtons.tsx
+++ b/widgets/deploymentsView/src/detailsPane/DrilldownButtons.tsx
@@ -9,17 +9,11 @@ export interface DrilldownButtonsProps {
     drillDown: (templateName: string, drilldownContext: Record<string, any>, drilldownPageName: string) => void;
 }
 
-const subdeploymentsDrilldownTemplateName = 'drilldownDeployments';
-
 const ButtonsContainer = styled.div`
     margin: 0 1em;
 `;
 
-const i18nDrillDownPrefix = `${i18nPrefix}.drillDown`;
-
 const DrilldownButtons: FunctionComponent<DrilldownButtonsProps> = ({ drillDown, deployment }) => {
-    const { Button, Icon } = Stage.Basic;
-    const { i18n } = Stage;
     const {
         id: deploymentName,
         // TODO(RD-2003): fetch the number of only the immediate children
@@ -27,48 +21,65 @@ const DrilldownButtons: FunctionComponent<DrilldownButtonsProps> = ({ drillDown,
         sub_environments_count: subenvironmentsCount
     } = deployment;
 
-    const drilldownToSubenvironments = () => {
-        drillDown(
-            subdeploymentsDrilldownTemplateName,
-            // TODO(RD-2004): add filter rules in context to only show environments
-            {},
-            `${deploymentName} [${i18n.t(`${i18nDrillDownPrefix}.breadcrumbs.environments`)}]`
-        );
-    };
-    const drilldownToSubservices = () => {
-        drillDown(
-            subdeploymentsDrilldownTemplateName,
-            // TODO(RD-2004): add filter rules in context to only show services
-            {},
-            `${deploymentName} [${i18n.t(`${i18nDrillDownPrefix}.breadcrumbs.services`)}]`
-        );
-    };
-
     return (
         <ButtonsContainer>
-            <Button
-                basic
-                color="blue"
-                onClick={drilldownToSubenvironments}
-                disabled={subenvironmentsCount === 0}
-                title={i18n.t(`${i18nDrillDownPrefix}.buttons.subenvironments.title`)}
-            >
-                <Icon name={subenvironmentsIcon} />
-                {i18n.t(`${i18nDrillDownPrefix}.buttons.subenvironments.label`)} ({subenvironmentsCount})
-                {/* TODO(RD-2005): add icons depending on children state */}
-            </Button>
-            <Button
-                basic
-                color="blue"
-                onClick={drilldownToSubservices}
-                disabled={subservicesCount === 0}
-                title={i18n.t(`${i18nDrillDownPrefix}.buttons.subservices.title`)}
-            >
-                <Icon name={subservicesIcon} />
-                {i18n.t(`${i18nDrillDownPrefix}.buttons.subservices.label`)} ({subservicesCount})
-                {/* TODO(RD-2005): add icons depending on children state */}
-            </Button>
+            <DrilldownButton
+                type="environments"
+                subdeploymentsCount={subenvironmentsCount}
+                drillDown={drillDown}
+                deploymentName={deploymentName}
+            />
+            <DrilldownButton
+                type="services"
+                subdeploymentsCount={subservicesCount}
+                drillDown={drillDown}
+                deploymentName={deploymentName}
+            />
         </ButtonsContainer>
     );
 };
 export default DrilldownButtons;
+
+interface DrilldownButtonProps {
+    subdeploymentsCount: number;
+    type: 'environments' | 'services';
+    drillDown: DrilldownButtonsProps['drillDown'];
+    deploymentName: string;
+}
+
+const subdeploymentsDrilldownTemplateName = 'drilldownDeployments';
+const i18nDrillDownPrefix = `${i18nPrefix}.drillDown`;
+
+const DrilldownButton: FunctionComponent<DrilldownButtonProps> = ({
+    subdeploymentsCount,
+    type,
+    drillDown,
+    deploymentName
+}) => {
+    const { Button, Icon } = Stage.Basic;
+    const { i18n } = Stage;
+    const icon = type === 'services' ? subservicesIcon : subenvironmentsIcon;
+
+    const drilldownToSubdeployments = () => {
+        drillDown(
+            subdeploymentsDrilldownTemplateName,
+            // TODO(RD-2004): add filter rules in context to only show specific subdeployments type
+            {},
+            `${deploymentName} [${i18n.t(`${i18nDrillDownPrefix}.breadcrumbs.${type}`)}]`
+        );
+    };
+
+    return (
+        <Button
+            basic
+            color="blue"
+            onClick={drilldownToSubdeployments}
+            disabled={subdeploymentsCount === 0}
+            title={i18n.t(`${i18nDrillDownPrefix}.buttons.${type}.title`)}
+        >
+            <Icon name={icon} />
+            {i18n.t(`${i18nDrillDownPrefix}.buttons.${type}.label`)} ({subdeploymentsCount})
+            {/* TODO(RD-2005): add icons depending on children state */}
+        </Button>
+    );
+};

--- a/widgets/deploymentsView/src/detailsPane/DrilldownButtons.tsx
+++ b/widgets/deploymentsView/src/detailsPane/DrilldownButtons.tsx
@@ -1,0 +1,27 @@
+import type { FunctionComponent } from 'react';
+
+import { subenvironmentsIcon, subservicesIcon } from '../common';
+
+export interface DrilldownButtonsProps {
+    subservicesCount: number;
+    subenvironmentsCount: number;
+    toolbox: Stage.Types.Toolbox;
+}
+
+const DrilldownButtons: FunctionComponent<DrilldownButtonsProps> = ({ subenvironmentsCount, subservicesCount }) => {
+    const { Button, Icon } = Stage.Basic;
+    return (
+        <div>
+            {/* TODO: add icons depending on children state */}
+            <Button basic color="blue">
+                <Icon name={subenvironmentsIcon} />
+                Subenvironments ({subenvironmentsCount})
+            </Button>
+            <Button basic color="blue">
+                <Icon name={subservicesIcon} />
+                Services ({subservicesCount})
+            </Button>
+        </div>
+    );
+};
+export default DrilldownButtons;

--- a/widgets/deploymentsView/src/detailsPane/DrilldownButtons.tsx
+++ b/widgets/deploymentsView/src/detailsPane/DrilldownButtons.tsx
@@ -24,6 +24,8 @@ const DrilldownButtons: FunctionComponent<DrilldownButtonsProps> = ({ drillDown,
         sub_environments_count: subenvironmentsCount
     } = deployment;
 
+    // TODO: use i18n for all texts
+
     const drilldownToSubenvironments = () => {
         // TODO(RD-2004): add filter rules in context to only show environments
         drillDown(subdeploymentsDrilldownTemplateName, {}, `${deploymentName} [Environments]`);
@@ -35,11 +37,23 @@ const DrilldownButtons: FunctionComponent<DrilldownButtonsProps> = ({ drillDown,
 
     return (
         <ButtonsContainer>
-            <Button basic color="blue" onClick={drilldownToSubenvironments} disabled={subenvironmentsCount === 0}>
+            <Button
+                basic
+                color="blue"
+                onClick={drilldownToSubenvironments}
+                disabled={subenvironmentsCount === 0}
+                title="Drill down to subenvironments"
+            >
                 <Icon name={subenvironmentsIcon} />
                 Subenvironments ({subenvironmentsCount}){/* TODO(RD-2005): add icons depending on children state */}
             </Button>
-            <Button basic color="blue" onClick={drilldownToSubservices} disabled={subservicesCount === 0}>
+            <Button
+                basic
+                color="blue"
+                onClick={drilldownToSubservices}
+                disabled={subservicesCount === 0}
+                title="Drill down to subservices"
+            >
                 <Icon name={subservicesIcon} />
                 Services ({subservicesCount}){/* TODO(RD-2005): add icons depending on children state */}
             </Button>

--- a/widgets/deploymentsView/src/detailsPane/DrilldownButtons.tsx
+++ b/widgets/deploymentsView/src/detailsPane/DrilldownButtons.tsx
@@ -1,7 +1,7 @@
 import type { FunctionComponent } from 'react';
 import styled from 'styled-components';
 
-import { subenvironmentsIcon, subservicesIcon } from '../common';
+import { i18nPrefix, subenvironmentsIcon, subservicesIcon } from '../common';
 import type { Deployment } from '../types';
 
 export interface DrilldownButtonsProps {
@@ -15,8 +15,11 @@ const ButtonsContainer = styled.div`
     margin: 0 1em;
 `;
 
+const i18nDrillDownPrefix = `${i18nPrefix}.drillDown`;
+
 const DrilldownButtons: FunctionComponent<DrilldownButtonsProps> = ({ drillDown, deployment }) => {
     const { Button, Icon } = Stage.Basic;
+    const { i18n } = Stage;
     const {
         id: deploymentName,
         // TODO(RD-2003): fetch the number of only the immediate children
@@ -24,15 +27,21 @@ const DrilldownButtons: FunctionComponent<DrilldownButtonsProps> = ({ drillDown,
         sub_environments_count: subenvironmentsCount
     } = deployment;
 
-    // TODO: use i18n for all texts
-
     const drilldownToSubenvironments = () => {
-        // TODO(RD-2004): add filter rules in context to only show environments
-        drillDown(subdeploymentsDrilldownTemplateName, {}, `${deploymentName} [Environments]`);
+        drillDown(
+            subdeploymentsDrilldownTemplateName,
+            // TODO(RD-2004): add filter rules in context to only show environments
+            {},
+            `${deploymentName} [${i18n.t(`${i18nDrillDownPrefix}.breadcrumbs.environments`)}]`
+        );
     };
     const drilldownToSubservices = () => {
-        // TODO(RD-2004): add filter rules in context to only show services
-        drillDown(subdeploymentsDrilldownTemplateName, {}, `${deploymentName} [Services]`);
+        drillDown(
+            subdeploymentsDrilldownTemplateName,
+            // TODO(RD-2004): add filter rules in context to only show services
+            {},
+            `${deploymentName} [${i18n.t(`${i18nDrillDownPrefix}.breadcrumbs.services`)}]`
+        );
     };
 
     return (
@@ -42,20 +51,22 @@ const DrilldownButtons: FunctionComponent<DrilldownButtonsProps> = ({ drillDown,
                 color="blue"
                 onClick={drilldownToSubenvironments}
                 disabled={subenvironmentsCount === 0}
-                title="Drill down to subenvironments"
+                title={i18n.t(`${i18nDrillDownPrefix}.buttons.subenvironments.title`)}
             >
                 <Icon name={subenvironmentsIcon} />
-                Subenvironments ({subenvironmentsCount}){/* TODO(RD-2005): add icons depending on children state */}
+                {i18n.t(`${i18nDrillDownPrefix}.buttons.subenvironments.label`)} ({subenvironmentsCount})
+                {/* TODO(RD-2005): add icons depending on children state */}
             </Button>
             <Button
                 basic
                 color="blue"
                 onClick={drilldownToSubservices}
                 disabled={subservicesCount === 0}
-                title="Drill down to subservices"
+                title={i18n.t(`${i18nDrillDownPrefix}.buttons.subservices.title`)}
             >
                 <Icon name={subservicesIcon} />
-                Services ({subservicesCount}){/* TODO(RD-2005): add icons depending on children state */}
+                {i18n.t(`${i18nDrillDownPrefix}.buttons.subservices.label`)} ({subservicesCount})
+                {/* TODO(RD-2005): add icons depending on children state */}
             </Button>
         </ButtonsContainer>
     );

--- a/widgets/deploymentsView/src/detailsPane/DrilldownButtons.tsx
+++ b/widgets/deploymentsView/src/detailsPane/DrilldownButtons.tsx
@@ -1,27 +1,49 @@
 import type { FunctionComponent } from 'react';
+import styled from 'styled-components';
 
 import { subenvironmentsIcon, subservicesIcon } from '../common';
+import type { Deployment } from '../types';
 
 export interface DrilldownButtonsProps {
-    subservicesCount: number;
-    subenvironmentsCount: number;
-    toolbox: Stage.Types.Toolbox;
+    deployment: Deployment;
+    drillDown: (templateName: string, drilldownContext: Record<string, any>, drilldownPageName: string) => void;
 }
 
-const DrilldownButtons: FunctionComponent<DrilldownButtonsProps> = ({ subenvironmentsCount, subservicesCount }) => {
+const subdeploymentsDrilldownTemplateName = 'drilldownDeployments';
+
+const ButtonsContainer = styled.div`
+    margin: 0 1em;
+`;
+
+const DrilldownButtons: FunctionComponent<DrilldownButtonsProps> = ({ drillDown, deployment }) => {
     const { Button, Icon } = Stage.Basic;
+    const {
+        id: deploymentName,
+        // TODO(RD-2003): fetch the number of only the immediate children
+        sub_services_count: subservicesCount,
+        sub_environments_count: subenvironmentsCount
+    } = deployment;
+
+    const drilldownToSubenvironments = () => {
+        // TODO(RD-2004): add filter rules in context to only show environments
+        drillDown(subdeploymentsDrilldownTemplateName, {}, `${deploymentName} [Environments]`);
+    };
+    const drilldownToSubservices = () => {
+        // TODO(RD-2004): add filter rules in context to only show services
+        drillDown(subdeploymentsDrilldownTemplateName, {}, `${deploymentName} [Services]`);
+    };
+
     return (
-        <div>
-            {/* TODO: add icons depending on children state */}
-            <Button basic color="blue">
+        <ButtonsContainer>
+            <Button basic color="blue" onClick={drilldownToSubenvironments} disabled={subenvironmentsCount === 0}>
                 <Icon name={subenvironmentsIcon} />
-                Subenvironments ({subenvironmentsCount})
+                Subenvironments ({subenvironmentsCount}){/* TODO(RD-2005): add icons depending on children state */}
             </Button>
-            <Button basic color="blue">
+            <Button basic color="blue" onClick={drilldownToSubservices} disabled={subservicesCount === 0}>
                 <Icon name={subservicesIcon} />
-                Services ({subservicesCount})
+                Services ({subservicesCount}){/* TODO(RD-2005): add icons depending on children state */}
             </Button>
-        </div>
+        </ButtonsContainer>
     );
 };
 export default DrilldownButtons;

--- a/widgets/deploymentsView/src/detailsPane/header.tsx
+++ b/widgets/deploymentsView/src/detailsPane/header.tsx
@@ -1,15 +1,14 @@
 import { noop } from 'lodash';
-import { ComponentProps, FunctionComponent, useMemo, useRef } from 'react';
-
-import DrilldownButtons from './DrilldownButtons';
+import { ComponentProps, FunctionComponent, ReactNode, useMemo, useRef } from 'react';
 
 import './header.scss';
 
 export interface DetailsPaneHeaderProps {
     deploymentName: string;
+    drilldownButtons: ReactNode;
 }
 
-const DetailsPaneHeader: FunctionComponent<DetailsPaneHeaderProps> = ({ deploymentName }) => {
+const DetailsPaneHeader: FunctionComponent<DetailsPaneHeaderProps> = ({ deploymentName, drilldownButtons }) => {
     const { Header } = Stage.Basic;
     const { Widget } = Stage.Shared.Widgets;
     const uuidRef = useRef(Stage.Utils.uuid);
@@ -33,7 +32,7 @@ const DetailsPaneHeader: FunctionComponent<DetailsPaneHeaderProps> = ({ deployme
     return (
         <div className="detailsPaneHeader">
             <Header>{deploymentName}</Header>
-            <DrilldownButtons subservicesCount={0} subenvironmentsCount={0} />
+            {drilldownButtons}
             <Widget
                 widget={deploymentActionButtonsWidgetDescription}
                 isEditMode={false}

--- a/widgets/deploymentsView/src/detailsPane/header.tsx
+++ b/widgets/deploymentsView/src/detailsPane/header.tsx
@@ -1,6 +1,8 @@
 import { noop } from 'lodash';
 import { ComponentProps, FunctionComponent, useMemo, useRef } from 'react';
 
+import DrilldownButtons from './DrilldownButtons';
+
 import './header.scss';
 
 export interface DetailsPaneHeaderProps {
@@ -31,6 +33,7 @@ const DetailsPaneHeader: FunctionComponent<DetailsPaneHeaderProps> = ({ deployme
     return (
         <div className="detailsPaneHeader">
             <Header>{deploymentName}</Header>
+            <DrilldownButtons subservicesCount={0} subenvironmentsCount={0} />
             <Widget
                 widget={deploymentActionButtonsWidgetDescription}
                 isEditMode={false}

--- a/widgets/deploymentsView/src/detailsPane/index.tsx
+++ b/widgets/deploymentsView/src/detailsPane/index.tsx
@@ -1,6 +1,7 @@
 import type { FunctionComponent } from 'react';
 
 import type { Deployment } from '../types';
+import DrilldownButtons, { DrilldownButtonsProps } from './DrilldownButtons';
 import DetailsPaneHeader from './header';
 import DetailsPaneWidgets from './widgets';
 
@@ -14,9 +15,11 @@ export interface DetailsPaneProps {
      *    selected)
      */
     deployment: Deployment | undefined;
+    toolbox: Stage.Types.Toolbox;
+    widget: Stage.Types.Widget<any>;
 }
 
-const DetailsPane: FunctionComponent<DetailsPaneProps> = ({ deployment }) => {
+const DetailsPane: FunctionComponent<DetailsPaneProps> = ({ deployment, widget, toolbox }) => {
     if (!deployment) {
         const { Message } = Stage.Basic;
 
@@ -35,9 +38,15 @@ const DetailsPane: FunctionComponent<DetailsPaneProps> = ({ deployment }) => {
         );
     }
 
+    const drillDown: DrilldownButtonsProps['drillDown'] = (templateName, drilldownContext, drilldownPageName) =>
+        toolbox.drillDown(widget, templateName, drilldownContext, drilldownPageName);
+
     return (
         <div className="detailsPane">
-            <DetailsPaneHeader deploymentName={deployment.id} />
+            <DetailsPaneHeader
+                deploymentName={deployment.id}
+                drilldownButtons={<DrilldownButtons deployment={deployment} drillDown={drillDown} />}
+            />
             <DetailsPaneWidgets />
         </div>
     );

--- a/widgets/deploymentsView/src/table/columns.tsx
+++ b/widgets/deploymentsView/src/table/columns.tsx
@@ -2,7 +2,7 @@ import { mapValues } from 'lodash';
 import type { ReactNode } from 'react';
 import type { IconProps } from 'semantic-ui-react';
 
-import { i18nPrefix } from '../common';
+import { i18nPrefix, subenvironmentsIcon, subservicesIcon } from '../common';
 import { Deployment, DeploymentStatus, SubdeploymentStatus } from '../types';
 
 // NOTE: the order in the array determines the order in the UI
@@ -103,7 +103,7 @@ const partialDeploymentsViewColumnDefinitions: Record<
         }
     },
     subenvironmentsCount: {
-        label: <Stage.Basic.Icon name="object group" />,
+        label: <Stage.Basic.Icon name={subenvironmentsIcon} />,
         width: '1em',
         // NOTE: properties come from the API. They are not prop-types (false-positive)
         /* eslint-disable camelcase */
@@ -121,7 +121,7 @@ const partialDeploymentsViewColumnDefinitions: Record<
         }
     },
     subservicesCount: {
-        label: <Stage.Basic.Icon name="cube" />,
+        label: <Stage.Basic.Icon name={subservicesIcon} />,
         width: '1em',
         render({ sub_services_count, sub_services_status }) {
             // NOTE: handle possible `null`s

--- a/widgets/deploymentsView/src/widget.tsx
+++ b/widgets/deploymentsView/src/widget.tsx
@@ -185,7 +185,7 @@ const DeploymentsView: FunctionComponent<DeploymentsViewProps> = ({ widget, tool
                 deployments={deploymentsResult.data.items}
                 fieldsToShow={fieldsToShow}
             />
-            <DetailsPane deployment={selectedDeployment} />
+            <DetailsPane deployment={selectedDeployment} widget={widget} toolbox={toolbox} />
         </div>
     );
 };

--- a/widgets/deploymentsView/src/widget.tsx
+++ b/widgets/deploymentsView/src/widget.tsx
@@ -13,7 +13,7 @@ import DetailsPane from './detailsPane';
 import './styles.scss';
 import type { DeploymentsResponse } from './types';
 
-interface DeploymentsViewWidgetConfiguration {
+export interface DeploymentsViewWidgetConfiguration {
     /** In milliseconds */
     customPollingTime: number;
     filterId?: string;
@@ -21,7 +21,7 @@ interface DeploymentsViewWidgetConfiguration {
     fieldsToShow: DeploymentsViewColumnId[];
     pageSize: number;
     sortColumn: string;
-    sortAscending: string;
+    sortAscending: boolean;
 }
 
 Stage.defineWidget<never, never, DeploymentsViewWidgetConfiguration>({


### PR DESCRIPTION
This PRs is adding support for the basic drill-down functionalities in the Deployments View widget.

This is a partial implementation. The drill-down functionality itself is working, but there is still work to be done to get it working correctly and according to the designs. Take a look at the subtasks for RD-1226 for a list of upcoming tasks.

## Video


https://user-images.githubusercontent.com/889383/114018951-1f118b00-986e-11eb-894c-ca56f6be45e4.mp4

The structure of the deployments in the video is the same as in the tests:

```
        //                app-env
        //                  - -
        //                -/   \-
        //               /       \-
        //             -/          \-
        //            /              \
        //         db-env           web-app
        //          ---
        //        -/   \-
        //      -/       \
        //   db-1        db-2
```

## System tests

https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/417/pipeline

Ran 2021-04-08 15:49 CEST