### PR TITLE
RD-1527 Tests for Deployments Map marker clustering

### DIFF
--- a/test/cypress/integration/widgets/deployments_view_spec.ts
+++ b/test/cypress/integration/widgets/deployments_view_spec.ts
@@ -736,6 +736,33 @@ describe('Deployments View widget', () => {
                         });
                 });
         });
+
+        it('should cluster markers and always show the selected deployment marker outside the cluster', () => {
+            useDeploymentsViewWidget({
+                configurationOverrides: { mapOpenByDefault: true }
+            });
+
+            const zoomOut = () => cy.get('[aria-label="Zoom out"]').click();
+            cy.getSearchInput().type(mapDeploymentsPrefix);
+
+            selectDeploymentInTableAndVerifyMapSelection(getSiteDeploymentName(siteNames.london));
+            cy.log('Check if there is a cluster');
+            getDeploymentsViewMap().within(() => {
+                zoomOut();
+                getDeploymentMarkerIcons().should('have.length', 2);
+                cy.contains('.leaflet-marker-icon', 2).click();
+                cy.log('Check that the cluster is zoomed-in into');
+                getDeploymentMarkerIcons().should('have.length', 3);
+                zoomOut();
+                getDeploymentMarkerIcons().should('have.length', 2);
+            });
+
+            selectDeploymentInTableAndVerifyMapSelection(getSiteDeploymentName(siteNames.warsaw));
+            cy.log('Check that the selected deployment is not clustered');
+            getDeploymentsViewMap().within(() => {
+                getDeploymentMarkerIcons().should('have.length', 3);
+            });
+        });
     });
 
     describe('bulk actions', () => {

--- a/test/cypress/integration/widgets/deployments_view_spec.ts
+++ b/test/cypress/integration/widgets/deployments_view_spec.ts
@@ -594,6 +594,17 @@ describe('Deployments View widget', () => {
             getDeploymentsMapTooltip().within(callback);
             getMarker().trigger('mouseout', { force: ignoreMarkerNotInView });
         };
+        function selectDeploymentInTableAndVerifyMapSelection(name: string) {
+            const getSelectedMarker = () => cy.get('path.test__map-selected-marker');
+
+            getDeploymentsViewTable().contains(name).click();
+            getDeploymentsViewMap().within(() => {
+                // NOTE: need to `force` events, since the selection circle is covered by a marker image
+                // and Cypress would not interact with the circle underneath
+                withinMarkerTooltip(getSelectedMarker, () => cy.contains(name), { ignoreMarkerNotInView: true });
+            });
+        }
+        const getDeploymentMarkerIcons = () => cy.get('.leaflet-marker-icon');
 
         it('should be toggled upon clicking the button', () => {
             useDeploymentsViewWidget();
@@ -606,7 +617,7 @@ describe('Deployments View widget', () => {
                 .should('have.attr', 'title', 'Close map');
             cy.getSearchInput().type(siteNames.london);
             getDeploymentsViewMap().within(() => {
-                cy.get('.leaflet-marker-icon').should('have.length', 1);
+                getDeploymentMarkerIcons().should('have.length', 1);
                 withinMarkerTooltip(
                     () => getMarkerByImageSuffix(MarkerImageSuffix.Red),
                     () => cy.contains(getSiteDeploymentName(siteNames.london))
@@ -631,7 +642,7 @@ describe('Deployments View widget', () => {
             });
 
             getDeploymentsViewMap().within(() => {
-                cy.get('.leaflet-marker-icon').should('be.visible').and('have.length', 3);
+                getDeploymentMarkerIcons().should('be.visible').and('have.length', 3);
 
                 const getTooltipSubenvironments = () => cy.get('i.icon.object.group').parent();
                 const getTooltipSubservices = () => cy.get('i.icon.cube').parent();
@@ -687,18 +698,7 @@ describe('Deployments View widget', () => {
                 configurationOverrides: { mapOpenByDefault: true }
             });
 
-            const getSelectedMarker = () => cy.get('path.test__map-selected-marker');
-
             cy.getSearchInput().type(mapDeploymentsPrefix);
-
-            function selectDeploymentInTableAndVerifyMapSelection(name: string) {
-                getDeploymentsViewTable().contains(name).click();
-                getDeploymentsViewMap().within(() => {
-                    // NOTE: need to `force` events, since the selection circle is covered by a marker image
-                    // and Cypress would not interact with the circle underneath
-                    withinMarkerTooltip(getSelectedMarker, () => cy.contains(name), { ignoreMarkerNotInView: true });
-                });
-            }
 
             selectDeploymentInTableAndVerifyMapSelection(getSiteDeploymentName(siteNames.london));
 


### PR DESCRIPTION
This PR builds on top of #1369 and adds a system test that verifies some of the functionalities implemented in #1369:
1. Nearby markers are clustered
2. Clicking the cluster zooms on and breaks the cluster
3. The currently selected deployment is not clustered

Functionalities not tested:
1. Cluster marker icon color (the fact that it's based on the worst deployment state)
    The problem is that there are many cases to test here (2 deployments, 3 states = 6 possible states) and each requires a different fixture/dynamically changing the deployment status and then refreshing the page.

    It would be better tested by unit tests/integration tests for the component IMO which would not have the overhead of refreshing the whole page for each state.

## System tests

https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/601/pipeline

Ran 2021-05-14 17:24 CEST

Deployments View tests passed for me locally aside from one for bulk actions which I am not sure the state of:
![image](https://user-images.githubusercontent.com/889383/118293631-20bc1780-b4da-11eb-86b3-a2766914b1d1.png)
