### PR TITLE
RD-1123 Added cypress test for filters management widget

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12309,6 +12309,283 @@
         }
       }
     },
+    "cypress-get-table": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cypress-get-table/-/cypress-get-table-1.0.1.tgz",
+      "integrity": "sha512-lyNxGFhwlXA2ddcOOHAHGYtenGdvzBS418QN7pShiGhjlIuvWcMsNsLHMWgtrC77qpVXXqxSqlGzSiHGaDSsRQ==",
+      "dev": true,
+      "requires": {
+        "cypress": "^4.3.0",
+        "deep-equal-in-any-order": "^1.0.27"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "arch": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
+          "integrity": "sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==",
+          "dev": true
+        },
+        "bluebird": {
+          "version": "3.7.2",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+          "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+          "dev": true
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
+          }
+        },
+        "cli-table3": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.5.1.tgz",
+          "integrity": "sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==",
+          "dev": true,
+          "requires": {
+            "colors": "^1.1.2",
+            "object-assign": "^4.1.0",
+            "string-width": "^2.1.1"
+          }
+        },
+        "colors": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+          "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+          "dev": true,
+          "optional": true
+        },
+        "commander": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+          "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+          "dev": true
+        },
+        "cypress": {
+          "version": "4.12.1",
+          "resolved": "https://registry.npmjs.org/cypress/-/cypress-4.12.1.tgz",
+          "integrity": "sha512-9SGIPEmqU8vuRA6xst2CMTYd9sCFCxKSzrHt0wr+w2iAQMCIIsXsQ5Gplns1sT6LDbZcmLv6uehabAOl3fhc9Q==",
+          "dev": true,
+          "requires": {
+            "@cypress/listr-verbose-renderer": "^0.4.1",
+            "@cypress/request": "^2.88.5",
+            "@cypress/xvfb": "^1.2.4",
+            "@types/sinonjs__fake-timers": "^6.0.1",
+            "@types/sizzle": "^2.3.2",
+            "arch": "^2.1.2",
+            "bluebird": "^3.7.2",
+            "cachedir": "^2.3.0",
+            "chalk": "^2.4.2",
+            "check-more-types": "^2.24.0",
+            "cli-table3": "~0.5.1",
+            "commander": "^4.1.1",
+            "common-tags": "^1.8.0",
+            "debug": "^4.1.1",
+            "eventemitter2": "^6.4.2",
+            "execa": "^1.0.0",
+            "executable": "^4.1.1",
+            "extract-zip": "^1.7.0",
+            "fs-extra": "^8.1.0",
+            "getos": "^3.2.1",
+            "is-ci": "^2.0.0",
+            "is-installed-globally": "^0.3.2",
+            "lazy-ass": "^1.6.0",
+            "listr": "^0.14.3",
+            "lodash": "^4.17.19",
+            "log-symbols": "^3.0.0",
+            "minimist": "^1.2.5",
+            "moment": "^2.27.0",
+            "ospath": "^1.2.2",
+            "pretty-bytes": "^5.3.0",
+            "ramda": "~0.26.1",
+            "request-progress": "^3.0.0",
+            "supports-color": "^7.1.0",
+            "tmp": "~0.1.0",
+            "untildify": "^4.0.0",
+            "url": "^0.11.0",
+            "yauzl": "^2.10.0"
+          }
+        },
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "execa": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^4.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.2.6",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+          "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
+        "log-symbols": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
+          "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.2"
+          }
+        },
+        "moment": {
+          "version": "2.29.1",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+          "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "pump": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+          "dev": true,
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          },
+          "dependencies": {
+            "has-flag": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+              "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+              "dev": true
+            }
+          }
+        },
+        "tmp": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
+          "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
+          "dev": true,
+          "requires": {
+            "rimraf": "^2.6.3"
+          }
+        },
+        "universalify": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+          "dev": true
+        }
+      }
+    },
     "cypress-localstorage-commands": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/cypress-localstorage-commands/-/cypress-localstorage-commands-1.3.1.tgz",
@@ -12634,6 +12911,16 @@
         "object-is": "^1.0.1",
         "object-keys": "^1.1.1",
         "regexp.prototype.flags": "^1.2.0"
+      }
+    },
+    "deep-equal-in-any-order": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/deep-equal-in-any-order/-/deep-equal-in-any-order-1.1.4.tgz",
+      "integrity": "sha512-yigFzn8ynCxq7ECTXiH/sS3as0QZaXDeSY6QmXPA67C+TwfilSh2AkNMrmmCYp+dh/UcA7UHTmpC7qwT4zEOLA==",
+      "dev": true,
+      "requires": {
+        "lodash.mapvalues": "^4.6.0",
+        "sort-any": "^1.2.2"
       }
     },
     "deep-is": {
@@ -21537,6 +21824,12 @@
       "integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM=",
       "dev": true
     },
+    "lodash.mapvalues": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
+      "integrity": "sha1-G6+lAF3p3W9PJmaMMMo3IwzJaJw=",
+      "dev": true
+    },
     "lodash.memoize": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
