### PR TITLE
RD-2089 Add deployments map placeholder

### DIFF
--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -631,6 +631,13 @@
                     "placeholder": "Select fields from the list"
                 }
             },
+            "header": {
+              "map": {
+                "label": "Map",
+                "openMap": "Open map",
+                "closeMap": "Close map"
+              }
+            },
             "iconLabels": {
                 "inProgress": "In progress",
                 "requiresAttention": "Requires attention"

--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -629,6 +629,13 @@
                 "fieldsToShow": {
                     "name": "List of fields to show in the table",
                     "placeholder": "Select fields from the list"
+                },
+                "mapOpenByDefault": {
+                    "name": "Show map by default"
+                },
+                "mapHeight": {
+                    "name": "Map height",
+                    "description": "The height of the map in pixels"
                 }
             },
             "header": {

--- a/test/cypress/integration/widgets/deployments_view_spec.ts
+++ b/test/cypress/integration/widgets/deployments_view_spec.ts
@@ -81,10 +81,16 @@ describe('Deployments View widget', () => {
         cy.get('.widget').filter('.deploymentsViewWidget, .deploymentsViewDrilledDownWidget').find('.widgetItem');
     const getDeploymentsViewTable = () => getDeploymentsViewWidget().get('.gridTable');
     const getDeploymentsViewDetailsPane = () => getDeploymentsViewWidget().get('.detailsPane');
+    // TODO(RD-2090): use a better selector for the map
+    const getDeploymentsViewMap = () => getDeploymentsViewWidget().contains('I am a map');
+
+    const verifyMapHeight = (expectedHeight: number) =>
+        getDeploymentsViewMap().invoke('height').should('eq', expectedHeight);
 
     const widgetConfigurationHelpers = {
         getFieldsDropdown: () => cy.contains('List of fields to show in the table').parent().find('[role="listbox"]'),
-        toggleFieldsDropdown: () => widgetConfigurationHelpers.getFieldsDropdown().find('.dropdown.icon').click()
+        toggleFieldsDropdown: () => widgetConfigurationHelpers.getFieldsDropdown().find('.dropdown.icon').click(),
+        mapHeightInput: () => cy.contains('Map height').parent().find('input[type="number"]')
     };
 
     describe('configuration', () => {
@@ -118,7 +124,20 @@ describe('Deployments View widget', () => {
         });
 
         it('should affect the map', () => {
-            // TODO:
+            useDeploymentsViewWidget({
+                configurationOverrides: { mapOpenByDefault: true }
+            });
+
+            verifyMapHeight(widgetConfiguration.mapHeight);
+
+            const newHeight = 100;
+
+            cy.editWidgetConfiguration(widgetId, () => {
+                // NOTE: after clearing the input, 0 is automatically inserted. {home}{del} removes the leading 0
+                widgetConfigurationHelpers.mapHeightInput().clear().type(`${newHeight}{home}{del}`);
+            });
+
+            verifyMapHeight(newHeight);
         });
     });
 

--- a/test/cypress/integration/widgets/deployments_view_spec.ts
+++ b/test/cypress/integration/widgets/deployments_view_spec.ts
@@ -116,6 +116,10 @@ describe('Deployments View widget', () => {
                 cy.contains(siteName).should('not.exist');
             });
         });
+
+        it('should affect the map', () => {
+            // TODO:
+        });
     });
 
     it('should display the deployments and content in the details pane', () => {
@@ -463,5 +467,12 @@ describe('Deployments View widget', () => {
         cy.usePageMock([`${widgetId}DrilledDown`]).mockLogin();
 
         cy.contains('Unexpected widget usage');
+    });
+
+    describe('map', () => {
+        // TODO(RD-2090): make the test more meaningful
+        it('should be toggled upon clicking the button', () => {
+            // TODO:
+        });
     });
 });

