### PR TITLE
WDR-21 Add polling to drill-down buttons

### DIFF
--- a/.size-limit
+++ b/.size-limit
@@ -20,7 +20,7 @@
     },
     {
         "name": "Application package",
-        "limit": "13.39 MB",
+        "limit": "13.45 MB",
         "gzip": false,
         "running": false,
         "path": ["dist", "!dist/**/*.gz"]

--- a/app/utils/StageAPI.ts
+++ b/app/utils/StageAPI.ts
@@ -23,7 +23,7 @@ type StageHooks = typeof StageHooks;
 /** @see https://docs.cloudify.co/developer/writing_widgets/widget-apis/#toolbox-object */
 interface StageToolbox {
     drillDown(
-        widget: StageWidget,
+        widget: StageWidget<unknown>,
         defaultTemplate: string,
         drilldownContext: Record<string, any>,
         drilldownPageName?: any

--- a/test/cypress/integration/widgets/deployments_view_spec.ts
+++ b/test/cypress/integration/widgets/deployments_view_spec.ts
@@ -529,6 +529,25 @@ describe('Deployments View widget', () => {
             getDeploymentsViewTable().within(() => cy.contains(tempDeploymentId).should('not.exist'));
             getBreadcrumbs().contains(parentDeploymentId);
         });
+
+        it('should refresh the drill-down buttons on an interval', () => {
+            useDeploymentsViewWidget({ configurationOverrides: { customPollingTime: 1 } });
+
+            cy.getSearchInput().type(deploymentName);
+
+            getDeploymentsViewDetailsPane().within(() => {
+                getSubservicesButton().contains('0');
+
+                cy.interceptSp('GET', `${deploymentName}?all_sub_deployments=false`, req =>
+                    req.reply(res => {
+                        res.body.sub_services_count = 50;
+                    })
+                ).as('deploymentDetails');
+                cy.wait('@deploymentDetails');
+
+                getSubservicesButton().contains('50');
+            });
+        });
     });
 
     it('should display an error message when using the drilled-down widget on a top-level page', () => {

--- a/widgets/common/src/deploymentsView/configuration.ts
+++ b/widgets/common/src/deploymentsView/configuration.ts
@@ -2,7 +2,7 @@ import { i18nPrefix } from './common';
 import { deploymentsViewColumnDefinitions, DeploymentsViewColumnId, deploymentsViewColumnIds } from './table';
 
 export interface SharedDeploymentsViewWidgetConfiguration {
-    /** In milliseconds */
+    /** In seconds */
     customPollingTime: number;
     mapOpenByDefault: boolean;
     mapHeight: number;

--- a/widgets/common/src/deploymentsView/detailsPane/DrilldownButtons.tsx
+++ b/widgets/common/src/deploymentsView/detailsPane/DrilldownButtons.tsx
@@ -14,7 +14,8 @@ export interface DrilldownButtonsProps {
 }
 
 const ButtonsContainer = styled.div`
-    margin: 0 1em;
+    margin-right: 1rem;
+    margin-bottom: 1rem;
     position: relative;
 `;
 

--- a/widgets/common/src/deploymentsView/detailsPane/DrilldownButtons.tsx
+++ b/widgets/common/src/deploymentsView/detailsPane/DrilldownButtons.tsx
@@ -10,19 +10,27 @@ export interface DrilldownButtonsProps {
     deploymentId: string;
     drillDown: (templateName: string, drilldownContext: Record<string, any>, drilldownPageName: string) => void;
     toolbox: Stage.Types.Toolbox;
+    refetchInterval: number;
 }
 
 const ButtonsContainer = styled.div`
     margin: 0 1em;
+    position: relative;
 `;
 
 const i18nDrillDownButtonsPrefix = `${i18nDrillDownPrefix}.buttons`;
 const getDeploymentUrl = (id: string) => `/deployments/${id}?all_sub_deployments=false`;
 
-const DrilldownButtons: FunctionComponent<DrilldownButtonsProps> = ({ drillDown, deploymentId, toolbox }) => {
+const DrilldownButtons: FunctionComponent<DrilldownButtonsProps> = ({
+    drillDown,
+    deploymentId,
+    toolbox,
+    refetchInterval
+}) => {
     const deploymentDetailsResult = useQuery(
         getDeploymentUrl(deploymentId),
-        ({ queryKey: url }): Promise<Deployment> => toolbox.getManager().doGet(url)
+        ({ queryKey: url }): Promise<Deployment> => toolbox.getManager().doGet(url),
+        { refetchInterval }
     );
 
     if (deploymentDetailsResult.isIdle || deploymentDetailsResult.isError) {
@@ -37,9 +45,13 @@ const DrilldownButtons: FunctionComponent<DrilldownButtonsProps> = ({ drillDown,
     }
 
     const subdeploymentResults = getSubdeploymentResults(deploymentDetailsResult);
+    const { LoadingOverlay } = Stage.Basic;
 
     return (
         <ButtonsContainer>
+            {/* NOTE: Show a spinner only when refetching. During the initial fetch there are spinners inside the buttons. */}
+            {deploymentDetailsResult.isFetching && !deploymentDetailsResult.isLoading && <LoadingOverlay />}
+
             <DrilldownButton
                 type="environments"
                 drillDown={drillDown}

--- a/widgets/common/src/deploymentsView/detailsPane/header.tsx
+++ b/widgets/common/src/deploymentsView/detailsPane/header.tsx
@@ -31,7 +31,9 @@ const DetailsPaneHeader: FunctionComponent<DetailsPaneHeaderProps> = ({ deployme
 
     return (
         <div className="detailsPaneHeader">
-            <Header>{deploymentName}</Header>
+            <div style={{ marginRight: '1rem', marginBottom: '1rem' }}>
+                <Header>{deploymentName}</Header>
+            </div>
             {drilldownButtons}
             <Widget
                 widget={deploymentActionButtonsWidgetDescription}

--- a/widgets/common/src/deploymentsView/detailsPane/index.tsx
+++ b/widgets/common/src/deploymentsView/detailsPane/index.tsx
@@ -4,6 +4,7 @@ import type { Deployment } from '../types';
 import DrilldownButtons, { DrilldownButtonsProps } from './DrilldownButtons';
 import DetailsPaneHeader from './header';
 import DetailsPaneWidgets from './widgets';
+import type { SharedDeploymentsViewWidgetConfiguration } from '../configuration';
 
 export interface DetailsPaneProps {
     /**
@@ -16,7 +17,7 @@ export interface DetailsPaneProps {
      */
     deployment: Deployment | undefined;
     toolbox: Stage.Types.Toolbox;
-    widget: Stage.Types.Widget<any>;
+    widget: Stage.Types.Widget<SharedDeploymentsViewWidgetConfiguration>;
 }
 
 const DetailsPane: FunctionComponent<DetailsPaneProps> = ({ deployment, widget, toolbox }) => {
@@ -46,7 +47,12 @@ const DetailsPane: FunctionComponent<DetailsPaneProps> = ({ deployment, widget, 
             <DetailsPaneHeader
                 deploymentName={deployment.id}
                 drilldownButtons={
-                    <DrilldownButtons deploymentId={deployment.id} drillDown={drillDown} toolbox={toolbox} />
+                    <DrilldownButtons
+                        deploymentId={deployment.id}
+                        drillDown={drillDown}
+                        toolbox={toolbox}
+                        refetchInterval={widget.configuration.customPollingTime * 1000}
+                    />
                 }
             />
             <DetailsPaneWidgets />


### PR DESCRIPTION
The PR adds polling (`refreshInterval`) to drill-down buttons in the Deployments View widget. Fixes https://cloudifysource.atlassian.net/browse/WDR-21

I have also taken the chance to improve the margins in the details pane's header.

## Video

https://user-images.githubusercontent.com/889383/118489841-96fc8c00-b71d-11eb-9089-b2444aa1fa7d.mp4

Notice that there's a loading overlay for the drill-down buttons now. Also, notice that there's a gap between the drill-down buttons and the deployment action buttons (they were right next to each other previously, without any vertical space).

## System tests

https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/605/pipeline

Queued 2021-05-17 14:37 CEST