### PR TITLE
RD-2078 'Deploy on' modal improvements

### DIFF
--- a/widgets/common/src/DeployBlueprintModal.tsx
+++ b/widgets/common/src/DeployBlueprintModal.tsx
@@ -35,7 +35,7 @@ const DeployBlueprintModal: FunctionComponent<DeployBlueprintModalProps> = ({ to
     function installDeployment(
         deploymentId: string,
         _deploymentParameters: BlueprintDeployParams,
-        installWorkflowParameters: any,
+        installWorkflowParameters: Record<string, any>,
         installWorkflowOptions: WorkflowOptions
     ) {
         const deploymentActions = new DeploymentActions(toolbox);
@@ -77,6 +77,7 @@ const DeployBlueprintModal: FunctionComponent<DeployBlueprintModalProps> = ({ to
             i18nHeaderKey="widgets.common.deployments.deployModal.header"
             showDeploymentNameInput
             showDeployButton
+            showInstallOptions
             deployValidationMessage={t('steps.deploy.validatingData')}
             deploySteps={[
                 { message: t('steps.deploy.deployingBlueprint'), executeStep: deployBlueprint },

--- a/widgets/common/src/DeploymentActions.ts
+++ b/widgets/common/src/DeploymentActions.ts
@@ -39,7 +39,7 @@ export default class DeploymentActions {
     doExecute(
         deploymentId: string,
         workflowId: string,
-        workflowParameters: any = {},
+        workflowParameters: Record<string, any> = {},
         { force, dryRun, queue, scheduledTime }: WorkflowOptions = {
             force: false,
             dryRun: false,

--- a/widgets/common/src/ExecuteDeploymentModal.jsx
+++ b/widgets/common/src/ExecuteDeploymentModal.jsx
@@ -9,6 +9,7 @@ function getWorkflowName(workflow) {
 export default function ExecuteDeploymentModal({
     deploymentId,
     deployments,
+    hideOptions,
     onExecute,
     onHide,
     toolbox,
@@ -238,78 +239,82 @@ export default function ExecuteDeploymentModal({
 
                     {InputsUtils.getInputFields(baseWorkflowParams, handleInputChange, userWorkflowParams, errors)}
 
-                    <Form.Divider>
-                        <Header size="tiny">Actions</Header>
-                    </Form.Divider>
+                    {!hideOptions && (
+                        <>
+                            <Form.Divider>
+                                <Header size="tiny">Actions</Header>
+                            </Form.Divider>
 
-                    <Form.Field>
-                        <Form.Checkbox
-                            name="force"
-                            toggle
-                            label="Force"
-                            help='Execute the workflow even if there is an ongoing
+                            <Form.Field>
+                                <Form.Checkbox
+                                    name="force"
+                                    toggle
+                                    label="Force"
+                                    help='Execute the workflow even if there is an ongoing
                                                  execution for the given deployment.
                                                  You cannot use this option with "Queue".'
-                            checked={force}
-                            onChange={(event, field) => setForce(field.checked)}
-                        />
-                    </Form.Field>
+                                    checked={force}
+                                    onChange={(event, field) => setForce(field.checked)}
+                                />
+                            </Form.Field>
 
-                    <Form.Field>
-                        <Form.Checkbox
-                            name="dryRun"
-                            toggle
-                            label="Dry run"
-                            help='If set, no actual operations will be performed.
+                            <Form.Field>
+                                <Form.Checkbox
+                                    name="dryRun"
+                                    toggle
+                                    label="Dry run"
+                                    help='If set, no actual operations will be performed.
                                                  Executed tasks will be logged without side effects.
                                                  You cannot use this option with "Queue".'
-                            checked={dryRun}
-                            onChange={(event, field) => setDryRun(field.checked)}
-                        />
-                    </Form.Field>
+                                    checked={dryRun}
+                                    onChange={(event, field) => setDryRun(field.checked)}
+                                />
+                            </Form.Field>
 
-                    <Form.Field>
-                        <Form.Checkbox
-                            name="queue"
-                            toggle
-                            label="Queue"
-                            help='If set, executions that can`t currently run will
+                            <Form.Field>
+                                <Form.Checkbox
+                                    name="queue"
+                                    toggle
+                                    label="Queue"
+                                    help='If set, executions that can`t currently run will
                                                  be queued and run automatically when possible.
                                                  You cannot use this option with "Force" and "Dry run".'
-                            checked={queue}
-                            onChange={(event, field) => {
-                                setQueue(field.checked);
-                                clearForce();
-                                clearDryRun();
-                                clearSchedule();
-                                clearScheduleTime();
-                                clearErrors();
-                            }}
-                        />
-                    </Form.Field>
+                                    checked={queue}
+                                    onChange={(event, field) => {
+                                        setQueue(field.checked);
+                                        clearForce();
+                                        clearDryRun();
+                                        clearSchedule();
+                                        clearScheduleTime();
+                                        clearErrors();
+                                    }}
+                                />
+                            </Form.Field>
 
-                    <Form.Field error={!!errors.scheduledTime}>
-                        <Form.Checkbox
-                            name="schedule"
-                            toggle
-                            label="Schedule"
-                            help='If set, workflow will be executed at specific time (local timezone)
+                            <Form.Field error={!!errors.scheduledTime}>
+                                <Form.Checkbox
+                                    name="schedule"
+                                    toggle
+                                    label="Schedule"
+                                    help='If set, workflow will be executed at specific time (local timezone)
                                                  provided below. You cannot use this option with "Queue".'
-                            checked={schedule}
-                            onChange={(event, field) => setSchedule(field.checked)}
-                        />
-                        {schedule && <Divider hidden />}
-                        {schedule && (
-                            <DateInput
-                                name="scheduledTime"
-                                value={scheduledTime}
-                                defaultValue=""
-                                minDate={moment()}
-                                maxDate={moment().add(1, 'Y')}
-                                onChange={(event, field) => setScheduledTime(field.value)}
-                            />
-                        )}
-                    </Form.Field>
+                                    checked={schedule}
+                                    onChange={(event, field) => setSchedule(field.checked)}
+                                />
+                                {schedule && <Divider hidden />}
+                                {schedule && (
+                                    <DateInput
+                                        name="scheduledTime"
+                                        value={scheduledTime}
+                                        defaultValue=""
+                                        minDate={moment()}
+                                        maxDate={moment().add(1, 'Y')}
+                                        onChange={(event, field) => setScheduledTime(field.value)}
+                                    />
+                                )}
+                            </Form.Field>
+                        </>
+                    )}
                 </Form>
             </Modal.Content>
 
@@ -342,11 +347,13 @@ ExecuteDeploymentModal.propTypes = {
         PropTypes.string
     ]).isRequired,
     onExecute: PropTypes.func,
-    onHide: PropTypes.func.isRequired
+    onHide: PropTypes.func.isRequired,
+    hideOptions: PropTypes.bool
 };
 ExecuteDeploymentModal.defaultProps = {
     deploymentId: '',
     deployments: [],
+    hideOptions: false,
     onExecute: _.noop
 };
 

--- a/widgets/common/src/GenericDeployModal.jsx
+++ b/widgets/common/src/GenericDeployModal.jsx
@@ -255,7 +255,15 @@ class GenericDeployModal extends React.Component {
             ExecuteDeploymentModal,
             Labels: { Input: LabelsInput }
         } = Stage.Common;
-        const { onHide, open, toolbox, i18nHeaderKey, showDeploymentNameInput, showDeployButton } = this.props;
+        const {
+            onHide,
+            open,
+            toolbox,
+            i18nHeaderKey,
+            showInstallOptions,
+            showDeploymentNameInput,
+            showDeployButton
+        } = this.props;
         const {
             blueprint,
             deploymentInputs,
@@ -404,6 +412,7 @@ class GenericDeployModal extends React.Component {
                         onExecute={this.onDeployAndInstall}
                         onHide={this.hideInstallModal}
                         toolbox={toolbox}
+                        hideOptions={!showInstallOptions}
                     />
                 </Modal.Content>
 
@@ -480,6 +489,11 @@ GenericDeployModal.propTypes = {
     showDeployButton: PropTypes.bool,
 
     /**
+     * Whether to show install workflow options (force, dry run, queue, schedule)
+     */
+    showInstallOptions: PropTypes.bool,
+
+    /**
      * Steps to be executed on 'Deploy' button press, needs to be specified only when `showDeployButton` is enabled
      */
     deploySteps: StepsPropType,
@@ -506,6 +520,7 @@ GenericDeployModal.defaultProps = {
     onHide: _.noop,
     showDeploymentNameInput: false,
     showDeployButton: false,
+    showInstallOptions: false,
     deploySteps: null,
     deployValidationMessage: null
 };

--- a/widgets/common/src/deploymentsView/header/DeployOnModal.tsx
+++ b/widgets/common/src/deploymentsView/header/DeployOnModal.tsx
@@ -5,6 +5,7 @@ import { DeploymentsResponse } from '../types';
 import { BlueprintDeployParams } from '../../BlueprintActions';
 import { i18nPrefix } from '../common';
 import ExecutionGroupsActions from '../../ExecutionGroupsActions';
+import DeploymentActions from '../../DeploymentActions';
 
 interface DeployOnModalProps {
     filterRules: FilterRule[];
@@ -31,19 +32,26 @@ const DeployOnModal: FunctionComponent<DeployOnModalProps> = ({ filterRules, too
                 {
                     blueprint_id: deploymentParameters.blueprintId,
                     default_inputs: deploymentParameters.inputs,
-                    labels: deploymentParameters.labels,
+                    labels: DeploymentActions.toManagerLabels(deploymentParameters.labels),
                     visibility: deploymentParameters.visibility,
                     new_deployments: environments.map(environmentId => ({
                         id: `${environmentId}-${deploymentParameters.blueprintId}-{uuid}`,
-                        labels: [{ 'csys-obj-parent': environmentId }]
+                        labels: [{ 'csys-obj-parent': environmentId }],
+                        site_name: deploymentParameters.siteName,
+                        runtime_only_evaluation: deploymentParameters.runtimeOnlyEvaluation,
+                        skip_plugins_validation: deploymentParameters.skipPluginsValidation
                     }))
                 }
             )
             .then((response: { id: string }) => response.id);
     }
 
-    function startInstallWorkflow(deploymentGroupId: string) {
-        return new ExecutionGroupsActions(toolbox).doStart('install', deploymentGroupId);
+    function startInstallWorkflow(
+        deploymentGroupId: string,
+        _deploymentParameters: BlueprintDeployParams,
+        installWorkflowParameters: Record<string, any>
+    ) {
+        return new ExecutionGroupsActions(toolbox).doStart('install', deploymentGroupId, installWorkflowParameters);
     }
 
     function finalize() {


### PR DESCRIPTION
* Removed workflow options from workflow execution modal
* Fixed labels handling
* Added `site_name`, `runtime_only_evaluation` and `skip_plugins_validation` deployment properties support