### PR TITLE
RD-2372 Prevent Execution Task Graph crashing when no deployment

### DIFF
--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -672,6 +672,9 @@
                 }
             }
         },
+        "executions": {
+            "noExecutionFound": "There are no executions that could be shown."
+        },
         "deploymentsView": {
             "name": "Deployments view",
             "description": "A complete deployments view – Deployment list, map view, and detailed deployment info",
@@ -800,11 +803,11 @@
                 "loadingSites": "Loading sites",
                 "errorLoadingSites": "Error loading sites",
                 "tooltip": {
-                  "status": {
-                    "good": "Good",
-                    "inProgress": "In progress",
-                    "requiresAttention": "Requires attention"
-                  }
+                    "status": {
+                        "good": "Good",
+                        "inProgress": "In progress",
+                        "requiresAttention": "Requires attention"
+                    }
                 }
             },
             "drillDown": {

--- a/widgets/executions/src/widget.jsx
+++ b/widgets/executions/src/widget.jsx
@@ -80,6 +80,10 @@ Stage.defineWidget({
 
         if (singleExecutionView) {
             const lastExecution = _.chain(data.items).sortBy('started_at').last().value();
+            if (!lastExecution) {
+                const { ErrorMessage } = Stage.Basic;
+                return <ErrorMessage error={Stage.i18n.t('widgets.executions.noExecutionFound')} />;
+            }
             return <SingleExecution execution={lastExecution} toolbox={toolbox} />;
         }
 


### PR DESCRIPTION
When the deployment was being deleted, the component crashed and did not recover when changing the selected deployment. Having an explicit error check prevents the widget from crashing.

## Video


https://user-images.githubusercontent.com/889383/118945695-fb099500-b955-11eb-8d42-f6611d9b6012.mp4

## System tests

https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/628/pipeline

Queued 2021-05-20 17:52 CEST