--- a/test/cypress/integration/widgets/deployments_view_spec.ts
+++ b/test/cypress/integration/widgets/deployments_view_spec.ts
@@ -83,6 +83,7 @@ describe('Deployments View widget', () => {
     const getDeploymentsViewDetailsPane = () => getDeploymentsViewWidget().get('.detailsPane');
     // TODO(RD-2090): use a better selector for the map
     const getDeploymentsViewMap = () => getDeploymentsViewWidget().contains('I am a map');
+    const getDeploymentsMapToggleButton = () => getDeploymentsViewWidget().contains('button', 'Map');
 
     const verifyMapHeight = (expectedHeight: number) =>
         getDeploymentsViewMap().invoke('height').should('eq', expectedHeight);
@@ -491,7 +492,21 @@ describe('Deployments View widget', () => {
     describe('map', () => {
         // TODO(RD-2090): make the test more meaningful
         it('should be toggled upon clicking the button', () => {
-            // TODO:
+            useDeploymentsViewWidget();
+
+            getDeploymentsViewMap().should('not.exist');
+
+            getDeploymentsMapToggleButton()
+                .click()
+                .should('have.class', 'active')
+                .should('have.attr', 'title', 'Close map');
+            getDeploymentsViewMap();
+
+            getDeploymentsMapToggleButton()
+                .click()
+                .should('not.have.class', 'active')
+                .should('have.attr', 'title', 'Open map');
+            getDeploymentsViewMap().should('not.exist');
         });
     });
 });

--- a/test/cypress/integration/widgets/deployments_view_spec.ts
+++ b/test/cypress/integration/widgets/deployments_view_spec.ts
@@ -20,7 +20,9 @@ describe('Deployments View widget', () => {
         pageSize: 100,
         customPollingTime: 10,
         sortColumn: 'created_at',
-        sortAscending: false
+        sortAscending: false,
+        mapHeight: 300,
+        mapOpenByDefault: false
     };
     // NOTE: widgets below are shown in the details pane
     const additionalWidgetIdsToLoad = [

--- a/widgets/common/src/deploymentsView/DeploymentsView.tsx
+++ b/widgets/common/src/deploymentsView/DeploymentsView.tsx
@@ -7,7 +7,13 @@ import type { SharedDeploymentsViewWidgetConfiguration } from './configuration';
 import DetailsPane from './detailsPane';
 import { DeploymentsTable } from './table';
 import { FilterRuleOperators, FilterRuleType } from '../filters/types';
-import { DeploymentDetailsContainer, DeploymentsTableContainer, DeploymentsViewContainer } from './layout';
+import {
+    DeploymentDetailsContainer,
+    DeploymentsMapContainer,
+    DeploymentsTableContainer,
+    DeploymentsViewContainer,
+    DeploymentsViewHeaderContainer
+} from './layout';
 
 export interface DeploymentsViewProps {
     widget: Stage.Types.Widget<SharedDeploymentsViewWidgetConfiguration>;
@@ -94,6 +100,8 @@ export const DeploymentsView: FunctionComponent<DeploymentsViewProps> = ({
 
     return (
         <DeploymentsViewContainer>
+            <DeploymentsViewHeaderContainer>Map toggle goes here</DeploymentsViewHeaderContainer>
+            <DeploymentsMapContainer>Hey, I am a map</DeploymentsMapContainer>
             <DeploymentsTableContainer>
                 <DeploymentsTable
                     setGridParams={setGridParams}

--- a/widgets/common/src/deploymentsView/DeploymentsView.tsx
+++ b/widgets/common/src/deploymentsView/DeploymentsView.tsx
@@ -14,6 +14,7 @@ import {
     DeploymentsViewContainer,
     DeploymentsViewHeaderContainer
 } from './layout';
+import DeploymentsViewHeader from './header';
 
 export interface DeploymentsViewProps {
     widget: Stage.Types.Widget<SharedDeploymentsViewWidgetConfiguration>;
@@ -59,6 +60,8 @@ export const DeploymentsView: FunctionComponent<DeploymentsViewProps> = ({
 
     Stage.Hooks.useEventListener(toolbox, 'deployments:refresh', deploymentsResult.refetch);
 
+    const [mapOpen, toggleMap] = Stage.Hooks.useToggle(false);
+
     const { Loading, ErrorMessage } = Stage.Basic;
     const { i18n } = Stage;
 
@@ -100,8 +103,12 @@ export const DeploymentsView: FunctionComponent<DeploymentsViewProps> = ({
 
     return (
         <DeploymentsViewContainer>
-            <DeploymentsViewHeaderContainer>Map toggle goes here</DeploymentsViewHeaderContainer>
-            <DeploymentsMapContainer>Hey, I am a map</DeploymentsMapContainer>
+            <DeploymentsViewHeaderContainer>
+                <DeploymentsViewHeader mapOpen={mapOpen} toggleMap={toggleMap} />
+            </DeploymentsViewHeaderContainer>
+
+            {mapOpen && <DeploymentsMapContainer>Hey, I am a map</DeploymentsMapContainer>}
+
             <DeploymentsTableContainer>
                 <DeploymentsTable
                     setGridParams={setGridParams}

--- a/widgets/common/src/deploymentsView/DeploymentsView.tsx
+++ b/widgets/common/src/deploymentsView/DeploymentsView.tsx
@@ -7,6 +7,7 @@ import type { SharedDeploymentsViewWidgetConfiguration } from './configuration';
 import DetailsPane from './detailsPane';
 import { DeploymentsTable } from './table';
 import { FilterRuleOperators, FilterRuleType } from '../filters/types';
+import { DeploymentDetailsContainer, DeploymentsTableContainer, DeploymentsViewContainer } from './layout';
 
 export interface DeploymentsViewProps {
     widget: Stage.Types.Widget<SharedDeploymentsViewWidgetConfiguration>;
@@ -92,18 +93,22 @@ export const DeploymentsView: FunctionComponent<DeploymentsViewProps> = ({
     }
 
     return (
-        <div className="grid">
-            <DeploymentsTable
-                setGridParams={setGridParams}
-                toolbox={toolbox}
-                loadingIndicatorVisible={fetchingRules || deploymentsResult.isFetching}
-                pageSize={widget.configuration.pageSize}
-                totalSize={deploymentsResult.data.metadata.pagination.total}
-                deployments={deploymentsResult.data.items}
-                fieldsToShow={widget.configuration.fieldsToShow}
-            />
-            <DetailsPane deployment={selectedDeployment} widget={widget} toolbox={toolbox} />
-        </div>
+        <DeploymentsViewContainer>
+            <DeploymentsTableContainer>
+                <DeploymentsTable
+                    setGridParams={setGridParams}
+                    toolbox={toolbox}
+                    loadingIndicatorVisible={fetchingRules || deploymentsResult.isFetching}
+                    pageSize={widget.configuration.pageSize}
+                    totalSize={deploymentsResult.data.metadata.pagination.total}
+                    deployments={deploymentsResult.data.items}
+                    fieldsToShow={widget.configuration.fieldsToShow}
+                />
+            </DeploymentsTableContainer>
+            <DeploymentDetailsContainer>
+                <DetailsPane deployment={selectedDeployment} widget={widget} toolbox={toolbox} />
+            </DeploymentDetailsContainer>
+        </DeploymentsViewContainer>
     );
 };
 

--- a/widgets/common/src/deploymentsView/DeploymentsView.tsx
+++ b/widgets/common/src/deploymentsView/DeploymentsView.tsx
@@ -60,7 +60,7 @@ export const DeploymentsView: FunctionComponent<DeploymentsViewProps> = ({
 
     Stage.Hooks.useEventListener(toolbox, 'deployments:refresh', deploymentsResult.refetch);
 
-    const [mapOpen, toggleMap] = Stage.Hooks.useToggle(false);
+    const [mapOpen, toggleMap] = Stage.Hooks.useToggle(widget.configuration.mapOpenByDefault);
 
     const { Loading, ErrorMessage } = Stage.Basic;
     const { i18n } = Stage;
@@ -107,7 +107,11 @@ export const DeploymentsView: FunctionComponent<DeploymentsViewProps> = ({
                 <DeploymentsViewHeader mapOpen={mapOpen} toggleMap={toggleMap} />
             </DeploymentsViewHeaderContainer>
 
-            {mapOpen && <DeploymentsMapContainer>Hey, I am a map</DeploymentsMapContainer>}
+            {mapOpen && (
+                <DeploymentsMapContainer height={widget.configuration.mapHeight}>
+                    Hey, I am a map
+                </DeploymentsMapContainer>
+            )}
 
             <DeploymentsTableContainer>
                 <DeploymentsTable

--- a/widgets/common/src/deploymentsView/configuration.ts
+++ b/widgets/common/src/deploymentsView/configuration.ts
@@ -4,11 +4,17 @@ import { deploymentsViewColumnDefinitions, DeploymentsViewColumnId, deploymentsV
 export interface SharedDeploymentsViewWidgetConfiguration {
     /** In milliseconds */
     customPollingTime: number;
+    mapOpenByDefault: boolean;
+    mapHeight: number;
     fieldsToShow: DeploymentsViewColumnId[];
     pageSize: number;
     sortColumn: string;
     sortAscending: boolean;
 }
+
+const configurationT = (suffix: string) => Stage.i18n.t(`${i18nPrefix}.configuration.${suffix}`);
+
+const defaultMapHeight = 300;
 
 export const sharedConfiguration: Stage.Types.WidgetConfigurationDefinition[] = [
     {
@@ -16,11 +22,23 @@ export const sharedConfiguration: Stage.Types.WidgetConfigurationDefinition[] = 
         // NOTE: polling is handled by react-query, thus, use a different ID
         id: 'customPollingTime'
     },
-    // TODO(RD-1225): add map configuration
+    {
+        id: 'mapOpenByDefault',
+        type: Stage.Basic.GenericField.BOOLEAN_TYPE,
+        name: configurationT('mapOpenByDefault.name'),
+        default: false
+    },
+    {
+        id: 'mapHeight',
+        type: Stage.Basic.GenericField.NUMBER_TYPE,
+        name: configurationT('mapHeight.name'),
+        description: configurationT('mapHeight.description'),
+        default: defaultMapHeight
+    },
     {
         id: 'fieldsToShow',
-        name: Stage.i18n.t(`${i18nPrefix}.configuration.fieldsToShow.name`),
-        placeHolder: Stage.i18n.t(`${i18nPrefix}.configuration.fieldsToShow.placeholder`),
+        name: configurationT('fieldsToShow.name'),
+        placeHolder: configurationT('fieldsToShow.placeholder'),
         items: deploymentsViewColumnIds.map(columnId => ({
             name: deploymentsViewColumnDefinitions[columnId].name,
             value: columnId

--- a/widgets/common/src/deploymentsView/detailsPane/header.scss
+++ b/widgets/common/src/deploymentsView/detailsPane/header.scss
@@ -3,6 +3,7 @@
     display: flex;
     flex-direction: column;
     overflow: auto;
+    height: 100%;
 
     .detailsPaneHeader {
         display: flex;

--- a/widgets/common/src/deploymentsView/header.tsx
+++ b/widgets/common/src/deploymentsView/header.tsx
@@ -8,8 +8,15 @@ interface DeploymentsViewHeaderProps {
 
 const mapT = (suffix: string) => Stage.i18n.t(`${i18nPrefix}.header.map.${suffix}`);
 
+const production = process.env.NODE_ENV === 'production' && !process.env.TEST;
+
 const DeploymentsViewHeader: FunctionComponent<DeploymentsViewHeaderProps> = ({ mapOpen, toggleMap }) => {
     const { Button, Icon } = Stage.Basic;
+
+    // TODO(RD-1225): enable the map in production
+    if (production) {
+        return null;
+    }
 
     return (
         <Button active={mapOpen} onClick={toggleMap} title={mapT(mapOpen ? 'closeMap' : 'openMap')}>

--- a/widgets/common/src/deploymentsView/header.tsx
+++ b/widgets/common/src/deploymentsView/header.tsx
@@ -1,0 +1,20 @@
+import type { FunctionComponent } from 'react';
+import { i18nPrefix } from './common';
+
+interface DeploymentsViewHeaderProps {
+    mapOpen: boolean;
+    toggleMap: () => void;
+}
+
+const mapT = (suffix: string) => Stage.i18n.t(`${i18nPrefix}.header.map.${suffix}`);
+
+const DeploymentsViewHeader: FunctionComponent<DeploymentsViewHeaderProps> = ({ mapOpen, toggleMap }) => {
+    const { Button, Icon } = Stage.Basic;
+
+    return (
+        <Button active={mapOpen} onClick={toggleMap} title={mapT(mapOpen ? 'closeMap' : 'openMap')}>
+            <Icon name="map" /> {mapT('label')}
+        </Button>
+    );
+};
+export default DeploymentsViewHeader;

--- a/widgets/common/src/deploymentsView/layout.ts
+++ b/widgets/common/src/deploymentsView/layout.ts
@@ -18,9 +18,8 @@ export const DeploymentsViewHeaderContainer = styled.div`
     justify-content: flex-end;
 `;
 
-export const DeploymentsMapContainer = styled.div`
-    // TODO(RD-1225): consume height from widget configuration
-    height: 400px;
+export const DeploymentsMapContainer = styled.div<{ height: number }>`
+    height: ${props => props.height}px;
     grid-area: map;
 `;
 

--- a/widgets/common/src/deploymentsView/layout.ts
+++ b/widgets/common/src/deploymentsView/layout.ts
@@ -3,12 +3,28 @@ import styled from 'styled-components';
 export const DeploymentsViewContainer = styled.div`
     height: 100%;
     display: grid;
+    grid-template-areas:
+        'header header'
+        'map map'
+        'table details';
+    grid-template-rows: min-content min-content minmax(250px, 1fr);
     grid-template-columns: minmax(50%, 1fr) 1fr;
+`;
+
+export const DeploymentsViewHeaderContainer = styled.div`
+    grid-area: header;
+`;
+
+export const DeploymentsMapContainer = styled.div`
+    // TODO(RD-1225): consume height from widget configuration
+    height: 400px;
+    grid-area: map;
 `;
 
 export const DeploymentsTableContainer = styled.div`
     height: 100%;
     overflow: auto;
+    grid-area: table;
 
     .gridTable {
         height: 100%;
@@ -26,4 +42,5 @@ export const DeploymentsTableContainer = styled.div`
 export const DeploymentDetailsContainer = styled.div`
     height: 100%;
     overflow: auto;
+    grid-area: details;
 `;

--- a/widgets/common/src/deploymentsView/layout.ts
+++ b/widgets/common/src/deploymentsView/layout.ts
@@ -1,0 +1,29 @@
+import styled from 'styled-components';
+
+export const DeploymentsViewContainer = styled.div`
+    height: 100%;
+    display: grid;
+    grid-template-columns: minmax(50%, 1fr) 1fr;
+`;
+
+export const DeploymentsTableContainer = styled.div`
+    height: 100%;
+    overflow: auto;
+
+    .gridTable {
+        height: 100%;
+        overflow: auto;
+
+        // NOTE: scroll only the table, not the searchbox
+        > div:nth-child(2) {
+            // NOTE: 48px - the offset of table in the parent
+            height: calc(100% - 48px);
+            overflow: auto;
+        }
+    }
+`;
+
+export const DeploymentDetailsContainer = styled.div`
+    height: 100%;
+    overflow: auto;
+`;

--- a/widgets/common/src/deploymentsView/layout.ts
+++ b/widgets/common/src/deploymentsView/layout.ts
@@ -13,6 +13,9 @@ export const DeploymentsViewContainer = styled.div`
 
 export const DeploymentsViewHeaderContainer = styled.div`
     grid-area: header;
+    margin-bottom: 1em;
+    display: flex;
+    justify-content: flex-end;
 `;
 
 export const DeploymentsMapContainer = styled.div`

--- a/widgets/common/src/deploymentsView/layout.ts
+++ b/widgets/common/src/deploymentsView/layout.ts
@@ -8,7 +8,7 @@ export const DeploymentsViewContainer = styled.div`
         'map map'
         'table details';
     grid-template-rows: min-content min-content minmax(250px, 1fr);
-    grid-template-columns: minmax(50%, 1fr) 1fr;
+    grid-template-columns: 1fr 1fr;
 `;
 
 export const DeploymentsViewHeaderContainer = styled.div`

--- a/widgets/common/src/deploymentsView/styles.scss
+++ b/widgets/common/src/deploymentsView/styles.scss
@@ -42,15 +42,4 @@ $deploymentProgressBarColors: (
             background-color: var(--deployment-progress-bar-color-#{$stateName});
         }
     }
-
-    .grid {
-        display: grid;
-        grid-template-columns: minmax(50%, 1fr) 1fr;
-        height: 100%;
-
-        // NOTE: scroll only the table, not the searchbox
-        .gridTable > div:nth-child(2) {
-            overflow: auto;
-        }
-    }
 }

--- a/widgets/common/src/deploymentsView/table/DeploymentsTable.tsx
+++ b/widgets/common/src/deploymentsView/table/DeploymentsTable.tsx
@@ -8,6 +8,7 @@ import type { Deployment } from '../types';
 
 const TableContainer = styled.div`
     position: relative;
+    height: 100%;
 `;
 const TableLoadingIndicator = styled(Stage.Basic.Loader)`
     // Increase specificity to override existing styling


### PR DESCRIPTION
The purpose of the PR is to prepare the structure for the Deployments Map in the Deployments View widget. The actual map will be implemented in RD-2090

## Changes

1. Change the scrollbar behavior in the Deployments View widget

    Each "component" (details, table, map) has its own area in a grid. Details and table have their own scrollbars

2. Add a button to toggle the map
3. Add map widget configuration
4. Add tests for the added functionalities'

## Video


https://user-images.githubusercontent.com/889383/115364630-dfc73080-a1c3-11eb-92e1-f3a193c523fe.mp4



## System tests

https://jenkins.cloudify.co/job/Stage-UI-System-Test/475/

Ran 2021-04-20 10:31 CEST