### PR TITLE
RD-2261 - fix for missing default parameter in doExecute method in deployment actions

### DIFF
--- a/widgets/common/src/DeploymentActions.ts
+++ b/widgets/common/src/DeploymentActions.ts
@@ -5,6 +5,13 @@ export interface WorkflowOptions {
     scheduledTime: any;
 }
 
+const defaultWorkflowOptions: WorkflowOptions = {
+    force: false,
+    dryRun: false,
+    queue: false,
+    scheduledTime: null
+};
+
 export default class DeploymentActions {
     constructor(private toolbox: Stage.Types.Toolbox) {}
 
@@ -40,7 +47,12 @@ export default class DeploymentActions {
         deploymentId: string,
         workflowId: string,
         workflowParameters: any,
-        { force = false, dryRun = false, queue = false, scheduledTime }: WorkflowOptions
+        {
+            force = defaultWorkflowOptions.force,
+            dryRun = defaultWorkflowOptions.dryRun,
+            queue = defaultWorkflowOptions.queue,
+            scheduledTime
+        }: WorkflowOptions = defaultWorkflowOptions
     ) {
         return this.toolbox.getManager().doPost('/executions', null, {
             deployment_id: deploymentId,

--- a/widgets/common/src/DeploymentActions.ts
+++ b/widgets/common/src/DeploymentActions.ts
@@ -51,7 +51,7 @@ export default class DeploymentActions {
             force = defaultWorkflowOptions.force,
             dryRun = defaultWorkflowOptions.dryRun,
             queue = defaultWorkflowOptions.queue,
-            scheduledTime
+            scheduledTime = defaultWorkflowOptions.scheduledTime
         }: WorkflowOptions = defaultWorkflowOptions
     ) {
         return this.toolbox.getManager().doPost('/executions', null, {


### PR DESCRIPTION
This PR fixes failing widgets/agents_spec.ts tests because of missing default value in deployment actions.

Ticket: https://cloudifysource.atlassian.net/browse/RD-2261-widgets_agents_spec_ts%20-tests-fail-because-of-some-element-covers-other-one

System tests passes: https://jenkins.cloudify.co/view/UI/job/Stage-UI-System-Test/552/