### PR TITLE
RD-2078 Deploy On development continued

### DIFF
--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -699,7 +699,8 @@
                                 "fetchingEnvironments": "2/4: Fetching environments list...",
                                 "creatingDeployments": "3/4: Creating deployments...",
                                 "installingDeployments": "4/4: Installing deployments..."
-                            }
+                            },
+                            "executionStarted": "Group execution started"
                         }
                     },
                     "runWorkflow": {
@@ -730,7 +731,14 @@
                         }
                     },
                     "common": {
-                        "goToExecutionsPageButton": "Go to Executions page"
+                        "executionStartedModal": {
+                            "header": "Group execution started",
+                            "message": "Click on 'Go to Executions page' button to track the progress",
+                            "buttons": {
+                                "goToExecutionsPage": "Go to Executions page",
+                                "close": "Close"
+                            }
+                        }
                     }
                 }
             },

--- a/app/utils/stageUtils.ts
+++ b/app/utils/stageUtils.ts
@@ -187,7 +187,7 @@ export default class StageUtils {
     }
 
     static getT(keyPrefix: string) {
-        return (keySuffix: string, params: Record<string, any>) => i18n.t(`${keyPrefix}.${keySuffix}`, params);
+        return (keySuffix: string, params?: Record<string, any>) => i18n.t(`${keyPrefix}.${keySuffix}`, params);
     }
 
     static isEmptyWidgetData = isEmptyWidgetData;

--- a/test/cypress/integration/widgets/deployments_view_spec.ts
+++ b/test/cypress/integration/widgets/deployments_view_spec.ts
@@ -771,8 +771,9 @@ describe('Deployments View widget', () => {
                     .its('response.body.deployment_ids')
                     .should('include.members', [deploymentName, secondDeploymentWithExampleSiteName]);
                 cy.wait('@startExecutionGroup').its('response.body.workflow_id').should('be.equal', 'restart');
+            });
 
-                cy.contains('Workflow has been started.');
+            cy.contains('.modal', 'Group execution started').within(() => {
                 cy.contains('Go to Executions page');
                 cy.contains('Close').click();
             });

