### PR TITLE
RD-2440 Fix page redirection on clicking site marker tooltip

### DIFF
--- a/test/cypress/integration/cluster_status_spec.js
+++ b/test/cypress/integration/cluster_status_spec.js
@@ -52,11 +52,7 @@ describe('Cluster Status', () => {
         cy.get('table.servicesData').within(() => {
             cy.get('button.refreshButton').should('not.have.class', 'loading');
             checkServicesStatus('Degraded', 'OK', 'OK');
-
-            cy.get('tbody tr:nth-child(1)').click();
         });
-
-        cy.location('pathname').should('be.equal', '/console/page/admin_operations');
     });
 
     it('shows correct data', () => {

--- a/test/cypress/integration/login_spec.js
+++ b/test/cypress/integration/login_spec.js
@@ -10,7 +10,7 @@ describe('Login', () => {
     it('succeeds and redirects when provided credentials are valid, license is active and redirect query parameter is specified', () => {
         cy.activate();
 
-        const redirectUrl = '/console/page/deployments';
+        const redirectUrl = '/console/page/test_page';
         cy.visit(`/console/login?redirect=${redirectUrl}`);
 
         cy.usePageMock().login();

--- a/test/cypress/integration/widgets/sites_map_spec.js
+++ b/test/cypress/integration/widgets/sites_map_spec.js
@@ -30,16 +30,8 @@ describe('Sites Map', () => {
         cy.get('.leaflet-marker-icon').should('have.length', 1).click();
         cy.get('.leaflet-popup .leaflet-popup-content')
             .should('be.visible')
-            .within(() => {
-                cy.get('h5.header').should('have.text', testSite.name).click();
-                cy.get('.deploymentState').first().click();
-            });
-        cy.location('pathname').should('be.equal', '/console/page/deployments');
-        cy.location('search').then(queryString =>
-            expect(JSON.parse(new URLSearchParams(queryString).get('c'))).to.deep.equal([
-                { context: { siteName: testSite.name } }
-            ])
-        );
+            .find('h5.header')
+            .should('have.text', testSite.name);
 
         cy.log('Add second site');
         const secondSite = { name: 'Bergen', location: '60.389433, 5.332489', visibility: 'private' };
@@ -48,5 +40,20 @@ describe('Sites Map', () => {
 
         cy.log('Verify second site is present on the map');
         cy.get('.leaflet-marker-icon').should('have.length', 2);
+    });
+
+    it('opens a page showing list of deployments per selected site', () => {
+        // NOTE: Do not mock login to load all currently available pages and test drill-down to site
+        cy.login();
+        cy.get('.leaflet-marker-icon:nth-of-type(1)').click();
+        cy.get('.leaflet-popup .leaflet-popup-content').find('.deploymentState').first().click();
+
+        cy.location('pathname').should('be.equal', `/console/page/console_deployments/Site:%20${testSite.name}`);
+        cy.location('search').then(queryString =>
+            expect(JSON.parse(new URLSearchParams(queryString).get('c'))).to.deep.equal([
+                { context: {} },
+                { context: { siteName: testSite.name }, pageName: `Site: ${testSite.name}` }
+            ])
+        );
     });
 });

--- a/test/cypress/integration/widgets/sites_map_spec.js
+++ b/test/cypress/integration/widgets/sites_map_spec.js
@@ -36,7 +36,8 @@ describe('Sites Map', () => {
         cy.log('Add second site');
         const secondSite = { name: 'Bergen', location: '60.389433, 5.332489', visibility: 'private' };
         cy.createSite(secondSite);
-        refreshDashboardPage();
+        // NOTE: In the CI for some reason refreshDashboardPage does not work here
+        cy.reload();
 
         cy.log('Verify second site is present on the map');
         cy.get('.leaflet-marker-icon').should('have.length', 2);

--- a/test/cypress/support/commands.ts
+++ b/test/cypress/support/commands.ts
@@ -284,9 +284,7 @@ const commands = {
                                 ]
                             }
                         ]
-                    },
-                    { id: 'admin_operations' },
-                    { id: 'deployments' }
+                    }
                 ]
             }
         });

--- a/widgets/sitesMap/src/SiteControl.tsx
+++ b/widgets/sitesMap/src/SiteControl.tsx
@@ -11,7 +11,7 @@ interface SiteControlProps {
 }
 const SiteControl: FunctionComponent<SiteControlProps> = ({ site, toolbox }) => {
     function goToDeploymentsPage(siteName: string) {
-        toolbox.goToPage('deployments', { siteName });
+        toolbox.drillDown(toolbox.getWidget(), 'deploy', { siteName }, `Site: ${siteName}`);
     }
 
     const { Grid } = Stage.Basic;

--- a/widgets/sitesMap/src/SitesMap.tsx
+++ b/widgets/sitesMap/src/SitesMap.tsx
@@ -20,7 +20,7 @@ function getMarkerColor(statusesSummary: DeploymentStatusesSummary) {
     } else if (statusesSummary[DeploymentStatuses.InProgress] > 0) {
         color = 'yellow';
     } else if (statusesSummary[DeploymentStatuses.Good] > 0) {
-        color = 'green';
+        color = 'blue';
     }
 
     return color;

--- a/widgets/sitesMap/src/groupStates.ts
+++ b/widgets/sitesMap/src/groupStates.ts
@@ -18,7 +18,7 @@ const groupStates: Record<DeploymentStatus, GroupState> = {
         description: 'deployments in which active workflow execution is performed'
     },
     [DeploymentStatuses.RequiresAttention]: {
-        name: 'failed',
+        name: 'requires attention',
         icon: 'exclamation',
         colorSUI: 'red',
         severity: 4,


### PR DESCRIPTION
As we removed/changed recently some of the pages from the layout Sites Map redirection (on clicking the deployment status in the site marker tooltip) stopped working. This PR fixes that.

Within that PR I also did two small alignments to Deployments View widget:
* Changed "Good" site marker color (from green to blue)
* Changed "Failed" deployment status name (from “Failed” to “Requires attention”)

As some of the pages were removed I also updated `usePageMock` function.

Full system test run: https://jenkins.cloudify.co/view/UI%20Health%20View/job/Stage-UI-System-Test/651/