### PR TITLE
WDR-31 Prevent using invalid site latitudes and longitudes

### DIFF
--- a/test/jest/widgets/common/map/site.test.ts
+++ b/test/jest/widgets/common/map/site.test.ts
@@ -1,0 +1,43 @@
+import StageUtils from 'utils/stageUtils';
+
+// @ts-expect-error Necessary global API
+Stage.Utils = StageUtils;
+
+// NOTE: use `require` to lazily load the module after `Stage.Utils` is set
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { isSiteWithPosition } = require('../../../../../widgets/common/src/map/site');
+
+describe('(Widgets common) isSiteWithPosition', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const declareValidityCheck = (expectedResult: boolean, position: [any, any]) => {
+        it(`should return ${expectedResult} for ${position}`, () => {
+            expect(
+                isSiteWithPosition({
+                    name: 'abc',
+                    latitude: position[0],
+                    longitude: position[1]
+                })
+            ).toBe(expectedResult);
+        });
+    };
+
+    const validPositions: [number, number][] = [
+        [1, 2],
+        [1.543241, -12.123123],
+        [51.5224160825326, -0.1318359375],
+        [42.322001080603, -71.12548828125],
+        [32.7734193549752, -117.04833984375]
+    ];
+    validPositions.forEach(position => declareValidityCheck(true, position));
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const invalidPositions: [any, any][] = [
+        [null, null],
+        [NaN, NaN],
+        [Infinity, Infinity],
+        [-Infinity, -Infinity],
+        ['12.33', '1.8'],
+        [true, false]
+    ];
+    invalidPositions.forEach(position => declareValidityCheck(false, position));
+});

--- a/widgets/common/src/map/site.ts
+++ b/widgets/common/src/map/site.ts
@@ -11,7 +11,7 @@ export interface SiteWithPosition {
 }
 
 export function isSiteWithPosition(site: Site): site is SiteWithPosition {
-    return typeof site.latitude === 'number' && typeof site.longitude === 'number';
+    return Number.isFinite(site.latitude) && Number.isFinite(site.longitude);
 }
 
 function pureSiteToLatLng(site: SiteWithPosition): [number, number] {


### PR DESCRIPTION
Do not allow `NaN` or `Infinity` (which are of type `number`).

This PR aims to be a hotfix, because the root cause is still unknown to me. As I have followed the source code, we do the following operations:
1. Filter out sites that have `latitude` and `longitude`
2. Match deployments with those sites

I don't see any other operation that would make latitude or longitude be a `NaN`.

If, after merging this PR, Ofer and Gabriel will not have satisfactory results in the UI, I will have to investigate using their managers, as I could not reproduce the problem locally.

## System tests

https://jenkins.cloudify.co/job/Stage-UI-System-Test/606/

Queued 2021-05-17 20:31 CEST