--- a/widgets/common/src/DeployBlueprintModal.tsx
+++ b/widgets/common/src/DeployBlueprintModal.tsx
@@ -78,6 +78,7 @@ const DeployBlueprintModal: FunctionComponent<DeployBlueprintModalProps> = ({ to
             showDeploymentNameInput
             showDeployButton
             showInstallOptions
+            showSitesInput
             deployValidationMessage={t('steps.deploy.validatingData')}
             deploySteps={[
                 { message: t('steps.deploy.deployingBlueprint'), executeStep: deployBlueprint },

--- a/widgets/common/src/GenericDeployModal.jsx
+++ b/widgets/common/src/GenericDeployModal.jsx
@@ -262,7 +262,8 @@ class GenericDeployModal extends React.Component {
             i18nHeaderKey,
             showInstallOptions,
             showDeploymentNameInput,
-            showDeployButton
+            showDeployButton,
+            showSitesInput
         } = this.props;
         const {
             blueprint,
@@ -356,20 +357,22 @@ class GenericDeployModal extends React.Component {
 
                         <Form.Divider>{t('sections.deploymentMetadata')}</Form.Divider>
 
-                        <Form.Field
-                            error={errors.siteName}
-                            label={t('inputs.siteName.label')}
-                            help={t('inputs.siteName.help')}
-                        >
-                            <DynamicDropdown
-                                value={siteName}
-                                onChange={value => this.setState({ siteName: value })}
-                                name="siteName"
-                                fetchUrl="/sites?_include=name"
-                                valueProp="name"
-                                toolbox={toolbox}
-                            />
-                        </Form.Field>
+                        {showSitesInput && (
+                            <Form.Field
+                                error={errors.siteName}
+                                label={t('inputs.siteName.label')}
+                                help={t('inputs.siteName.help')}
+                            >
+                                <DynamicDropdown
+                                    value={siteName}
+                                    onChange={value => this.setState({ siteName: value })}
+                                    name="siteName"
+                                    fetchUrl="/sites?_include=name"
+                                    valueProp="name"
+                                    toolbox={toolbox}
+                                />
+                            </Form.Field>
+                        )}
 
                         <Form.Field
                             label={i18n.t('widgets.common.labels.input.label')}
@@ -494,6 +497,11 @@ GenericDeployModal.propTypes = {
     showInstallOptions: PropTypes.bool,
 
     /**
+     * Whether to show site selection input
+     */
+    showSitesInput: PropTypes.bool,
+
+    /**
      * Steps to be executed on 'Deploy' button press, needs to be specified only when `showDeployButton` is enabled
      */
     deploySteps: StepsPropType,
@@ -512,7 +520,7 @@ GenericDeployModal.propTypes = {
     /**
      * Message to be displayed during inputs validation, before steps defined by `deployAndInstallSteps` are executed
      */
-    deployAndInstallValidationMessage: PropTypes.string.isRequired
+    deployAndInstallValidationMessage: PropTypes.string
 };
 
 GenericDeployModal.defaultProps = {
@@ -521,8 +529,10 @@ GenericDeployModal.defaultProps = {
     showDeploymentNameInput: false,
     showDeployButton: false,
     showInstallOptions: false,
+    showSitesInput: false,
     deploySteps: null,
-    deployValidationMessage: null
+    deployValidationMessage: null,
+    deployAndInstallValidationMessage: null
 };
 
 export default GenericDeployModal;

--- a/widgets/common/src/deploymentsView/header/DeployOnModal.tsx
+++ b/widgets/common/src/deploymentsView/header/DeployOnModal.tsx
@@ -9,6 +9,7 @@ import ExecutionGroupsActions from '../../ExecutionGroupsActions';
 import DeploymentGroupsActions from '../../DeploymentGroupsActions';
 import SearchActions from '../../SearchActions';
 import DeploymentActions from '../../DeploymentActions';
+import ExecutionStartedModal from './ExecutionStartedModal';
 
 interface DeployOnModalProps {
     filterRules: FilterRule[];
@@ -16,9 +17,11 @@ interface DeployOnModalProps {
     onHide: () => void;
 }
 
-const headerT = (suffix: string) => Stage.i18n.t(`${i18nPrefix}.header.${suffix}`);
+const t = Stage.Utils.getT(`${i18nPrefix}.header`);
 
 const DeployOnModal: FunctionComponent<DeployOnModalProps> = ({ filterRules, toolbox, onHide }) => {
+    const [executionStarted, setExecutionStarted] = Stage.Hooks.useBoolean();
+
     function fetchEnvironments() {
         return new SearchActions(toolbox)
             .doListAllDeployments(filterRules, { _include: 'id' })
@@ -34,9 +37,9 @@ const DeployOnModal: FunctionComponent<DeployOnModalProps> = ({ filterRules, too
                 labels: DeploymentActions.toManagerLabels(deploymentParameters.labels),
                 visibility: deploymentParameters.visibility,
                 new_deployments: environments.map(environmentId => ({
-                    id: `${environmentId}-${deploymentParameters.blueprintId}-{uuid}`,
+                    id: '{uuid}',
+                    display_name: `${deploymentParameters.blueprintId}-${Stage.Utils.uuid()}`,
                     labels: [{ 'csys-obj-parent': environmentId }],
-                    site_name: deploymentParameters.siteName,
                     runtime_only_evaluation: deploymentParameters.runtimeOnlyEvaluation,
                     skip_plugins_validation: deploymentParameters.skipPluginsValidation
                 }))
@@ -52,32 +55,34 @@ const DeployOnModal: FunctionComponent<DeployOnModalProps> = ({ filterRules, too
         return new ExecutionGroupsActions(toolbox).doStart(deploymentGroupId, 'install', installWorkflowParameters);
     }
 
-    function finalize() {
+    function cancel() {
         toolbox.getEventBus().trigger('deployments:refresh').trigger('executions:refresh');
         onHide();
     }
 
-    return (
+    return executionStarted ? (
+        <ExecutionStartedModal toolbox={toolbox} onCancel={cancel} />
+    ) : (
         <GenericDeployModal
             toolbox={toolbox}
             open
             onHide={onHide}
             i18nHeaderKey={`${i18nPrefix}.header.bulkActions.deployOn.modal.header`}
-            deployValidationMessage={headerT('bulkActions.deployOn.modal.steps.validatingData')}
+            deployValidationMessage={t('bulkActions.deployOn.modal.steps.validatingData')}
             deployAndInstallSteps={[
                 {
-                    message: headerT('bulkActions.deployOn.modal.steps.fetchingEnvironments'),
+                    message: t('bulkActions.deployOn.modal.steps.fetchingEnvironments'),
                     executeStep: fetchEnvironments
                 },
                 {
-                    message: headerT('bulkActions.deployOn.modal.steps.creatingDeployments'),
+                    message: t('bulkActions.deployOn.modal.steps.creatingDeployments'),
                     executeStep: createDeploymentGroup
                 },
                 {
-                    message: headerT('bulkActions.deployOn.modal.steps.installingDeployments'),
+                    message: t('bulkActions.deployOn.modal.steps.installingDeployments'),
                     executeStep: startInstallWorkflow
                 },
-                { executeStep: finalize }
+                { executeStep: setExecutionStarted }
             ]}
         />
     );

--- a/widgets/common/src/deploymentsView/header/ExecutionStartedModal.tsx
+++ b/widgets/common/src/deploymentsView/header/ExecutionStartedModal.tsx
@@ -1,0 +1,29 @@
+import type { FunctionComponent } from 'react';
+import { i18nPrefix } from '../common';
+import GoToExecutionsPageButton from './GoToExecutionsPageButton';
+
+interface ExecutionStartedModalProps {
+    toolbox: Stage.Types.Toolbox;
+    onCancel: () => void;
+}
+
+const t = Stage.Utils.getT(`${i18nPrefix}.header.bulkActions.common.executionStartedModal`);
+
+const ExecutionStartedModal: FunctionComponent<ExecutionStartedModalProps> = ({ toolbox, onCancel }) => {
+    const { CancelButton, Icon, Modal } = Stage.Basic;
+
+    return (
+        <Modal open>
+            <Modal.Header>
+                <Icon name="rocket" /> {t('header')}
+            </Modal.Header>
+            <Modal.Content>{t('message')}</Modal.Content>
+            <Modal.Actions>
+                <CancelButton onClick={onCancel} content={t('buttons.close')} />
+                <GoToExecutionsPageButton toolbox={toolbox} />
+            </Modal.Actions>
+        </Modal>
+    );
+};
+
+export default ExecutionStartedModal;

--- a/widgets/common/src/deploymentsView/header/GoToExecutionsPageButton.tsx
+++ b/widgets/common/src/deploymentsView/header/GoToExecutionsPageButton.tsx
@@ -12,7 +12,9 @@ const GoToExecutionsPageButton: FunctionComponent<GoToExecutionsPageButtonProps>
         <ApproveButton
             onClick={() => toolbox.goToPage('executions', null)}
             color="green"
-            content={Stage.i18n.t(`${i18nPrefix}.header.bulkActions.common.goToExecutionsPageButton`)}
+            content={Stage.i18n.t(
+                `${i18nPrefix}.header.bulkActions.common.executionStartedModal.buttons.goToExecutionsPage`
+            )}
         />
     );
 };

--- a/widgets/common/src/deploymentsView/header/RunWorkflowModal.tsx
+++ b/widgets/common/src/deploymentsView/header/RunWorkflowModal.tsx
@@ -2,8 +2,8 @@ import type { FunctionComponent } from 'react';
 import { useEffect, useMemo } from 'react';
 import { i18nPrefix } from '../common';
 import { FilterRule } from '../../filters/types';
-import GoToExecutionsPageButton from './GoToExecutionsPageButton';
 import { getGroupIdForBatchAction } from './common';
+import ExecutionStartedModal from './ExecutionStartedModal';
 
 interface RunWorkflowModalProps {
     filterRules: FilterRule[];
@@ -18,8 +18,8 @@ type Workflow = {
 };
 type WorkflowsResponse = Stage.Types.PaginatedResponse<Workflow>;
 
-const modalT = (key: string, params?: Record<string, string | undefined>) =>
-    Stage.i18n.t(`${i18nPrefix}.header.bulkActions.runWorkflow.modal.${key}`, params);
+const modalT = Stage.Utils.getT(`${i18nPrefix}.header.bulkActions.runWorkflow.modal`);
+
 const getWorkflowsOptions = (workflows: Workflow[]) => {
     return _.chain(workflows)
         .sortBy('name')
@@ -95,7 +95,9 @@ const RunWorkflowModal: FunctionComponent<RunWorkflowModalProps> = ({ filterRule
         turnOffLoading();
     }
 
-    return (
+    return executionGroupStarted ? (
+        <ExecutionStartedModal toolbox={toolbox} onCancel={onHide} />
+    ) : (
         <Modal open onClose={onHide}>
             <Modal.Header>
                 <Icon name="cogs" /> {modalT('header')}
@@ -104,45 +106,30 @@ const RunWorkflowModal: FunctionComponent<RunWorkflowModalProps> = ({ filterRule
             <Modal.Content>
                 <UnsafelyTypedForm errors={errors} onErrorsDismiss={clearErrors}>
                     {loadingMessage && <LoadingOverlay message={loadingMessage} />}
-                    {executionGroupStarted ? (
-                        <Message positive>{modalT('messages.executionGroupStarted')}</Message>
-                    ) : (
-                        <>
-                            <UnsafelyTypedFormField
-                                label={modalT('inputs.workflowId.label')}
-                                help={modalT('inputs.workflowId.help')}
-                            >
-                                <Dropdown
-                                    search
-                                    selection
-                                    options={workflowsOptions}
-                                    onChange={(_event, { value }) => setWorkflowId(value as string)}
-                                    value={workflowId}
-                                />
-                            </UnsafelyTypedFormField>
-                            <Message>{modalT('messages.limitations')}</Message>
-                        </>
-                    )}
+                    <UnsafelyTypedFormField
+                        label={modalT('inputs.workflowId.label')}
+                        help={modalT('inputs.workflowId.help')}
+                    >
+                        <Dropdown
+                            search
+                            selection
+                            options={workflowsOptions}
+                            onChange={(_event, { value }) => setWorkflowId(value as string)}
+                            value={workflowId}
+                        />
+                    </UnsafelyTypedFormField>
+                    <Message>{modalT('messages.limitations')}</Message>
                 </UnsafelyTypedForm>
             </Modal.Content>
 
             <Modal.Actions>
-                {executionGroupStarted ? (
-                    <>
-                        <CancelButton onClick={onHide} content={modalT('buttons.close')} />
-                        <GoToExecutionsPageButton toolbox={toolbox} />
-                    </>
-                ) : (
-                    <>
-                        <CancelButton onClick={onHide} />
-                        <ApproveButton
-                            onClick={runWorkflow}
-                            color="green"
-                            content={modalT('buttons.run')}
-                            disabled={!workflowId}
-                        />
-                    </>
-                )}
+                <CancelButton onClick={onHide} />
+                <ApproveButton
+                    onClick={runWorkflow}
+                    color="green"
+                    content={modalT('buttons.run')}
+                    disabled={!workflowId}
+                />
             </Modal.Actions>
         </Modal>
     );


### PR DESCRIPTION
This is hopefully the last portion of changes for Deploy On action:

- Created common 'execution group started' modal, reused by both Deploy On and Run Workflow actions
- Fix for `Stage.Utils.getT` adding optional flag to message parameters
- Removed sites input from Deploy On modal (RD-2277)
- Aligned values for `id` and `display_name` properties for newly created deployments (RD-2287)

System test for Deploy On will be part of the upcoming PR.

I run deployments view spec locally and I'm not planning full system tests execution at this time.