### PR TITLE
WDR-37 Sort deployments by created_at by default

### DIFF
--- a/widgets/common/src/deploymentsView/DeploymentsView.tsx
+++ b/widgets/common/src/deploymentsView/DeploymentsView.tsx
@@ -45,7 +45,13 @@ export const DeploymentsView: FunctionComponent<DeploymentsViewProps> = ({
 }) => {
     const manager = toolbox.getManager();
     const searchActions = new SearchActions(toolbox);
-    const [gridParams, setGridParams] = useState<Stage.Types.ManagerGridParams>();
+    const [gridParams, setGridParams] = useState<Stage.Types.ManagerGridParams>(() =>
+        Stage.Utils.mapGridParamsToManagerGridParams({
+            sortColumn: widget.configuration.sortColumn,
+            sortAscending: widget.configuration.sortAscending,
+            pageSize: widget.configuration.pageSize
+        })
+    );
     const [userFilterId, setUserFilterId] = useState<string>();
 
     const filterRulesResult = (() => {
@@ -180,7 +186,7 @@ export const DeploymentsView: FunctionComponent<DeploymentsViewProps> = ({
                     toolbox={toolbox}
                     loadingIndicatorVisible={filterRulesResult.isFetching || deploymentsResult.isFetching}
                     // eslint-disable-next-line no-underscore-dangle
-                    pageSize={gridParams?._size ?? widget.configuration.pageSize}
+                    pageSize={gridParams._size ?? widget.configuration.pageSize}
                     totalSize={deploymentsResult.data.metadata.pagination.total}
                     deployments={deploymentsResult.data.items}
                     fieldsToShow={widget.configuration.fieldsToShow}


### PR DESCRIPTION
Fix the default sorting in the Deployments View widget. It was not consumed due to using `react-query` and not widget's `fetchData` and `[params]` in the URL.

This fixes https://cloudifysource.atlassian.net/browse/WDR-37

## Screenshot

Here is the default view after opening the widget:

![image](https://user-images.githubusercontent.com/889383/118811489-5f244e80-b8ad-11eb-92a6-731dfbc19605.png)

Changing the sort order still works:

![image](https://user-images.githubusercontent.com/889383/118811553-6cd9d400-b8ad-11eb-965d-ee8d477b6ff4.png)

## System tests

https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/626/pipeline

Queued 2021-05-19 17:30 CEST