### PR TITLE
RD-1295 Upgrade TypeScript to 4.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29691,9 +29691,9 @@
       }
     },
     "typescript": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.3.tgz",
-      "integrity": "sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.2.tgz",
+      "integrity": "sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==",
       "dev": true
     },
     "typescript-styled-plugin": {

--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
     "source-map-loader": "^1.1.3",
     "style-loader": "^1.0.0",
     "timekeeper": "^1.0.0",
-    "typescript": "^4.2.3",
+    "typescript": "^4.3.2",
     "typescript-styled-plugin": "^0.15.0",
     "url-loader": "^2.1.0",
     "webpack": "^4.41.0",

--- a/test/cypress/support/blueprints.ts
+++ b/test/cypress/support/blueprints.ts
@@ -10,7 +10,12 @@ declare global {
 }
 
 const commands = {
-    uploadBlueprint: (pathOrUrl: string, id: string, yamlFile = 'blueprint.yaml', visibility = 'tenant') => {
+    uploadBlueprint: (
+        pathOrUrl: string,
+        id: string,
+        yamlFile = 'blueprint.yaml',
+        visibility = 'tenant'
+    ): Cypress.Chainable<unknown> => {
         if (pathOrUrl.startsWith('http')) {
             return cy.cfyRequest(
                 `/blueprints/${id}?blueprint_archive_url=${pathOrUrl}&visibility=${visibility}&application_file_name=${yamlFile}`,

--- a/test/cypress/support/commands.ts
+++ b/test/cypress/support/commands.ts
@@ -122,7 +122,7 @@ const commands = {
             ...options
         }),
     cfyFileRequest: (filePath: string, isBinaryFile: boolean, url: string, method = 'PUT', headers: any = null) => {
-        const filePromise = isBinaryFile
+        const filePromise: Cypress.Chainable<string | Blob> = isBinaryFile
             ? cy.fixture(filePath, 'binary').then(binary => Cypress.Blob.binaryStringToBlob(binary))
             : cy.fixture(filePath);
 


### PR DESCRIPTION
Upgrade TypeScript to the latest version (4.3.2) and address TypeScript errors that ensued from supposedly circular references in the types.

## Performance

1. Cold cache compilation improved from 30.72s to 25.56s (17%)
2. Other results look to be within measurement error margin

See https://docs.google.com/spreadsheets/d/1rMQYPDzRhN44GER2TXPcvnBBszUUodZNK-w11IS4jAE/edit#gid=0 for more data

## TS output files size

Looks like the tsbuildinfo size actually decreased by almost 50%. Aside from that, looks like no changes in the rest of the output.

Name | tsc-dist size (MB) | tsbuildinfo size (kB)
-- | -- | --
TS 4.2.3 | 10.0 | 610
TS 4.3.2 | 9.7 | 316

## ESLint warning

When linting, you will see the following message from ESLint now:

<details>

```sh
13:26 $ npm run lint

> cloudify-stage@6.0.0 lint /home/grzegorz/projects/cloudify/cloudify-stage
> eslint --cache --ignore-path .gitignore --ext js,jsx,ts,tsx .

=============

WARNING: You are currently running a version of TypeScript which is not officially supported by @typescript-eslint/typescript-estree.

You may find that it works just fine, or you may not.

SUPPORTED TYPESCRIPT VERSIONS: >=3.3.1 <4.3.0

YOUR TYPESCRIPT VERSION: 4.3.2

Please only submit bug reports when using the officially supported version.

=============
```

</details>

I have tried upgrading ESLint, prettier and related packages, but it turns out we would need to upgrade starting from the ones in cloudify-ui-common. Thus, I have dropped it and created 2 tasks to address the problem:

1. RD-2537
2. RD-2538

## System tests

https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/715/pipeline

Queued 2021-06-07 11:27 CEST