### PR TITLE
WDR-19 - Fix deployment name surpassing the Remove Deployment modal

### DIFF
--- a/widgets/common/src/RemoveDeploymentModal.tsx
+++ b/widgets/common/src/RemoveDeploymentModal.tsx
@@ -61,7 +61,8 @@ const RemoveDeploymentModal: FunctionComponent<RemoveDeploymentModalProps> = ({
     return (
         <Confirm
             content={
-                <div className="content">
+                // TODO(RD-2255): Once generic fix for long names is ready, the `style` prop should be removed
+                <div className="content" style={{ wordBreak: 'break-word' }}>
                     <ErrorMessage autoHide error={errors} onDismiss={clearErrors} />
                     {content}
                 </div>


### PR DESCRIPTION
Added proper style to RemoveDeploymentModal to display long deployment names inside the modal content. 

![image](https://user-images.githubusercontent.com/5202105/118125963-f3973880-b3f7-11eb-9118-2be79d367a67.png)

This is more like general issue in the whole application, so there's RD-2255 to handle it properly in the future.
