### PR TITLE
RD-2002 Add drilled-down Deployments View widget

### DIFF
--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -649,6 +649,8 @@
                 }
             },
             "drillDown": {
+                "name": "Deployments view (drilled-down)",
+                "description": "A complete deployments view in a drilled-down context – Deployment list, map view, and detailed deployment info",
                 "breadcrumbs": {
                     "environments": "Environments",
                     "services": "Services"

--- a/backend/test/handlers/WidgetHandler.test.js
+++ b/backend/test/handlers/WidgetHandler.test.js
@@ -24,6 +24,7 @@ describe('WidgetHandler', () => {
             { id: 'deploymentWizardButtons', isCustom: false },
             { id: 'deployments', isCustom: false },
             { id: 'deploymentsView', isCustom: false },
+            { id: 'deploymentsViewDrilledDown', isCustom: false },
             { id: 'events', isCustom: false },
             { id: 'eventsFilter', isCustom: false },
             { id: 'executionNum', isCustom: false },

--- a/templates/pages/drilldownDeployments.json
+++ b/templates/pages/drilldownDeployments.json
@@ -10,11 +10,8 @@
           "height": 28,
           "x": 0,
           "y": 0,
-          "TODO(RD-2002)": "use the new drilled down widget",
-          "definition": "deploymentsView",
-          "configuration": {
-            "filterByParentDeployment": true
-          }
+          "definition": "deploymentsViewDrilledDown",
+          "configuration": {}
         }
       ]
     }

--- a/test/cypress/integration/widgets/deployments_view_spec.ts
+++ b/test/cypress/integration/widgets/deployments_view_spec.ts
@@ -73,8 +73,8 @@ describe('Deployments View widget', () => {
         cy.wait('@deployments');
     };
 
-    // NOTE: matches both deploymentsViewWidget and deploymentsViewDrilledDownWidget
-    const getDeploymentsViewWidget = () => cy.get('.widget').filter('[class*="deploymentsView"]').find('.widgetItem');
+    const getDeploymentsViewWidget = () =>
+        cy.get('.widget').filter('.deploymentsViewWidget, .deploymentsViewDrilledDownWidget').find('.widgetItem');
     const getDeploymentsViewTable = () => getDeploymentsViewWidget().get('.gridTable');
     const getDeploymentsViewDetailsPane = () => getDeploymentsViewWidget().get('.detailsPane');
 

--- a/test/cypress/integration/widgets/deployments_view_spec.ts
+++ b/test/cypress/integration/widgets/deployments_view_spec.ts
@@ -34,7 +34,8 @@ describe('Deployments View widget', () => {
         'blueprintSources',
         'nodes',
         'executions',
-        'deploymentActionButtons'
+        'deploymentActionButtons',
+        'deploymentsViewDrilledDown'
     ];
     /** Column numbers as they appear in the table */
     const columnNumbers = {
@@ -72,7 +73,8 @@ describe('Deployments View widget', () => {
         cy.wait('@deployments');
     };
 
-    const getDeploymentsViewWidget = () => cy.get('.deploymentsViewWidget .widgetItem');
+    // NOTE: matches both deploymentsViewWidget and deploymentsViewDrilledDownWidget
+    const getDeploymentsViewWidget = () => cy.get('.widget').filter('[class*="deploymentsView"]').find('.widgetItem');
     const getDeploymentsViewTable = () => getDeploymentsViewWidget().get('.gridTable');
     const getDeploymentsViewDetailsPane = () => getDeploymentsViewWidget().get('.detailsPane');
 

--- a/test/cypress/integration/widgets/filters_spec.ts
+++ b/test/cypress/integration/widgets/filters_spec.ts
@@ -1,4 +1,3 @@
-import type { FilterRule } from '../../../../widgets/common/src/filters/types';
 import { FilterRuleOperators, FilterRuleType } from '../../../../widgets/common/src/filters/types';
 
 describe('Filters widget', () => {
@@ -7,7 +6,7 @@ describe('Filters widget', () => {
     });
 
     const filterName = 'filters_test_filter';
-    const filterRules: FilterRule[] = [
+    const filterRules: Stage.Common.Filters.Rule[] = [
         { type: FilterRuleType.Attribute, key: 'blueprint_id', values: ['bpid'], operator: FilterRuleOperators.AnyOf },
         { type: FilterRuleType.Label, key: 'precious', values: ['yes'], operator: FilterRuleOperators.AnyOf }
     ];

--- a/test/cypress/support/filters.ts
+++ b/test/cypress/support/filters.ts
@@ -1,5 +1,4 @@
 import { addCommands, GetCypressChainableFromCommands } from 'cloudify-ui-common/cypress/support';
-import type { FilterRule } from '../../../widgets/common/src/filters/types';
 import { waitUntilEmpty } from './resource_commons';
 
 declare global {
@@ -11,7 +10,7 @@ declare global {
 }
 
 const commands = {
-    createDeploymentsFilter: (id: string, rules: FilterRule[]) =>
+    createDeploymentsFilter: (id: string, rules: Stage.Common.Filters.Rule[]) =>
         cy.cfyRequest(`/filters/deployments/${id}`, 'PUT', null, { filter_rules: rules }),
 
     deleteDeploymentsFilter: (filterId: string, { ignoreFailure }: { ignoreFailure?: boolean } = {}) =>

--- a/test/cypress/tsconfig.json
+++ b/test/cypress/tsconfig.json
@@ -14,6 +14,7 @@
         "sourceMap": false,
         "types": ["cypress"]
     },
-    "include": ["**/*"],
+    // Some Stage.Common types used in tests are defined in widgets/common
+    "include": ["**/*", "../../widgets/common/**/*"],
     "files": ["../../app/typings/stage-api.d.ts"]
 }

--- a/widgets/common/src/deploymentsView/DeploymentsView.tsx
+++ b/widgets/common/src/deploymentsView/DeploymentsView.tsx
@@ -6,6 +6,7 @@ import { i18nMessagesPrefix } from './common';
 import type { SharedDeploymentsViewWidgetConfiguration } from './configuration';
 import DetailsPane from './detailsPane';
 import { DeploymentsTable } from './table';
+import { FilterRuleOperators, FilterRuleType } from '../filters/types';
 
 export interface DeploymentsViewProps {
     widget: Stage.Types.Widget<SharedDeploymentsViewWidgetConfiguration>;
@@ -123,11 +124,11 @@ const useFilteringByParentDeployment = ({ filterByParentDeployment }: { filterBy
     return {
         filterable: true,
         parentDeploymentRule: {
-            type: 'label',
+            type: FilterRuleType.Label,
             key: 'csys-obj-parent',
-            operator: 'any_of',
+            operator: FilterRuleOperators.AnyOf,
             values: [parentDeploymentId]
-        }
+        } as Stage.Common.Filters.Rule
     } as const;
 };
 

--- a/widgets/common/src/deploymentsView/DeploymentsView.tsx
+++ b/widgets/common/src/deploymentsView/DeploymentsView.tsx
@@ -107,15 +107,7 @@ export const DeploymentsView: FunctionComponent<DeploymentsViewProps> = ({
 
 const useFilteringByParentDeployment = ({ filterByParentDeployment }: { filterByParentDeployment: boolean }) => {
     const drilldownContext = ReactRedux.useSelector((state: Stage.Types.ReduxState) => state.drilldownContext);
-    const parentDeploymentId = useMemo(() => {
-        if (drilldownContext.length < 2) {
-            return undefined;
-        }
-
-        const parentPageContext = drilldownContext[drilldownContext.length - 2].context;
-
-        return parentPageContext?.deploymentId as string | undefined;
-    }, [drilldownContext]);
+    const parentDeploymentId = useMemo(() => getParentDeploymentId(drilldownContext), [drilldownContext]);
 
     if (!filterByParentDeployment) {
         return { filterable: true } as const;
@@ -137,4 +129,22 @@ const useFilteringByParentDeployment = ({ filterByParentDeployment }: { filterBy
             values: [parentDeploymentId]
         }
     } as const;
+};
+
+const getParentDeploymentId = (drilldownContext: Stage.Types.ReduxState['drilldownContext']) => {
+    /**
+     * NOTE: drilldownContext contains contexts for each page, starting with
+     * the top-level page, and ending with the current page's initial context.
+     *
+     * Thus, the current page's parent context will be the penultimate entry in the array.
+     *
+     * It may happen, that the array only contains a single item (if we are on the top-level page).
+     */
+    if (drilldownContext.length < 2) {
+        return undefined;
+    }
+
+    const parentPageContext = drilldownContext[drilldownContext.length - 2].context;
+
+    return parentPageContext?.deploymentId as string | undefined;
 };

--- a/widgets/common/src/deploymentsView/DeploymentsView.tsx
+++ b/widgets/common/src/deploymentsView/DeploymentsView.tsx
@@ -1,0 +1,140 @@
+import React, { FunctionComponent, useMemo, useState } from 'react';
+import { find } from 'lodash';
+import { useQuery } from 'react-query';
+
+import { i18nMessagesPrefix } from './common';
+import type { SharedDeploymentsViewWidgetConfiguration } from './configuration';
+import DetailsPane from './detailsPane';
+import { DeploymentsTable } from './table';
+
+export interface DeploymentsViewProps {
+    widget: Stage.Types.Widget<SharedDeploymentsViewWidgetConfiguration>;
+    toolbox: Stage.Types.Toolbox;
+
+    filterByParentDeployment: boolean;
+    filterRules: Stage.Common.Filters.Rule[];
+    fetchingRules: boolean;
+}
+
+export const DeploymentsView: FunctionComponent<DeploymentsViewProps> = ({
+    toolbox,
+    widget,
+    filterByParentDeployment,
+    filterRules,
+    fetchingRules
+}) => {
+    const manager = toolbox.getManager();
+    const [gridParams, setGridParams] = useState<Stage.Types.ManagerGridParams>();
+
+    const filteringByParentDeploymentResult = useFilteringByParentDeployment({ filterByParentDeployment });
+    const finalFilterRules = useMemo(() => {
+        if (!filteringByParentDeploymentResult.parentDeploymentRule) {
+            return filterRules;
+        }
+
+        return [...filterRules, filteringByParentDeploymentResult.parentDeploymentRule];
+    }, [filterRules, filteringByParentDeploymentResult.parentDeploymentRule]);
+
+    const deploymentsUrl = '/searches/deployments';
+    const deploymentsResult = useQuery(
+        [deploymentsUrl, gridParams, finalFilterRules],
+        (): Promise<Stage.Common.DeploymentsView.Types.DeploymentsResponse> =>
+            manager.doPost(deploymentsUrl, gridParams, {
+                filter_rules: finalFilterRules
+            }),
+        {
+            enabled: filteringByParentDeploymentResult.filterable,
+            onSuccess: data => {
+                const context = toolbox.getContext();
+                // TODO(RD-1830): detect if deploymentId is not present in the current page and reset it.
+                // Do that only if `fetchData` was called from `DataTable`. If it's just polling,
+                // then don't reset it (because user may be interacting with some other component)
+                if (context.getValue('deploymentId') === undefined && data.items.length > 0) {
+                    context.setValue('deploymentId', data.items[0].id);
+                }
+            },
+            refetchInterval: widget.configuration.customPollingTime * 1000,
+            keepPreviousData: true
+        }
+    );
+
+    const { Loading, ErrorMessage } = Stage.Basic;
+    const { i18n } = Stage;
+
+    if (filteringByParentDeploymentResult.missingParentDeploymentId) {
+        const i18nMissingParentDeploymentPrefix = `${i18nMessagesPrefix}.missingParentDeploymentId`;
+
+        return (
+            <ErrorMessage
+                header={i18n.t(`${i18nMissingParentDeploymentPrefix}.header`)}
+                error={i18n.t(`${i18nMissingParentDeploymentPrefix}.message`)}
+            />
+        );
+    }
+
+    if (deploymentsResult.isLoading || deploymentsResult.isIdle) {
+        return <Loading message={i18n.t(`${i18nMessagesPrefix}.loadingDeployments`)} />;
+    }
+    if (deploymentsResult.isError) {
+        return (
+            <ErrorMessage
+                header={i18n.t(`${i18nMessagesPrefix}.errorLoadingDeployments`)}
+                error={deploymentsResult.error as { message: string }}
+            />
+        );
+    }
+
+    const selectedDeployment = find(deploymentsResult.data.items, {
+        // NOTE: type assertion since lodash has problems receiving string[] in the object
+        id: toolbox.getContext().getValue('deploymentId') as string | undefined
+    });
+
+    return (
+        <div className="grid">
+            <DeploymentsTable
+                setGridParams={setGridParams}
+                toolbox={toolbox}
+                loadingIndicatorVisible={fetchingRules || deploymentsResult.isFetching}
+                pageSize={widget.configuration.pageSize}
+                totalSize={deploymentsResult.data.metadata.pagination.total}
+                deployments={deploymentsResult.data.items}
+                fieldsToShow={widget.configuration.fieldsToShow}
+            />
+            <DetailsPane deployment={selectedDeployment} widget={widget} toolbox={toolbox} />
+        </div>
+    );
+};
+
+const useFilteringByParentDeployment = ({ filterByParentDeployment }: { filterByParentDeployment: boolean }) => {
+    const drilldownContext = ReactRedux.useSelector((state: Stage.Types.ReduxState) => state.drilldownContext);
+    const parentDeploymentId = useMemo(() => {
+        if (drilldownContext.length < 2) {
+            return undefined;
+        }
+
+        const parentPageContext = drilldownContext[drilldownContext.length - 2].context;
+
+        return parentPageContext?.deploymentId as string | undefined;
+    }, [drilldownContext]);
+
+    if (!filterByParentDeployment) {
+        return { filterable: true } as const;
+    }
+
+    if (!parentDeploymentId) {
+        return {
+            filterable: false,
+            missingParentDeploymentId: true
+        } as const;
+    }
+
+    return {
+        filterable: true,
+        parentDeploymentRule: {
+            type: 'label',
+            key: 'csys-obj-parent',
+            operator: 'any_of',
+            values: [parentDeploymentId]
+        }
+    } as const;
+};

--- a/widgets/common/src/deploymentsView/common.ts
+++ b/widgets/common/src/deploymentsView/common.ts
@@ -1,6 +1,7 @@
 import type { SemanticICONS } from 'semantic-ui-react';
 
 export const i18nPrefix = 'widgets.deploymentsView';
+export const i18nMessagesPrefix = `${i18nPrefix}.messages`;
 
 export const subenvironmentsIcon: SemanticICONS = 'object group';
 export const subservicesIcon: SemanticICONS = 'cube';

--- a/widgets/common/src/deploymentsView/common.ts
+++ b/widgets/common/src/deploymentsView/common.ts
@@ -2,6 +2,7 @@ import type { SemanticICONS } from 'semantic-ui-react';
 
 export const i18nPrefix = 'widgets.deploymentsView';
 export const i18nMessagesPrefix = `${i18nPrefix}.messages`;
+export const i18nDrillDownPrefix = `${i18nPrefix}.drillDown`;
 
 export const subenvironmentsIcon: SemanticICONS = 'object group';
 export const subservicesIcon: SemanticICONS = 'cube';

--- a/widgets/common/src/deploymentsView/configuration.ts
+++ b/widgets/common/src/deploymentsView/configuration.ts
@@ -1,0 +1,49 @@
+import { i18nPrefix } from './common';
+import { deploymentsViewColumnDefinitions, DeploymentsViewColumnId, deploymentsViewColumnIds } from './table';
+
+export interface SharedDeploymentsViewWidgetConfiguration {
+    /** In milliseconds */
+    customPollingTime: number;
+    fieldsToShow: DeploymentsViewColumnId[];
+    pageSize: number;
+    sortColumn: string;
+    sortAscending: boolean;
+}
+
+export const sharedConfiguration: Stage.Types.WidgetConfigurationDefinition[] = [
+    {
+        ...Stage.GenericConfig.POLLING_TIME_CONFIG(10),
+        // NOTE: polling is handled by react-query, thus, use a different ID
+        id: 'customPollingTime'
+    },
+    // TODO(RD-1225): add map configuration
+    {
+        id: 'fieldsToShow',
+        name: Stage.i18n.t(`${i18nPrefix}.configuration.fieldsToShow.name`),
+        placeHolder: Stage.i18n.t(`${i18nPrefix}.configuration.fieldsToShow.placeholder`),
+        items: deploymentsViewColumnIds.map(columnId => ({
+            name: deploymentsViewColumnDefinitions[columnId].name,
+            value: columnId
+        })),
+        default: deploymentsViewColumnIds.filter(columnId => columnId !== 'environmentType'),
+        type: Stage.Basic.GenericField.MULTI_SELECT_LIST_TYPE
+    },
+    Stage.GenericConfig.PAGE_SIZE_CONFIG(100),
+    Stage.GenericConfig.SORT_COLUMN_CONFIG('created_at'),
+    Stage.GenericConfig.SORT_ASCENDING_CONFIG(false)
+];
+
+// NOTE: a constrained identity function for full type safety with less typing
+const getSharedDefinition = <D extends Partial<Stage.Types.WidgetDefinition>>(d: D) => d;
+export const sharedDefinition = getSharedDefinition({
+    initialWidth: 12,
+    initialHeight: 28,
+    color: 'purple',
+    categories: [Stage.GenericConfig.CATEGORY.DEPLOYMENTS],
+
+    isReact: true,
+    // TODO(RD-1532): enable readme after filling it in
+    hasReadme: false,
+    hasStyle: false,
+    permission: Stage.GenericConfig.WIDGET_PERMISSION('deploymentsView')
+});

--- a/widgets/common/src/deploymentsView/configuration.ts
+++ b/widgets/common/src/deploymentsView/configuration.ts
@@ -28,7 +28,7 @@ export const sharedConfiguration: Stage.Types.WidgetConfigurationDefinition[] = 
         default: deploymentsViewColumnIds.filter(columnId => columnId !== 'environmentType'),
         type: Stage.Basic.GenericField.MULTI_SELECT_LIST_TYPE
     },
-    Stage.GenericConfig.PAGE_SIZE_CONFIG(100),
+    Stage.GenericConfig.PAGE_SIZE_CONFIG(50),
     Stage.GenericConfig.SORT_COLUMN_CONFIG('created_at'),
     Stage.GenericConfig.SORT_ASCENDING_CONFIG(false)
 ];

--- a/widgets/common/src/deploymentsView/detailsPane/DrilldownButtons.tsx
+++ b/widgets/common/src/deploymentsView/detailsPane/DrilldownButtons.tsx
@@ -1,7 +1,7 @@
 import type { FunctionComponent } from 'react';
 import styled from 'styled-components';
 
-import { i18nPrefix, subenvironmentsIcon, subservicesIcon } from '../common';
+import { i18nDrillDownPrefix, subenvironmentsIcon, subservicesIcon } from '../common';
 import type { Deployment } from '../types';
 
 export interface DrilldownButtonsProps {
@@ -48,7 +48,6 @@ interface DrilldownButtonProps {
 }
 
 const subdeploymentsDrilldownTemplateName = 'drilldownDeployments';
-const i18nDrillDownPrefix = `${i18nPrefix}.drillDown`;
 
 const DrilldownButton: FunctionComponent<DrilldownButtonProps> = ({
     subdeploymentsCount,

--- a/widgets/common/src/deploymentsView/index.ts
+++ b/widgets/common/src/deploymentsView/index.ts
@@ -1,22 +1,24 @@
-import * as Table from './table';
 import * as DCommon from './common';
-import DetailsPane from './detailsPane';
-import type { Deployment, DeploymentsResponse } from './types';
+import type { DeploymentsResponse } from './types';
 import { SharedDeploymentsViewWidgetConfiguration, sharedConfiguration, sharedDefinition } from './configuration';
 import './styles.scss';
+import { DeploymentsView as DDeploymentsView } from './DeploymentsView';
 
 declare global {
-    namespace Stage.Common.DeploymentsView {
-        // NOTE: necessary rename to DCommon, since `Common` resolves to `Stage.Common`, not the `Common` import
-        export { Table, DCommon as Common, DetailsPane, sharedDefinition };
+    namespace Stage.Common {
+        // eslint-disable-next-line @typescript-eslint/no-namespace
+        namespace DeploymentsView {
+            // NOTE: necessary rename to DCommon, since `Common` resolves to `Stage.Common`, not the `Common` import
+            export { DCommon as Common, sharedDefinition, DDeploymentsView as DeploymentsView };
 
-        // NOTE: no-namespace rule does not detect that `export namespace` are in a `declare` context
-        /* eslint-disable @typescript-eslint/no-namespace */
-        export namespace Configuration {
-            export { SharedDeploymentsViewWidgetConfiguration, sharedConfiguration };
-        }
-        export namespace Types {
-            export { Deployment, DeploymentsResponse };
+            // NOTE: no-namespace rule does not detect that `export namespace` are in a `declare` context
+            /* eslint-disable @typescript-eslint/no-namespace */
+            export namespace Configuration {
+                export { SharedDeploymentsViewWidgetConfiguration, sharedConfiguration };
+            }
+            export namespace Types {
+                export { DeploymentsResponse };
+            }
         }
     }
 }
@@ -25,10 +27,9 @@ Stage.defineCommon({
     name: 'DeploymentsView',
     common: {
         sharedDefinition,
-        DetailsPane,
         Common: DCommon,
-        Table,
         Configuration: { sharedConfiguration },
+        DeploymentsView: DDeploymentsView,
         Types: {}
     }
 });

--- a/widgets/common/src/deploymentsView/index.ts
+++ b/widgets/common/src/deploymentsView/index.ts
@@ -1,17 +1,22 @@
-// NOTE: names prefixed with D so they can be exported inside namespace with a different name
-import * as DTable from './table';
+import * as Table from './table';
 import * as DCommon from './common';
-import DDetailsPane from './detailsPane';
-import type { Deployment, DeploymentsResponse, SharedDeploymentsViewWidgetConfiguration } from './types';
+import DetailsPane from './detailsPane';
+import type { Deployment, DeploymentsResponse } from './types';
+import { SharedDeploymentsViewWidgetConfiguration, sharedConfiguration, sharedDefinition } from './configuration';
 import './styles.scss';
 
 declare global {
     namespace Stage.Common.DeploymentsView {
-        const Table: typeof DTable;
-        const Common: typeof DCommon;
-        const DetailsPane: typeof DDetailsPane;
-        namespace Types {
-            export { Deployment, DeploymentsResponse, SharedDeploymentsViewWidgetConfiguration };
+        // NOTE: necessary rename to DCommon, since `Common` resolves to `Stage.Common`, not the `Common` import
+        export { Table, DCommon as Common, DetailsPane, sharedDefinition };
+
+        // NOTE: no-namespace rule does not detect that `export namespace` are in a `declare` context
+        /* eslint-disable @typescript-eslint/no-namespace */
+        export namespace Configuration {
+            export { SharedDeploymentsViewWidgetConfiguration, sharedConfiguration };
+        }
+        export namespace Types {
+            export { Deployment, DeploymentsResponse };
         }
     }
 }
@@ -19,9 +24,11 @@ declare global {
 Stage.defineCommon({
     name: 'DeploymentsView',
     common: {
-        DetailsPane: DDetailsPane,
+        sharedDefinition,
+        DetailsPane,
         Common: DCommon,
-        Table: DTable,
+        Table,
+        Configuration: { sharedConfiguration },
         Types: {}
     }
 });

--- a/widgets/common/src/deploymentsView/styles.scss
+++ b/widgets/common/src/deploymentsView/styles.scss
@@ -5,7 +5,8 @@ $deploymentProgressBarColors: (
     'failed': #db2828
 );
 
-.deploymentsViewWidget {
+.deploymentsViewWidget,
+.deploymentsViewDrilledDownWidget {
     --deployment-progress-underline-height: 0.14em;
     // NOTE: use CSS custom properties to make user overrides easier
     @each $stateName, $color in $deploymentProgressBarColors {

--- a/widgets/common/src/deploymentsView/types.ts
+++ b/widgets/common/src/deploymentsView/types.ts
@@ -1,5 +1,3 @@
-import type { DeploymentsViewColumnId } from './table';
-
 export enum LatestExecutionStatus {
     Completed = 'completed',
     Failed = 'failed',
@@ -45,12 +43,3 @@ export interface Deployment {
 }
 
 export type DeploymentsResponse = Stage.Types.PaginatedResponse<Deployment>;
-
-export interface SharedDeploymentsViewWidgetConfiguration {
-    /** In milliseconds */
-    customPollingTime: number;
-    fieldsToShow: DeploymentsViewColumnId[];
-    pageSize: number;
-    sortColumn: string;
-    sortAscending: boolean;
-}

--- a/widgets/common/src/filters/index.ts
+++ b/widgets/common/src/filters/index.ts
@@ -1,4 +1,5 @@
 import FiltersDefinitionForm from './FiltersDefinitionForm';
+import { FilterRule } from './types';
 
 const Filters = {
     Form: FiltersDefinitionForm
@@ -8,6 +9,10 @@ const Filters = {
 const FiltersAlias = Filters;
 declare global {
     namespace Stage.Common {
+        // eslint-disable-next-line @typescript-eslint/no-namespace
+        namespace Filters {
+            export type Rule = FilterRule;
+        }
         const Filters: typeof FiltersAlias;
     }
 }

--- a/widgets/deploymentsView/src/widget.tsx
+++ b/widgets/deploymentsView/src/widget.tsx
@@ -74,9 +74,14 @@ const TopLevelDeploymentsView: FunctionComponent<TopLevelDeploymentsViewProps> =
     }
 
     if (filterRulesResult.isIdle) {
-        throw new Error(
-            'Fetching filter rules is disabled without explicitly handling this scenario. Those rules should always be fetched.'
-        );
+        /**
+         * NOTE: handling the `isIdle` state is necessary for TypeScript's type-narrowing to exclude `undefined` from
+         * the possible values of `filterRulesResult.data`.
+         *
+         * Such a case should not happen naturally, unless an `enabled` option is added to `useQuery`. If it is added,
+         * it should be here.
+         */
+        throw new Error('Idle state for fetching filter rules is not implemented.');
     }
 
     const { DeploymentsView } = Stage.Common.DeploymentsView;

--- a/widgets/deploymentsView/src/widget.tsx
+++ b/widgets/deploymentsView/src/widget.tsx
@@ -38,7 +38,6 @@ Stage.defineWidget<never, never, DeploymentsViewWidgetConfiguration>({
             name: Stage.i18n.t(`${i18nPrefix}.configuration.filterId.name`)
         },
         {
-            // TODO(RD-1853): handle filtering by parent deployment
             id: 'filterByParentDeployment',
             type: Stage.Basic.GenericField.BOOLEAN_TYPE,
             name: Stage.i18n.t(`${i18nPrefix}.configuration.filterByParentDeployment.name`),

--- a/widgets/deploymentsView/src/widget.tsx
+++ b/widgets/deploymentsView/src/widget.tsx
@@ -1,8 +1,6 @@
 import { find } from 'lodash';
 import { FunctionComponent, useMemo, useState } from 'react';
 import { useQuery } from 'react-query';
-// NOTE: workaround for Cypress TS project to pick up the common types
-import type {} from '../../common/src/deploymentsView';
 
 export interface DeploymentsViewWidgetConfiguration
     extends Stage.Common.DeploymentsView.Configuration.SharedDeploymentsViewWidgetConfiguration {

--- a/widgets/deploymentsView/src/widget.tsx
+++ b/widgets/deploymentsView/src/widget.tsx
@@ -5,32 +5,28 @@ import { useQuery } from 'react-query';
 import type {} from '../../common/src/deploymentsView';
 
 export interface DeploymentsViewWidgetConfiguration
-    extends Stage.Common.DeploymentsView.Types.SharedDeploymentsViewWidgetConfiguration {
+    extends Stage.Common.DeploymentsView.Configuration.SharedDeploymentsViewWidgetConfiguration {
     filterId?: string;
     filterByParentDeployment: boolean;
 }
 
 const {
     Common: { i18nPrefix },
-    Table: { deploymentsViewColumnIds, deploymentsViewColumnDefinitions, DeploymentsTable },
-    DetailsPane
+    Table: { DeploymentsTable },
+    Configuration: { sharedConfiguration },
+    DetailsPane,
+    sharedDefinition
 } = Stage.Common.DeploymentsView;
 
 Stage.defineWidget<never, never, DeploymentsViewWidgetConfiguration>({
+    ...sharedDefinition,
+
     id: 'deploymentsView',
     name: Stage.i18n.t(`${i18nPrefix}.name`),
     description: Stage.i18n.t(`${i18nPrefix}.description`),
-    initialWidth: 12,
-    initialHeight: 28,
-    color: 'purple',
-    categories: [Stage.GenericConfig.CATEGORY.DEPLOYMENTS],
 
     initialConfiguration: [
-        {
-            ...Stage.GenericConfig.POLLING_TIME_CONFIG(10),
-            // NOTE: polling is handled by react-query, thus, use a different ID
-            id: 'customPollingTime'
-        },
+        ...sharedConfiguration,
         {
             id: 'filterId',
             // TODO(RD-1851): add autocomplete instead of plain text input
@@ -43,28 +39,8 @@ Stage.defineWidget<never, never, DeploymentsViewWidgetConfiguration>({
             name: Stage.i18n.t(`${i18nPrefix}.configuration.filterByParentDeployment.name`),
             description: Stage.i18n.t(`${i18nPrefix}.configuration.filterByParentDeployment.description`),
             default: false
-        },
-        // TODO(RD-1225): add map configuration
-        {
-            id: 'fieldsToShow',
-            name: Stage.i18n.t(`${i18nPrefix}.configuration.fieldsToShow.name`),
-            placeHolder: Stage.i18n.t(`${i18nPrefix}.configuration.fieldsToShow.placeholder`),
-            items: deploymentsViewColumnIds.map(columnId => ({
-                name: deploymentsViewColumnDefinitions[columnId].name,
-                value: columnId
-            })),
-            default: deploymentsViewColumnIds.filter(columnId => columnId !== 'environmentType'),
-            type: Stage.Basic.GenericField.MULTI_SELECT_LIST_TYPE
-        },
-        Stage.GenericConfig.PAGE_SIZE_CONFIG(100),
-        Stage.GenericConfig.SORT_COLUMN_CONFIG('created_at'),
-        Stage.GenericConfig.SORT_ASCENDING_CONFIG(false)
+        }
     ],
-    isReact: true,
-    // TOOD(RD-1532): enable readme after filling it in
-    hasReadme: false,
-    hasStyle: false,
-    permission: Stage.GenericConfig.WIDGET_PERMISSION('deploymentsView'),
 
     render(widget, _data, _error, toolbox) {
         return <DeploymentsView widget={widget} toolbox={toolbox} />;

--- a/widgets/deploymentsViewDrilledDown/README.md
+++ b/widgets/deploymentsViewDrilledDown/README.md
@@ -1,0 +1,5 @@
+# Deployments View (drilled-down)
+
+A complete deployments view – Deployment list, map view, and detailed deployment info
+
+TODO(RD-1532): fill in

--- a/widgets/deploymentsViewDrilledDown/src/widget.tsx
+++ b/widgets/deploymentsViewDrilledDown/src/widget.tsx
@@ -1,0 +1,34 @@
+export {};
+
+const {
+    Common: { i18nDrillDownPrefix },
+    Configuration: { sharedConfiguration },
+    sharedDefinition
+} = Stage.Common.DeploymentsView;
+
+type DrilledDownWidgetConfiguration = Stage.Common.DeploymentsView.Configuration.SharedDeploymentsViewWidgetConfiguration;
+
+Stage.defineWidget<never, never, DrilledDownWidgetConfiguration>({
+    ...sharedDefinition,
+
+    id: 'deploymentsViewDrilledDown',
+    name: Stage.i18n.t(`${i18nDrillDownPrefix}.name`),
+    description: Stage.i18n.t(`${i18nDrillDownPrefix}.description`),
+
+    initialConfiguration: sharedConfiguration,
+
+    render(widget, _data, _error, toolbox) {
+        // TODO(RD-2004): get filter rules from context
+
+        const { DeploymentsView } = Stage.Common.DeploymentsView;
+        return (
+            <DeploymentsView
+                toolbox={toolbox}
+                widget={widget}
+                filterByParentDeployment
+                filterRules={[]}
+                fetchingRules={false}
+            />
+        );
+    }
+});


### PR DESCRIPTION
The PR adds a new `deploymentsViewDrilledDown` widget that is rendered in the drilled-down pages of Environments. The changes should be transparent to the user - there are no functional changes. The new widget is very similar to the existing widget, but:
1. Has limited configuration
2. Always filters by parent deployment
3. Does not fetch filter rules (they will come from the context in RD-2004)

Despite having a large number of changes on paper, most of the code for `widgets/common/src/deploymentsView/DeploymentsView.tsx` comes from the preexisting widget code. You may want to use [the git's `--color-moved` config](https://github.blog/2018-04-05-git-217-released/#coloring-moved-code) to reduce the diff and show which lines were moved as-is :smile: I'd say around 200 lines were moved, and not added/deleted :slightly_smiling_face: 

I have also found a way to expose `FilterRule` from `widgets/common/src/filters` as `Stage.Common.Filters.Rule`, which IMO is a better way to use that type than importing the type using a long `../..` path :slightly_smiling_face:

## System tests

https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/436/pipeline

Ran 2021-04-13 9:35 CEST