### PR TITLE
RD-2252 - The getting started progress bar should be always visible

### DIFF
--- a/app/components/GettingStartedModal/ModalContent.tsx
+++ b/app/components/GettingStartedModal/ModalContent.tsx
@@ -51,7 +51,7 @@ const ModalContent = ({
     const secretsStepData = secretsStepsData[secretsStepSchema?.name];
     const statusStepActive = stepName === StepName.Status;
     return (
-        <Modal.Content style={{ minHeight: 220 }}>
+        <Modal.Content style={{ minHeight: 220, display: 'flex', flexDirection: 'column' }}>
             {!_.isEmpty(stepErrors) && (
                 <>
                     <ErrorMessage error={stepErrors} onDismiss={onStepErrorsDismiss} />

--- a/app/components/GettingStartedModal/steps/SummaryStep/SummaryStep.tsx
+++ b/app/components/GettingStartedModal/steps/SummaryStep/SummaryStep.tsx
@@ -95,7 +95,10 @@ const SummaryStep = ({
         installationErrors.length > 0;
 
     return (
-        <UnsafelyTypedForm style={{ minHeight: 150 }} loading={tasksLoading}>
+        <UnsafelyTypedForm
+            style={{ minHeight: 150, flex: 1, display: 'flex', flexDirection: 'column' }}
+            loading={tasksLoading}
+        >
             {errorDetected && (
                 <Message color="red">
                     <List relaxed>
@@ -115,7 +118,7 @@ const SummaryStep = ({
                 blueprintsInstallationTasks.tasks) && (
                 <>
                     <Header as="h4">{i18n.t('gettingStartedModal.summary.taskListTitle')}</Header>
-                    <List ordered relaxed>
+                    <List ordered relaxed style={{ margin: 0, flex: 1, overflow: 'auto' }}>
                         <PluginsInstallationTasks tasks={pluginsInstallationTasks.tasks} />
                         <SecretsInstallationTasks tasks={secretsInstallationTasks.tasks} />
                         <BlueprintsInstallationTasks tasks={blueprintsInstallationTasks.tasks} />


### PR DESCRIPTION
The main goal of this PR is to make the installation/upload progress bar always visible - even the list of items is higher than modal height.

Ticket: https://cloudifysource.atlassian.net/browse/RD-2252

Build (system tests passed): https://jenkins.cloudify.co/view/UI/job/Stage-UI-System-Test/575/

Scrollable 'Task List' list:
![image](https://user-images.githubusercontent.com/78533022/117666827-8e97d480-b1a4-11eb-95a9-525e640d49bf.png)
