### PR TITLE
RD-2003 Display the number of only immediate subdeployments

### DIFF
--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -661,6 +661,7 @@
                     "services": "Services"
                 },
                 "buttons": {
+                    "detailsFetchingError": "Could not fetch deployment details",
                     "environments": {
                         "label": "Subenvironments",
                         "title": "Drill down to subenvironments"

--- a/test/cypress/integration/widgets/deployments_view_spec.ts
+++ b/test/cypress/integration/widgets/deployments_view_spec.ts
@@ -373,8 +373,7 @@ describe('Deployments View widget', () => {
             const getBreadcrumbs = () => cy.get('.breadcrumb');
 
             getDeploymentsViewDetailsPane().within(() => {
-                // TODO(RD-2003): uncomment the line below
-                // getSubservicesButton().contains('1');
+                getSubservicesButton().contains('1');
                 cy.log('Drill down to subenvironments of app-env');
                 getSubenvironmentsButton().contains('1').click();
             });
@@ -420,8 +419,7 @@ describe('Deployments View widget', () => {
             getBreadcrumbs().contains('Test Page').click();
             getDeploymentsViewDetailsPane().within(() => {
                 cy.log('Drill down to subservices of app-env');
-                // TODO(RD-2003): expect 1, not 3 directly attached subservices
-                getSubservicesButton().contains('3').click();
+                getSubservicesButton().contains('1').click();
             });
             getDeploymentsViewTable().within(() => {
                 cy.log('Subservices of app-end should be visible (web-app)');

--- a/widgets/common/src/deploymentsView/detailsPane/DrilldownButtons.tsx
+++ b/widgets/common/src/deploymentsView/detailsPane/DrilldownButtons.tsx
@@ -1,4 +1,5 @@
 import type { FunctionComponent } from 'react';
+import { QueryObserverLoadingResult, QueryObserverSuccessResult, useQuery } from 'react-query';
 import styled from 'styled-components';
 
 import { FilterRuleOperators, FilterRuleType } from '../../filters/types';
@@ -6,57 +7,84 @@ import { filterRulesContextKey, i18nDrillDownPrefix, subenvironmentsIcon, subser
 import type { Deployment } from '../types';
 
 export interface DrilldownButtonsProps {
-    deployment: Deployment;
+    deploymentId: string;
     drillDown: (templateName: string, drilldownContext: Record<string, any>, drilldownPageName: string) => void;
+    toolbox: Stage.Types.Toolbox;
 }
 
 const ButtonsContainer = styled.div`
     margin: 0 1em;
 `;
 
-const DrilldownButtons: FunctionComponent<DrilldownButtonsProps> = ({ drillDown, deployment }) => {
-    const {
-        id: deploymentName,
-        // TODO(RD-2003): fetch the number of only the immediate children
-        sub_services_count: subservicesCount,
-        sub_environments_count: subenvironmentsCount
-    } = deployment;
+const i18nDrillDownButtonsPrefix = `${i18nDrillDownPrefix}.buttons`;
+const getDeploymentUrl = (id: string) => `/deployments/${id}?all_sub_deployments=false`;
+
+const DrilldownButtons: FunctionComponent<DrilldownButtonsProps> = ({ drillDown, deploymentId, toolbox }) => {
+    const deploymentDetailsResult = useQuery(
+        getDeploymentUrl(deploymentId),
+        ({ queryKey: url }): Promise<Deployment> => toolbox.getManager().doGet(url)
+    );
+
+    if (deploymentDetailsResult.isIdle || deploymentDetailsResult.isError) {
+        const { ErrorMessage } = Stage.Basic;
+        return (
+            <ErrorMessage
+                error={Stage.i18n.t(`${i18nDrillDownButtonsPrefix}.detailsFetchingError`)}
+                header=""
+                onDismiss={null}
+            />
+        );
+    }
+
+    const subdeploymentResults = getSubdeploymentResults(deploymentDetailsResult);
 
     return (
         <ButtonsContainer>
             <DrilldownButton
                 type="environments"
-                subdeploymentsCount={subenvironmentsCount}
                 drillDown={drillDown}
-                deploymentName={deploymentName}
+                deploymentName={deploymentId}
+                result={subdeploymentResults.subenvironments}
             />
             <DrilldownButton
                 type="services"
-                subdeploymentsCount={subservicesCount}
                 drillDown={drillDown}
-                deploymentName={deploymentName}
+                deploymentName={deploymentId}
+                result={subdeploymentResults.subservices}
             />
         </ButtonsContainer>
     );
 };
 export default DrilldownButtons;
 
+const getSubdeploymentResults = (
+    deploymentDetailsResult: QueryObserverLoadingResult<Deployment> | QueryObserverSuccessResult<Deployment>
+): { subservices: SubdeploymentsResult; subenvironments: SubdeploymentsResult } => {
+    if (deploymentDetailsResult.isLoading) {
+        return {
+            subservices: { loading: true },
+            subenvironments: { loading: true }
+        };
+    }
+
+    return {
+        subservices: { loading: false, count: deploymentDetailsResult.data.sub_services_count },
+        subenvironments: { loading: false, count: deploymentDetailsResult.data.sub_environments_count }
+    };
+};
+
+type SubdeploymentsResult = { loading: true } | { loading: false; count: number };
+
 interface DrilldownButtonProps {
-    subdeploymentsCount: number;
     type: 'environments' | 'services';
     drillDown: DrilldownButtonsProps['drillDown'];
     deploymentName: string;
+    result: SubdeploymentsResult;
 }
 
 const subdeploymentsDrilldownTemplateName = 'drilldownDeployments';
 
-const DrilldownButton: FunctionComponent<DrilldownButtonProps> = ({
-    subdeploymentsCount,
-    type,
-    drillDown,
-    deploymentName
-}) => {
-    const { Button, Icon } = Stage.Basic;
+const DrilldownButton: FunctionComponent<DrilldownButtonProps> = ({ type, drillDown, deploymentName, result }) => {
     const { i18n } = Stage;
     const icon = type === 'services' ? subservicesIcon : subenvironmentsIcon;
 
@@ -75,16 +103,20 @@ const DrilldownButton: FunctionComponent<DrilldownButtonProps> = ({
         );
     };
 
+    const { Button, Icon } = Stage.Basic;
+
     return (
         <Button
             basic
             color="blue"
             onClick={drilldownToSubdeployments}
-            disabled={subdeploymentsCount === 0}
-            title={i18n.t(`${i18nDrillDownPrefix}.buttons.${type}.title`)}
+            disabled={result.loading || result.count === 0}
+            loading={result.loading}
+            title={i18n.t(`${i18nDrillDownButtonsPrefix}.${type}.title`)}
         >
             <Icon name={icon} />
-            {i18n.t(`${i18nDrillDownPrefix}.buttons.${type}.label`)} ({subdeploymentsCount})
+            {i18n.t(`${i18nDrillDownButtonsPrefix}.${type}.label`)}
+            {!result.loading && <> ({result.count})</>}
             {/* TODO(RD-2005): add icons depending on children state */}
         </Button>
     );

--- a/widgets/common/src/deploymentsView/detailsPane/index.tsx
+++ b/widgets/common/src/deploymentsView/detailsPane/index.tsx
@@ -45,7 +45,9 @@ const DetailsPane: FunctionComponent<DetailsPaneProps> = ({ deployment, widget, 
         <div className="detailsPane">
             <DetailsPaneHeader
                 deploymentName={deployment.id}
-                drilldownButtons={<DrilldownButtons deployment={deployment} drillDown={drillDown} />}
+                drilldownButtons={
+                    <DrilldownButtons deploymentId={deployment.id} drillDown={drillDown} toolbox={toolbox} />
+                }
             />
             <DetailsPaneWidgets />
         </div>


### PR DESCRIPTION
Show the correct numbers in the drill-down buttons in Deployments View.

## Screenshot

![image](https://user-images.githubusercontent.com/889383/114529547-57d4aa00-9c4a-11eb-8a2c-be8c293114ca.png)

Notice that the number of subservices in the drill-down button is 1, meaning that it correctly counts only the immediate children. The table still shows 3 subservices, as it counts all ancestors.

## System tests

https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/449/pipeline

Ran 2021-04-13 15:57 CEST