### PR TITLE
RD-1824 Prevent going to parent page on deployment delete

### DIFF
--- a/test/cypress/integration/widgets/deployments_view_spec.ts
+++ b/test/cypress/integration/widgets/deployments_view_spec.ts
@@ -352,12 +352,19 @@ describe('Deployments View widget', () => {
             });
         });
 
-        it('should support the drill-down workflow', () => {
+        const useEnvironmentsWidget = () => {
             useDeploymentsViewWidget({
                 configurationOverrides: {
                     filterId: 'csys-environment-filter'
                 }
             });
+        };
+        const getSubenvironmentsButton = () => cy.get('button').contains('Subenvironments');
+        const getSubservicesButton = () => cy.get('button').contains('Services');
+        const getBreadcrumbs = () => cy.get('.breadcrumb');
+
+        it('should support the drill-down workflow', () => {
+            useEnvironmentsWidget();
 
             getDeploymentsViewTable().within(() => {
                 cy.log('Only top-level environments should be visible');
@@ -367,10 +374,6 @@ describe('Deployments View widget', () => {
                 cy.contains('db-2').should('not.exist');
                 cy.contains('web-app').should('not.exist');
             });
-
-            const getSubenvironmentsButton = () => cy.get('button').contains('Subenvironments');
-            const getSubservicesButton = () => cy.get('button').contains('Services');
-            const getBreadcrumbs = () => cy.get('.breadcrumb');
 
             getDeploymentsViewDetailsPane().within(() => {
                 getSubservicesButton().contains('1');

--- a/test/cypress/integration/widgets/deployments_view_spec.ts
+++ b/test/cypress/integration/widgets/deployments_view_spec.ts
@@ -359,8 +359,8 @@ describe('Deployments View widget', () => {
                 }
             });
         };
-        const getSubenvironmentsButton = () => cy.get('button').contains('Subenvironments');
-        const getSubservicesButton = () => cy.get('button').contains('Services');
+        const getSubenvironmentsButton = () => cy.contains('button', 'Subenvironments');
+        const getSubservicesButton = () => cy.contains('button', 'Services');
         const getBreadcrumbs = () => cy.get('.breadcrumb');
 
         it('should support the drill-down workflow', () => {

--- a/test/cypress/integration/widgets/deployments_view_spec.ts
+++ b/test/cypress/integration/widgets/deployments_view_spec.ts
@@ -430,6 +430,31 @@ describe('Deployments View widget', () => {
                 cy.contains('db-env').should('not.exist');
             });
         });
+
+        it('should allow deleting a deployment without redirecting to the parent page', () => {
+            const tempDeploymentId = `${specPrefix}_temp_deployment_to_remove`;
+            const parentDeploymentId = getDeploymentFullName('app-env');
+            cy.deployBlueprint(blueprintName, tempDeploymentId).setLabels(tempDeploymentId, [
+                { 'csys-obj-type': 'service' },
+                { 'csys-obj-parent': parentDeploymentId }
+            ]);
+
+            useEnvironmentsWidget();
+
+            getDeploymentsViewDetailsPane().within(() => getSubservicesButton().click());
+
+            getBreadcrumbs().contains(parentDeploymentId);
+
+            getDeploymentsViewTable().within(() => cy.contains(tempDeploymentId).click());
+
+            cy.log('Delete the deployment');
+            getDeploymentsViewDetailsPane().contains('Deployment actions').click();
+            cy.get('.popup').contains('Delete').click();
+            cy.get('.modal').contains('Yes').click();
+
+            getDeploymentsViewTable().within(() => cy.contains(tempDeploymentId).should('not.exist'));
+            getBreadcrumbs().contains(parentDeploymentId);
+        });
     });
 
     it('should display an error message when using the drilled-down widget on a top-level page', () => {

--- a/test/jest/tsconfig.json
+++ b/test/jest/tsconfig.json
@@ -7,5 +7,6 @@
         },
         "types": ["jest"]
     },
-    "include": ["**/*", "../../app/**/*"]
+    // Some Stage.Common types used in tests are defined in widgets/common
+    "include": ["**/*", "../../app/**/*", "../../widgets/common/**/*"]
 }

--- a/test/jest/widgets/common/DeploymentActions.test.ts
+++ b/test/jest/widgets/common/DeploymentActions.test.ts
@@ -22,7 +22,8 @@ describe('(Widgets common) DeploymentActions', () => {
 
         const deploymentId = 'depId';
 
-        return new DeploymentActions().waitUntilCreated(deploymentId).then(() => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return new DeploymentActions(undefined as any).waitUntilCreated(deploymentId).then(() => {
             expect(wait).toHaveReturnedTimes(2);
             expect(doGetExecutions).toHaveBeenCalledWith(deploymentId);
             expect(doGetExecutions).toHaveBeenCalledTimes(2);

--- a/widgets/common/src/DeploymentActions.ts
+++ b/widgets/common/src/DeploymentActions.ts
@@ -1,40 +1,43 @@
-/**
- * Created by kinneretzin on 19/10/2016.
- */
-
 export default class DeploymentActions {
-    constructor(toolbox) {
-        this.toolbox = toolbox;
-    }
+    constructor(private toolbox: Stage.Types.Toolbox) {}
 
-    static toManagerLabels(labels) {
+    static toManagerLabels(labels: Stage.Common.Labels.Label[]) {
         return _.map(labels, ({ key, value }) => ({ [key]: value }));
     }
 
-    doGet(deployment, params) {
+    doGet(deployment: { id: string }, params: any) {
         return this.toolbox.getManager().doGet(`/deployments/${deployment.id}`, params);
     }
 
-    doGetDeployments(params) {
+    doGetDeployments(params: any) {
         return this.toolbox.getManager().doGet('/deployments?_include=id', params);
     }
 
-    doDelete(deployment) {
+    doDelete(deployment: { id: string }) {
         return this.toolbox.getManager().doDelete(`/deployments/${deployment.id}`);
     }
 
-    doForceDelete(deployment) {
+    doForceDelete(deployment: { id: string }) {
         return this.toolbox.getManager().doDelete(`/deployments/${deployment.id}`, { force: 'true' });
     }
 
-    doCancel(execution, action) {
+    // eslint-disable-next-line camelcase
+    doCancel(execution: { id: string; deployment_id: string }, action: string) {
         return this.toolbox.getManager().doPost(`/executions/${execution.id}`, null, {
             deployment_id: execution.deployment_id,
             action
         });
     }
 
-    doExecute(deployment, workflow, params, force, dry_run = false, queue = false, scheduled_time = undefined) {
+    doExecute(
+        deployment: { id: string },
+        workflow: { name: string },
+        params: any,
+        force: boolean,
+        dry_run = false,
+        queue = false,
+        scheduled_time = undefined
+    ) {
         return this.toolbox.getManager().doPost('/executions', null, {
             deployment_id: deployment.id,
             workflow_id: workflow.name,
@@ -47,19 +50,19 @@ export default class DeploymentActions {
     }
 
     doUpdate(
-        deploymentName,
-        blueprintName,
-        deploymentInputs,
-        shouldRunInstallWorkflow,
-        shouldRunUninstallWorkflow,
-        installWorkflowFirst,
-        ignoreFailure,
-        shouldRunReinstall,
-        reinstallList,
-        forceUpdate,
-        preview
+        deploymentName: string,
+        blueprintName: string,
+        deploymentInputs: any,
+        shouldRunInstallWorkflow: boolean,
+        shouldRunUninstallWorkflow: boolean,
+        installWorkflowFirst: boolean,
+        ignoreFailure: boolean,
+        shouldRunReinstall: boolean,
+        reinstallList: any,
+        forceUpdate: boolean,
+        preview: boolean
     ) {
-        const data = {};
+        const data: Record<string, any> = {};
 
         if (!_.isEmpty(blueprintName)) {
             data.blueprint_id = blueprintName;
@@ -81,17 +84,17 @@ export default class DeploymentActions {
         return this.toolbox.getManager().doPut(`/deployment-updates/${deploymentName}/update/initiate`, null, data);
     }
 
-    doSetVisibility(deploymentId, visibility) {
+    doSetVisibility(deploymentId: string, visibility: any) {
         return this.toolbox.getManager().doPatch(`/deployments/${deploymentId}/set-visibility`, null, { visibility });
     }
 
-    doSetSite(deploymentId, siteName, detachSite) {
+    doSetSite(deploymentId: string, siteName: string, detachSite: any) {
         const data = detachSite ? { detach_site: detachSite } : { site_name: siteName };
 
         return this.toolbox.getManager().doPost(`/deployments/${deploymentId}/set-site`, null, data);
     }
 
-    doGetSiteName(deploymentId) {
+    doGetSiteName(deploymentId: string) {
         return this.toolbox
             .getManager()
             .doGet(`/deployments/${deploymentId}?_include=site_name`)
@@ -102,16 +105,16 @@ export default class DeploymentActions {
         return this.toolbox.getManager().doGet('/sites?_include=name&_sort=name');
     }
 
-    doSetLabels(deploymentId, deploymentLabels) {
+    doSetLabels(deploymentId: string, deploymentLabels: Stage.Common.Labels.Label[]) {
         const labels = DeploymentActions.toManagerLabels(deploymentLabels);
         return this.toolbox.getManager().doPatch(`/deployments/${deploymentId}`, null, { labels });
     }
 
-    doGetLabel(key, value) {
+    doGetLabel(key: string, value: string) {
         return this.toolbox.getManager().doGet(`/labels/deployments/${key}?_search=${value}`);
     }
 
-    doGetLabels(deploymentId) {
+    doGetLabels(deploymentId: string) {
         return this.toolbox
             .getManager()
             .doGet(`/deployments/${deploymentId}?_include=labels`)
@@ -125,11 +128,11 @@ export default class DeploymentActions {
             .then(({ items }) => items);
     }
 
-    doGetWorkflows(deploymentId) {
+    doGetWorkflows(deploymentId: string) {
         return this.toolbox.getManager().doGet(`/deployments/${deploymentId}?_include=id,workflows`);
     }
 
-    async waitUntilCreated(deploymentId) {
+    async waitUntilCreated(deploymentId: string) {
         const { ExecutionActions, PollHelper } = Stage.Common;
 
         const executionActions = new ExecutionActions(this.toolbox);
@@ -145,6 +148,12 @@ export default class DeploymentActions {
                 return;
             }
         }
+    }
+}
+
+declare global {
+    namespace Stage.Common {
+        export { DeploymentActions };
     }
 }
 

--- a/widgets/common/src/DeploymentActionsModals.tsx
+++ b/widgets/common/src/DeploymentActionsModals.tsx
@@ -7,13 +7,15 @@ interface DeploymentActionsModalsProps {
     deploymentId: string;
     onHide: () => void;
     toolbox: Stage.Types.Toolbox;
+    redirectToParentPageAfterDelete: boolean;
 }
 
 const DeploymentActionsModals: FunctionComponent<DeploymentActionsModalsProps> = ({
     activeAction,
     deploymentId,
     onHide,
-    toolbox
+    toolbox,
+    redirectToParentPageAfterDelete
 }) => {
     const {
         Common: {
@@ -43,7 +45,13 @@ const DeploymentActionsModals: FunctionComponent<DeploymentActionsModalsProps> =
             return <UpdateDeploymentModal {...commonProps} />;
         case actions.delete:
         case actions.forceDelete:
-            return <RemoveDeploymentModal {...commonProps} force={activeAction === actions.forceDelete} />;
+            return (
+                <RemoveDeploymentModal
+                    {...commonProps}
+                    force={activeAction === actions.forceDelete}
+                    redirectToParentPageAfterDelete={redirectToParentPageAfterDelete}
+                />
+            );
         case actions.setSite:
             return <SetSiteModal {...commonProps} />;
         default:
@@ -56,7 +64,8 @@ DeploymentActionsModals.propTypes = {
     deploymentId: PropTypes.string.isRequired,
     onHide: PropTypes.func.isRequired,
     // NOTE: `as any` assertion since Toolbox from PropTypes and TS slightly differ
-    toolbox: Stage.PropTypes.Toolbox.isRequired as any
+    toolbox: Stage.PropTypes.Toolbox.isRequired as any,
+    redirectToParentPageAfterDelete: PropTypes.bool.isRequired
 };
 
 declare global {

--- a/widgets/common/src/DeploymentActionsModals.tsx
+++ b/widgets/common/src/DeploymentActionsModals.tsx
@@ -1,15 +1,33 @@
 /* eslint-disable react/jsx-props-no-spreading */
+import type { FunctionComponent } from 'react';
 import { actions } from './DeploymentActionsMenu';
 
-export default function DeploymentActionsModals({ activeAction, deploymentId, onHide, toolbox }) {
+interface DeploymentActionsModalsProps {
+    activeAction: string;
+    deploymentId: string;
+    onHide: () => void;
+    toolbox: Stage.Types.Toolbox;
+}
+
+const DeploymentActionsModals: FunctionComponent<DeploymentActionsModalsProps> = ({
+    activeAction,
+    deploymentId,
+    onHide,
+    toolbox
+}) => {
     const {
         Common: {
+            // @ts-expect-error Not migrated to TS yet
             ExecuteDeploymentModal,
+            // @ts-expect-error Not migrated to TS yet
             UpdateDeploymentModal,
             RemoveDeploymentModal,
+            // @ts-expect-error Not migrated to TS yet
             SetSiteModal,
+            // @ts-expect-error Not migrated to TS yet
             Labels: { ManageModal: ManageLabelsModal }
         }
+        // NOTE: `as any` since the commons are not migrated to TS yet
     } = Stage;
 
     const commonProps = { deploymentId, open: true, onHide, toolbox };
@@ -31,14 +49,22 @@ export default function DeploymentActionsModals({ activeAction, deploymentId, on
         default:
             return null;
     }
-}
+};
 
 DeploymentActionsModals.propTypes = {
     activeAction: PropTypes.string.isRequired,
     deploymentId: PropTypes.string.isRequired,
     onHide: PropTypes.func.isRequired,
-    toolbox: Stage.PropTypes.Toolbox.isRequired
+    // NOTE: `as any` assertion since Toolbox from PropTypes and TS slightly differ
+    toolbox: Stage.PropTypes.Toolbox.isRequired as any
 };
+
+declare global {
+    namespace Stage.Common {
+        // eslint-disable-next-line import/prefer-default-export
+        export { DeploymentActionsModals };
+    }
+}
 
 Stage.defineCommon({
     name: 'DeploymentActionsModals',

--- a/widgets/common/src/DeploymentActionsModals.tsx
+++ b/widgets/common/src/DeploymentActionsModals.tsx
@@ -38,9 +38,8 @@ const DeploymentActionsModals: FunctionComponent<DeploymentActionsModalsProps> =
         case actions.manageLabels:
             return <ManageLabelsModal {...commonProps} />;
         case actions.install:
-            return <ExecuteDeploymentModal {...commonProps} workflow="install" />;
         case actions.uninstall:
-            return <ExecuteDeploymentModal {...commonProps} workflow="uninstall" />;
+            return <ExecuteDeploymentModal {...commonProps} workflow={activeAction} />;
         case actions.update:
             return <UpdateDeploymentModal {...commonProps} />;
         case actions.delete:

--- a/widgets/common/src/ExecutionActions.ts
+++ b/widgets/common/src/ExecutionActions.ts
@@ -1,27 +1,31 @@
-/**
- * Created by jakubniezgoda on 27/01/2017.
- */
+export {};
 
 class ExecutionActions {
-    constructor(toolbox) {
-        this.toolbox = toolbox;
-    }
+    constructor(private toolbox: Stage.Types.Toolbox) {}
 
-    doGetExecutions(deploymentId) {
+    doGetExecutions(deploymentId: string) {
         return this.toolbox
             .getManager()
             .doGet('/executions?_include=id,status,ended_at', { deployment_id: deploymentId });
     }
 
-    doGetStatus(executionId) {
+    doGetStatus(executionId: string) {
         return this.toolbox.getManager().doGet('/executions?_include=id,status', { id: executionId });
     }
 
-    doAct(execution, action) {
+    // eslint-disable-next-line camelcase
+    doAct(execution: { id: string; deployment_id: string }, action: any) {
         return this.toolbox.getManager().doPost(`/executions/${execution.id}`, null, {
             deployment_id: execution.deployment_id,
             action
         });
+    }
+}
+
+declare global {
+    namespace Stage.Common {
+        // eslint-disable-next-line import/prefer-default-export
+        export { ExecutionActions };
     }
 }
 

--- a/widgets/common/src/RemoveDeploymentModal.tsx
+++ b/widgets/common/src/RemoveDeploymentModal.tsx
@@ -6,6 +6,7 @@ interface RemoveDeploymentModalProps {
     force: boolean;
     onHide: () => void;
     toolbox: Stage.Types.Toolbox;
+    redirectToParentPageAfterDelete: boolean;
 }
 
 const RemoveDeploymentModal: FunctionComponent<RemoveDeploymentModalProps> = ({
@@ -13,7 +14,8 @@ const RemoveDeploymentModal: FunctionComponent<RemoveDeploymentModalProps> = ({
     deploymentId,
     force,
     onHide,
-    toolbox
+    toolbox,
+    redirectToParentPageAfterDelete
 }) => {
     const {
         Basic: { Confirm, ErrorMessage },
@@ -42,8 +44,10 @@ const RemoveDeploymentModal: FunctionComponent<RemoveDeploymentModalProps> = ({
                 const contextDeploymentId = toolbox.getContext().getValue('deploymentId');
                 if (deploymentId === contextDeploymentId) {
                     toolbox.getContext().setValue('deploymentId', null);
-                    // TODO(RD-1824): do not go to parent page
-                    toolbox.goToParentPage();
+
+                    if (redirectToParentPageAfterDelete) {
+                        toolbox.goToParentPage();
+                    }
                 }
                 toolbox.getEventBus().trigger('deployments:refresh');
                 onHide();
@@ -75,7 +79,8 @@ RemoveDeploymentModal.propTypes = {
     open: PropTypes.bool.isRequired,
     onHide: PropTypes.func.isRequired,
     // NOTE: `as any` assertion since Toolbox from PropTypes and TS slightly differ
-    toolbox: Stage.PropTypes.Toolbox.isRequired as any
+    toolbox: Stage.PropTypes.Toolbox.isRequired as any,
+    redirectToParentPageAfterDelete: PropTypes.bool.isRequired
 };
 
 declare global {

--- a/widgets/common/src/RemoveDeploymentModal.tsx
+++ b/widgets/common/src/RemoveDeploymentModal.tsx
@@ -1,4 +1,20 @@
-function RemoveDeploymentModal({ open, deploymentId, force, onHide, toolbox }) {
+import type { FunctionComponent } from 'react';
+
+interface RemoveDeploymentModalProps {
+    open: boolean;
+    deploymentId: string;
+    force: boolean;
+    onHide: () => void;
+    toolbox: Stage.Types.Toolbox;
+}
+
+const RemoveDeploymentModal: FunctionComponent<RemoveDeploymentModalProps> = ({
+    open,
+    deploymentId,
+    force,
+    onHide,
+    toolbox
+}) => {
     const {
         Basic: { Confirm, ErrorMessage },
         Common: { DeploymentActions },
@@ -6,7 +22,7 @@ function RemoveDeploymentModal({ open, deploymentId, force, onHide, toolbox }) {
         i18n
     } = Stage;
 
-    const { errors, setErrors, clearErrors } = useErrors(null);
+    const { errors, setErrors, clearErrors } = useErrors();
 
     useOpenProp(open, clearErrors);
 
@@ -26,12 +42,13 @@ function RemoveDeploymentModal({ open, deploymentId, force, onHide, toolbox }) {
                 const contextDeploymentId = toolbox.getContext().getValue('deploymentId');
                 if (deploymentId === contextDeploymentId) {
                     toolbox.getContext().setValue('deploymentId', null);
+                    // TODO(RD-1824): do not go to parent page
                     toolbox.goToParentPage();
                 }
                 toolbox.getEventBus().trigger('deployments:refresh');
                 onHide();
             })
-            .catch(error => {
+            .catch((error: any) => {
                 log.error(error);
                 setErrors(error.message);
             });
@@ -50,15 +67,23 @@ function RemoveDeploymentModal({ open, deploymentId, force, onHide, toolbox }) {
             onCancel={onHide}
         />
     );
-}
+};
 
 RemoveDeploymentModal.propTypes = {
     deploymentId: PropTypes.string.isRequired,
     force: PropTypes.bool.isRequired,
     open: PropTypes.bool.isRequired,
     onHide: PropTypes.func.isRequired,
-    toolbox: Stage.PropTypes.Toolbox.isRequired
+    // NOTE: `as any` assertion since Toolbox from PropTypes and TS slightly differ
+    toolbox: Stage.PropTypes.Toolbox.isRequired as any
 };
+
+declare global {
+    namespace Stage.Common {
+        // eslint-disable-next-line import/prefer-default-export
+        export { RemoveDeploymentModal };
+    }
+}
 
 Stage.defineCommon({
     name: 'RemoveDeploymentModal',

--- a/widgets/common/src/deploymentsView/detailsPane/header.tsx
+++ b/widgets/common/src/deploymentsView/detailsPane/header.tsx
@@ -22,7 +22,7 @@ const DetailsPaneHeader: FunctionComponent<DetailsPaneHeaderProps> = ({ deployme
             width: 1,
             height: 1,
             definition: 'deploymentActionButtons',
-            configuration: {},
+            configuration: { preventRedirectToParentPageAfterDelete: true },
             drillDownPages: {},
             maximized: false
         }),

--- a/widgets/common/src/props/Labels.ts
+++ b/widgets/common/src/props/Labels.ts
@@ -7,6 +7,13 @@ declare global {
             Label: typeof LabelPropType;
             Labels: typeof LabelsPropType;
         }
+        namespace Common.Labels {
+            export interface Label {
+                key: string;
+                value: string;
+                isInSystem?: boolean;
+            }
+        }
     }
 }
 // NOTE: prevents leaking variables as global in TS

--- a/widgets/deploymentActionButtons/src/DeploymentActionButtons.tsx
+++ b/widgets/deploymentActionButtons/src/DeploymentActionButtons.tsx
@@ -1,11 +1,19 @@
-export default function DeploymentActionButtons({ deployment, toolbox }) {
+import type { FunctionComponent } from 'react';
+
+interface DeploymentActionButtonsProps {
+    deployment: { id: string; workflows: unknown[] };
+    toolbox: Stage.Types.Toolbox;
+}
+
+const DeploymentActionButtons: FunctionComponent<DeploymentActionButtonsProps> = ({ deployment, toolbox }) => {
     const {
         Basic: { Button },
+        // @ts-expect-error Those commons are not migrated to TS yet
         Common: { DeploymentActionsMenu, DeploymentActionsModals, ExecuteDeploymentModal, WorkflowsMenu },
         Hooks: { useResettableState }
     } = Stage;
 
-    const [activeAction, setActiveAction, resetActiveAction] = useResettableState(null);
+    const [activeAction, setActiveAction, resetActiveAction] = useResettableState<string | null>(null);
     const [workflow, setWorkflow, resetWorkflow] = useResettableState(null);
 
     const { id, workflows } = deployment;
@@ -62,9 +70,5 @@ export default function DeploymentActionButtons({ deployment, toolbox }) {
             )}
         </div>
     );
-}
-
-DeploymentActionButtons.propTypes = {
-    deployment: PropTypes.shape({ id: PropTypes.string, workflows: PropTypes.arrayOf(PropTypes.shape({})) }).isRequired,
-    toolbox: Stage.PropTypes.Toolbox.isRequired
 };
+export default DeploymentActionButtons;

--- a/widgets/deploymentActionButtons/src/DeploymentActionButtons.tsx
+++ b/widgets/deploymentActionButtons/src/DeploymentActionButtons.tsx
@@ -3,9 +3,14 @@ import type { FunctionComponent } from 'react';
 interface DeploymentActionButtonsProps {
     deployment: { id: string; workflows: unknown[] };
     toolbox: Stage.Types.Toolbox;
+    redirectToParentPageAfterDelete: boolean;
 }
 
-const DeploymentActionButtons: FunctionComponent<DeploymentActionButtonsProps> = ({ deployment, toolbox }) => {
+const DeploymentActionButtons: FunctionComponent<DeploymentActionButtonsProps> = ({
+    deployment,
+    toolbox,
+    redirectToParentPageAfterDelete
+}) => {
     const {
         Basic: { Button },
         // @ts-expect-error Those commons are not migrated to TS yet
@@ -66,6 +71,7 @@ const DeploymentActionButtons: FunctionComponent<DeploymentActionButtonsProps> =
                     deploymentId={id}
                     onHide={resetActiveAction}
                     toolbox={toolbox}
+                    redirectToParentPageAfterDelete={redirectToParentPageAfterDelete}
                 />
             )}
         </div>

--- a/widgets/deploymentActionButtons/src/widget.jsx
+++ b/widgets/deploymentActionButtons/src/widget.jsx
@@ -42,6 +42,7 @@ Stage.defineWidget({
     render(widget, data, error, toolbox) {
         const { Loading } = Stage.Basic;
 
+        // TODO(RD-1827): move the loading indicator to the individual buttons, so they are always shown
         if (_.isEmpty(data)) {
             return <Loading />;
         }

--- a/widgets/deploymentActionButtons/src/widget.tsx
+++ b/widgets/deploymentActionButtons/src/widget.tsx
@@ -1,3 +1,4 @@
+import { castArray } from 'lodash';
 import type { ComponentProps } from 'react';
 import DeploymentActionButtons from './DeploymentActionButtons';
 
@@ -46,7 +47,7 @@ Stage.defineWidget<WidgetParams, WidgetData, WidgetConfiguration>({
     fetchParams(_widget, toolbox): WidgetParams {
         const deploymentId = toolbox.getContext().getValue('deploymentId');
         // Deployment Actions Buttons widget does not support multiple actions, thus picking only one deploymentId
-        const firstDeploymentId = _.castArray(deploymentId)[0] as WidgetParams['id'];
+        const firstDeploymentId = castArray(deploymentId)[0] as WidgetParams['id'];
 
         return { id: firstDeploymentId };
     },

--- a/widgets/deploymentActionButtons/src/widget.tsx
+++ b/widgets/deploymentActionButtons/src/widget.tsx
@@ -43,10 +43,10 @@ Stage.defineWidget<WidgetParams, WidgetData, WidgetConfiguration>({
         return actions.doGetWorkflows(id);
     },
 
-    fetchParams(_widget, toolbox): { id: string | null } {
+    fetchParams(_widget, toolbox): WidgetParams {
         const deploymentId = toolbox.getContext().getValue('deploymentId');
         // Deployment Actions Buttons widget does not support multiple actions, thus picking only one deploymentId
-        const firstDeploymentId: string | undefined | null = _.castArray(deploymentId)[0];
+        const firstDeploymentId = _.castArray(deploymentId)[0] as WidgetParams['id'];
 
         return { id: firstDeploymentId };
     },

--- a/widgets/deploymentActionButtons/src/widget.tsx
+++ b/widgets/deploymentActionButtons/src/widget.tsx
@@ -1,12 +1,15 @@
 import type { ComponentProps } from 'react';
 import DeploymentActionButtons from './DeploymentActionButtons';
 
-interface DeploymentActionsWidgetParams {
+interface WidgetParams {
     id: string | null | undefined;
 }
-type DeploymentActionsWidgetData = ComponentProps<typeof DeploymentActionButtons>['deployment'];
+type WidgetData = ComponentProps<typeof DeploymentActionButtons>['deployment'];
+interface WidgetConfiguration {
+    preventRedirectToParentPageAfterDelete?: boolean;
+}
 
-Stage.defineWidget<DeploymentActionsWidgetParams, DeploymentActionsWidgetData, Record<never, any>>({
+Stage.defineWidget<WidgetParams, WidgetData, WidgetConfiguration>({
     id: 'deploymentActionButtons',
     name: 'Deployment action buttons',
     description: 'Provides set of action buttons for deployment',
@@ -16,7 +19,15 @@ Stage.defineWidget<DeploymentActionsWidgetParams, DeploymentActionsWidgetData, R
     showBorder: false,
     categories: [Stage.GenericConfig.CATEGORY.DEPLOYMENTS, Stage.GenericConfig.CATEGORY.BUTTONS_AND_FILTERS],
 
-    initialConfiguration: [],
+    initialConfiguration: [
+        {
+            // NOTE: for programmatic use only, not exposed in the UI
+            type: Stage.Basic.GenericField.BOOLEAN_TYPE,
+            hidden: true,
+            id: 'preventRedirectToParentPageAfterDelete',
+            default: false
+        }
+    ],
     isReact: true,
     hasReadme: true,
     permission: Stage.GenericConfig.WIDGET_PERMISSION('deploymentActionButtons'),
@@ -41,7 +52,7 @@ Stage.defineWidget<DeploymentActionsWidgetParams, DeploymentActionsWidgetData, R
         return { id: firstDeploymentId };
     },
 
-    render(_widget, data, _error, toolbox) {
+    render(widget, data, _error, toolbox) {
         const { Loading } = Stage.Basic;
 
         // TODO(RD-1827): move the loading indicator to the individual buttons, so they are always shown
@@ -49,6 +60,12 @@ Stage.defineWidget<DeploymentActionsWidgetParams, DeploymentActionsWidgetData, R
             return <Loading />;
         }
 
-        return <DeploymentActionButtons deployment={data} toolbox={toolbox} />;
+        return (
+            <DeploymentActionButtons
+                deployment={data}
+                toolbox={toolbox}
+                redirectToParentPageAfterDelete={!widget.configuration.preventRedirectToParentPageAfterDelete}
+            />
+        );
     }
 });

--- a/widgets/deploymentActionButtons/src/widget.tsx
+++ b/widgets/deploymentActionButtons/src/widget.tsx
@@ -1,10 +1,12 @@
-/**
- * Created by jakubniezgoda on 01/03/2017.
- */
-
+import type { ComponentProps } from 'react';
 import DeploymentActionButtons from './DeploymentActionButtons';
 
-Stage.defineWidget({
+interface DeploymentActionsWidgetParams {
+    id: string | null | undefined;
+}
+type DeploymentActionsWidgetData = ComponentProps<typeof DeploymentActionButtons>['deployment'];
+
+Stage.defineWidget<DeploymentActionsWidgetParams, DeploymentActionsWidgetData, Record<never, any>>({
     id: 'deploymentActionButtons',
     name: 'Deployment action buttons',
     description: 'Provides set of action buttons for deployment',
@@ -19,8 +21,8 @@ Stage.defineWidget({
     hasReadme: true,
     permission: Stage.GenericConfig.WIDGET_PERMISSION('deploymentActionButtons'),
 
-    fetchData(widget, toolbox, { id }) {
-        if (_.isEmpty(id)) {
+    fetchData(_widget, toolbox, { id }) {
+        if (!id) {
             return Promise.resolve({ id: '', workflows: [] });
         }
 
@@ -31,19 +33,19 @@ Stage.defineWidget({
         return actions.doGetWorkflows(id).finally(() => toolbox.loading(false));
     },
 
-    fetchParams(widget, toolbox) {
+    fetchParams(_widget, toolbox): { id: string | null } {
         const deploymentId = toolbox.getContext().getValue('deploymentId');
         // Deployment Actions Buttons widget does not support multiple actions, thus picking only one deploymentId
-        const firstDeploymentId = _.castArray(deploymentId)[0];
+        const firstDeploymentId: string | undefined | null = _.castArray(deploymentId)[0];
 
         return { id: firstDeploymentId };
     },
 
-    render(widget, data, error, toolbox) {
+    render(_widget, data, _error, toolbox) {
         const { Loading } = Stage.Basic;
 
         // TODO(RD-1827): move the loading indicator to the individual buttons, so they are always shown
-        if (_.isEmpty(data)) {
+        if (Stage.Utils.isEmptyWidgetData(data)) {
             return <Loading />;
         }
 

--- a/widgets/deploymentActionButtons/src/widget.tsx
+++ b/widgets/deploymentActionButtons/src/widget.tsx
@@ -40,8 +40,7 @@ Stage.defineWidget<WidgetParams, WidgetData, WidgetConfiguration>({
         const { DeploymentActions } = Stage.Common;
         const actions = new DeploymentActions(toolbox);
 
-        toolbox.loading(true);
-        return actions.doGetWorkflows(id).finally(() => toolbox.loading(false));
+        return actions.doGetWorkflows(id);
     },
 
     fetchParams(_widget, toolbox): { id: string | null } {


### PR DESCRIPTION
Deleting a deployment in the Deployments View widget no longer triggers a redirect to the parent page.

The behavior is changed only when the _Deployment action buttons_ are displayed in the Deployments View widget. I have confirmed that redirecting to the parent page still happens when deleting a deployment from the drilled-down view of the old Deployments widget :slightly_smiling_face: (where it makes sense)

One caveat with deleting deployments is that the deployment is still present in the LIST request that follows the delete request. This is because the backend responds to the DELETE request and then deletes the deployment in the background, asynchronously, so the user will still see the deployment being deleted. The test still passes, since the deployment is gone with the next polling request. I've created RD-2057 to address it in the backend

The PR also contains some TS migrations of files I touched or were in the vicinity :slightly_smiling_face: Looks like git did not detect some of them as renames :worried: Reviewing commit-by-commit looks to be reasonable here

## System tests

https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/460/pipeline

Ran 2021-04-15 13:54 CEST