### PR TITLE
RD-2540 Fix race condition in filter_spec

### DIFF
--- a/test/cypress/integration/widgets/filter_spec.js
+++ b/test/cypress/integration/widgets/filter_spec.js
@@ -81,15 +81,15 @@ describe('Filter', () => {
         });
 
         it('blueprint upload and removal', () => {
-            cy.get('.blueprintsWidget').within(() => {
-                cy.getSearchInput().scrollIntoView().clear().type(blueprintName);
-                cy.get(`.${blueprintName}`).parent().find('.trash').click();
-            });
+            cy.get('.blueprintsWidget')
+                .as('blueprintsWidget')
+                .within(() => {
+                    cy.getSearchInput().scrollIntoView().clear().type(blueprintName);
+                    cy.get(`.${blueprintName}`).parent().find('.trash').click();
+                });
             cy.contains('Yes').click();
 
-            cy.get('.blueprintFilterField > .label').should('not.exist');
-            cy.get('.blueprintFilterField input').type(blueprintName, { force: true });
-            cy.contains('.blueprintFilterField', 'No results found.');
+            cy.get('@blueprintsWidget').contains('There are no Blueprints available.');
         });
     });
 });


### PR DESCRIPTION
There was a race condition between refetching the list of available
blueprints in the Resource Filter widget and the blueprint being
removed.

Removing the blueprint could have happened after the Resource Filter
widget's dropdown is opened, meaning that the test will fail as the
blueprint will supposedly still be in the system.

## System tests

Only a single test file is changed, so I'm running the tests just for that file:

https://jenkins.cloudify.co/job/Stage-UI-System-Test/698/

Queued 2021-06-01 14:53 CEST