@@ -26771,6 +27064,23 @@
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
+    "sort-any": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/sort-any/-/sort-any-1.2.3.tgz",
+      "integrity": "sha512-yJLpmCgDOu7Z6XS6ofzcKRy/Id8yfGB8KkzC7oKAk1F7P3jPWEU8GMxBJWDo5fKp71JYY1bJ8tmaHBfoTx+y8w==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.21"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
     "css-loader": "^3.2.0",
     "cypress": "^6.4.0",
     "cypress-file-upload": "^4.1.1",
+    "cypress-get-table": "^1.0.1",
     "cypress-localstorage-commands": "^1.2.5",
     "enzyme": "^3.9.0",
     "enzyme-adapter-react-16": "^1.15.1",

--- a/test/cypress/integration/widgets/filters_spec.ts
+++ b/test/cypress/integration/widgets/filters_spec.ts
@@ -1,4 +1,4 @@
-import { FilterRule } from '../../../../widgets/common/src/filters/types';
+import type { FilterRule } from '../../../../widgets/common/src/filters/types';
 
 describe('Filters widget', () => {
     before(() => {

--- a/test/cypress/integration/widgets/filters_spec.ts
+++ b/test/cypress/integration/widgets/filters_spec.ts
@@ -1,0 +1,116 @@
+import { FilterRule } from '../../../../widgets/common/src/filters/types';
+
+describe('Filters widget', () => {
+    before(() => {
+        cy.usePageMock('filters').activate().mockLogin();
+    });
+
+    const filterName = 'filters_test_filter';
+    const filterRules: FilterRule[] = [
+        { type: 'attribute', key: 'blueprint_id', values: ['bpid'], operator: 'any_of' },
+        { type: 'label', key: 'precious', values: ['yes'], operator: 'any_of' }
+    ];
+
+    beforeEach(() => {
+        cy.deleteDeploymentsFilters(filterName).createDeploymentsFilter(filterName, filterRules).refreshPage();
+        cy.get('input[placeholder="Search..."]').type(filterName);
+        cy.get('.loading').should('not.exist');
+    });
+
+    it('should list existing filters', () => {
+        cy.get('table')
+            .getTable()
+            .should(tableData => {
+                expect(tableData).to.have.length(1);
+                expect(tableData[0]['Filter name']).to.eq(filterName);
+                expect(tableData[0].Creator).to.eq('admin');
+                expect(tableData[0].Created).not.to.be.null;
+            });
+    });
+
+    it('should allow to add new filter', () => {
+        cy.contains('Add').click();
+
+        cy.contains('Save').click();
+        cy.contains('Please provide the filter ID');
+
+        const newFilterName = `${filterName}_added`;
+        cy.contains('.field', 'Filter ID').find('input').type(newFilterName);
+        // TODO: RD-1985 Define some filter rules once rules form is available here
+        cy.interceptSp('PUT', `/filters/deployments/${newFilterName}`).as('createRequest');
+        cy.contains('Save').click();
+        cy.wait('@createRequest').then(({ request }) => {
+            expect(request.body).to.deep.equal({
+                filter_rules: []
+            });
+        });
+
+        cy.get('.modal').should('not.exist');
+        cy.contains(newFilterName);
+
+        cy.get('table')
+            .getTable()
+            .should(tableData => {
+                expect(tableData).to.have.length(2);
+                expect(tableData[1]['Filter name']).to.eq(newFilterName);
+                expect(tableData[1].Creator).to.eq('admin');
+                expect(tableData[1].Created).not.to.be.null;
+            });
+    });
+
+    it('should allow to edit existing filter', () => {
+        cy.get('.edit').click();
+        cy.contains(`Edit filter '${filterName}'`);
+
+        // TODO: RD-1985 Change some filter rules once rules form is available here
+        cy.interceptSp('PATCH', `/filters/deployments/${filterName}`).as('updateRequest');
+        cy.contains('Save').click();
+        cy.wait('@updateRequest').then(({ request }) => {
+            expect(request.body).to.deep.equal({
+                filter_rules: filterRules
+            });
+        });
+
+        cy.get('.modal').should('not.exist');
+    });
+
+    it('should allow to clone existing filter', () => {
+        cy.get('.clone').click();
+        cy.contains(`Clone filter '${filterName}'`);
+
+        // TODO: RD-1985 Change some filter rules once rules form is available here
+        cy.interceptSp('PUT', `/filters/deployments/${filterName}_clone`).as('updateRequest');
+        cy.contains('Save').click();
+        cy.wait('@updateRequest').then(({ request }) => {
+            expect(request.body).to.deep.equal({
+                filter_rules: filterRules
+            });
+        });
+
+        cy.get('.modal').should('not.exist');
+    });
+
+    it('should allow to remove existing filter', () => {
+        cy.get('.trash').click();
+        cy.contains('Yes').click();
+
+        cy.contains('There are no filters defined');
+    });
+
+    it('should prevent filter used as default from being removed', () => {
+        cy.intercept('GET', `/console/filters/usage/${filterName}`, [
+            { pageName: 'Dashboard', widgetName: 'Deployments View', username: 'admin' }
+        ]).as('usageRequest');
+
+        cy.get('.trash').click();
+        cy.contains('Yes').click();
+
+        cy.wait('@usageRequest');
+
+        cy.contains("Filter 'filters_test_filter' cannot be removed");
+        cy.contains("Used as default filter in 'Deployments View' widget in 'Dashboard' page by user 'admin'");
+
+        cy.contains('OK').click();
+        cy.get('.modal').should('not.exist');
+    });
+});

--- a/test/cypress/support/commands.ts
+++ b/test/cypress/support/commands.ts
@@ -10,6 +10,7 @@
 
 import 'cypress-file-upload';
 import 'cypress-localstorage-commands';
+import 'cypress-get-table';
 import _ from 'lodash';
 import type { RouteHandler, StringMatcher } from 'cypress/types/net-stubbing';
 
@@ -37,8 +38,10 @@ const getCommonHeaders = () => ({
 declare global {
     namespace Cypress {
         // NOTE: necessary for extending the Cypress API
-        // eslint-disable-next-line @typescript-eslint/no-empty-interface
-        export interface Chainable extends GetCypressChainableFromCommands<typeof commands> {}
+        export interface Chainable extends GetCypressChainableFromCommands<typeof commands> {
+            // typing for cypress-get-table
+            getTable: () => Cypress.Chainable;
+        }
     }
 }
 

--- a/test/cypress/support/commands.ts
+++ b/test/cypress/support/commands.ts
@@ -39,7 +39,11 @@ declare global {
     namespace Cypress {
         // NOTE: necessary for extending the Cypress API
         export interface Chainable extends GetCypressChainableFromCommands<typeof commands> {
-            // typing for cypress-get-table
+            /**
+             * Returns the table data
+             *
+             * @see {@link https://www.npmjs.com/package/cypress-get-table}
+             */
             getTable: () => Cypress.Chainable<Record<string, any>[]>;
         }
     }

--- a/test/cypress/support/commands.ts
+++ b/test/cypress/support/commands.ts
@@ -40,7 +40,7 @@ declare global {
         // NOTE: necessary for extending the Cypress API
         export interface Chainable extends GetCypressChainableFromCommands<typeof commands> {
             // typing for cypress-get-table
-            getTable: () => Cypress.Chainable;
+            getTable: () => Cypress.Chainable<Record<string, any>[]>;
         }
     }
 }

--- a/test/cypress/support/filters.ts
+++ b/test/cypress/support/filters.ts
@@ -1,5 +1,6 @@
 import { addCommands, GetCypressChainableFromCommands } from 'cloudify-ui-common/cypress/support';
 import type { FilterRule } from '../../../widgets/common/src/filters/types';
+import { waitUntilEmpty } from './resource_commons';
 
 declare global {
     namespace Cypress {
@@ -16,7 +17,13 @@ const commands = {
     deleteDeploymentsFilter: (filterId: string, { ignoreFailure }: { ignoreFailure?: boolean } = {}) =>
         cy.cfyRequest(`/filters/deployments/${filterId}`, 'DELETE', undefined, undefined, {
             failOnStatusCode: !ignoreFailure
-        })
+        }),
+
+    deleteDeploymentsFilters: (search: string) => {
+        cy.cfyRequest(`/filters/deployments?_search=${search}`, 'GET')
+            .then(response => response.body.items.forEach(({ id }: { id: string }) => cy.deleteDeploymentsFilter(id)))
+            .then(() => waitUntilEmpty('filters/deployments', search));
+    }
 };
 
 addCommands(commands);

--- a/widgets/filters/src/FilterEditModal.tsx
+++ b/widgets/filters/src/FilterEditModal.tsx
@@ -1,7 +1,7 @@
 import { FunctionComponent } from 'react';
 import FilterModal, { FilterModalProps } from './FilterModal';
 
-type FilterEditModalProps = Pick<FilterModalProps, 'initialFilter', 'onSubmit', 'onCancel'>;
+type FilterEditModalProps = Pick<FilterModalProps, 'initialFilter' | 'onSubmit' | 'onCancel'>;
 
 const FilterEditModal: FunctionComponent<FilterEditModalProps> = props => {
     return (

--- a/widgets/filters/src/FilterEditModal.tsx
+++ b/widgets/filters/src/FilterEditModal.tsx
@@ -1,7 +1,7 @@
 import { FunctionComponent } from 'react';
 import FilterModal, { FilterModalProps } from './FilterModal';
 
-type FilterEditModalProps = Omit<FilterModalProps, 'i18nHeaderKey' | 'filterId'>;
+type FilterEditModalProps = Pick<FilterModalProps, 'initialFilter', 'onSubmit', 'onCancel'>;
 
 const FilterEditModal: FunctionComponent<FilterEditModalProps> = props => {
     return (


### PR DESCRIPTION
This PR includes `FilterEditModalProps` type fix as a follow-up to previous PR review.

This PR adds `cypress-get-table` cypress extension which makes table content validations easier. It's not perfect but it's extremely easy to use - it abstracts table structure by allowing to reference table cells by row number and column header. As such it encourages better, more thorough table content checking.

System tests run is queued (build 416).