### PR TITLE
RD-2553 Update documentation for 5.2 release to point to v5 branch

### DIFF
--- a/scripts/checkDocs.sh
+++ b/scripts/checkDocs.sh
@@ -8,10 +8,7 @@ else
   CURL_OPTIONS=
 fi
 
-DOCS_BRANCH="master"
-if [[ $STAGE_BRANCH =~ [0-9].[0-9]{1,2}-build ]]; then
-  DOCS_BRANCH=STAGE_BRANCH
-fi
+DOCS_BRANCH="5.1-build"
 
 COMPONENTS_REPOSITORY="cloudify-ui-components"
 STAGE_REPOSITORY="cloudify-stage"

--- a/scripts/readmesConfig.json
+++ b/scripts/readmesConfig.json
@@ -1,5 +1,5 @@
 {
-  "rawContentBasePath": "https://raw.githubusercontent.com/cloudify-cosmo/docs.getcloudify.org/master",
+  "rawContentBasePath": "https://raw.githubusercontent.com/cloudify-cosmo/docs.getcloudify.org/5.1-build",
   "files": [
     {"widget": "agents", "link": "/content/working_with/console/widgets/agents.md"},
     {"widget": "blueprintActionButtons", "link": "/content/working_with/console/widgets/blueprintActionButtons.md"},

--- a/widgets/agents/README.md
+++ b/widgets/agents/README.md
@@ -1,8 +1,8 @@
 # Agents Management
-Displays the following information about a specific agent:
+Displays the following information about a specific agent: 
 
 * **Id** - unique identifier of the agent
-* **IP** - IP address of the agent host
+* **IP** - IP address of the agent host 
 * **Deployment** - Deployment ID associated with agent
 * **Node** - Node ID associated with agent
 * **System** - agent host operation system

--- a/widgets/blueprintActionButtons/README.md
+++ b/widgets/blueprintActionButtons/README.md
@@ -1,8 +1,8 @@
 # Blueprint Action Buttons
-Buttons that allow performing actions on a selected blueprint - creating a deployment from it, deleting the blueprint or editing a copy of the blueprint in Composer (available only as part of the Premium edition). 
-The action buttons need to receive the id of the desired blueprint. This can be accomplished in two ways:
+Buttons that allow performing actions on a selected blueprint - creating a deployment from it, deleting the blueprint or editing a copy of the blueprint in Composer (available only as part of the Cloudify Premium edition). 
+The action buttons need to receive the id of the desired blueprint. This can be accomplished in two ways: 
 
-* By placing the buttons in a blueprint’s drill-down page, meaning the blueprint has been selected before entering the page, and its id is included in the page’s context.
+* By placing the buttons in a blueprint’s drill-down page, meaning the blueprint has been selected before entering the page, and its id is included in the page’s context. 
 * By adding to the page a widget allowing to select blueprints, such as the resources filter or the blueprints list.  
 
 ![blueprint-actions]( /images/ui/widgets/blueprint-action-buttons.png )

--- a/widgets/blueprintCatalog/README.md
+++ b/widgets/blueprintCatalog/README.md
@@ -2,16 +2,16 @@
 
 Displays blueprints from a repository under a configurable Github account or from an HTTP endpoint providing JSON response.
 
-By default, the widget presents the blueprints listed in JSON file taken from widget configuration.
-
-The widget includes an upload option for each of the blueprints, which lets you easily upload it to the current tenant on the manager.
+By default, the widget presents the blueprints listed in JSON file taken from widget configuration. 
+ 
+The widget includes an upload option for each of the blueprints, which lets you easily upload it to the current tenant on the manager. 
 After uploading a blueprint from the catalog, you will be able to see it under the **Blueprints** widget.
 
-You can also point the widget to read from a GitHub user account.
+You can also point the widget to read from a GitHub user account. 
 You can then filter the presented blueprints by providing a filter query in the widget’s settings. Check [Searching for repositories](https://help.github.com/en/github/searching-for-information-on-github/searching-for-repositories) page to get more information on how to filter data in GitHub.
 
-You can and should enter Github credentials for fetching data, as the defaults used by the widgets can reach the restricted query limit of GitHub (~50).
-These parameters are pulled from secrets as the github-username and github-password keys.
+You can and should enter Github credentials for fetching data, as the defaults used by the widgets can reach the restricted query limit of GitHub (~50). 
+These parameters are pulled from secrets as the github-username and github-password keys. 
 These parameters are a must if you want to configure the widget to access private repositories.
 
 ![blueprints-catalog]( /images/ui/widgets/blueprints-catalog.png )
@@ -21,6 +21,6 @@ These parameters are a must if you want to configure the widget to access privat
 
 * `Blueprint Examples URL` - Specifies the JSON file from which the blueprints are being read
 * `GitHub User` - GitHub user or organization account name which is the owner of the repository to fetch. Default: cloudify-examples
-* `GitHub Filter` - Optional filter for GitHub repositories. See GitHub’s web page ‘Searching repositories’ for more details.
+* `GitHub Filter` - Optional filter for GitHub repositories. See GitHub’s web page ‘Searching repositories’ for more details. 
 * `Display style` - defines whether the widget’s view is Catalog or Table. Default: Catalog
 * `Sort by name` -  if set to true, then blueprints will be sorted by name. Default: No

--- a/widgets/blueprintInfo/README.md
+++ b/widgets/blueprintInfo/README.md
@@ -1,5 +1,5 @@
 # Blueprint Info
-Displays the following information about a specific blueprint:
+Displays the following information about a specific blueprint: 
 
 * **Picture**
 * **Name**

--- a/widgets/blueprintNum/README.md
+++ b/widgets/blueprintNum/README.md
@@ -1,6 +1,6 @@
 # Number of blueprints
-Displays the total number of blueprints in the tenant, according to the user’s permissions and the blueprints’ visibility levels.
-The widget is clickable, and upon clicking will redirect by default to the “Local Blueprint” page. You can set the widget’s configuration to lead to a different page.
+Displays the total number of blueprints in the tenant, according to the user’s permissions and the blueprints’ visibility levels. 
+The widget is clickable, and upon clicking will redirect by default to the “Local Blueprint” page. You can set the widget’s configuration to lead to a different page. 
 
 ![number_of_blueprints]( /images/ui/widgets/num_of_blueprints.png )
 

--- a/widgets/blueprintSources/README.md
+++ b/widgets/blueprintSources/README.md
@@ -8,4 +8,4 @@ If blueprint imports another blueprint, then all imported blueprint will be list
 
 ## Settings
 
-* `Content pane initial width in %` - sets the default size of the source part of the window in percent of screen width. Default: 65%.
+* `Content pane initial width in %` - sets the default size of the source part of the window in percent of screen width. Default: 65%. 

--- a/widgets/blueprintUploadButton/README.md
+++ b/widgets/blueprintUploadButton/README.md
@@ -1,12 +1,12 @@
 # Blueprint upload button
-This button allows uploading a blueprint to the manager.
+This button allows uploading a blueprint to the manager. 
 
 ![blueprint-upload-button]( /images/ui/widgets/blueprint-upload-button.png )
 
 Clicking on it opens a dialog for providing the following details:
 
 * **Blueprint visibility** (optional) - represented by a colourful icon in the upper right corner, and can be set by clicking on it. See [resource’s visibility](/working_with/manager/resource-visibility). Default: tenant
-* **Blueprint package** - single YAML file or blueprint archive (local or URL).
+* **Blueprint package** - single YAML file or blueprint archive (local or URL). 
 * **Blueprint Name** - unique name to identify the blueprint on the manager.
 * **Blueprint YAML file** - main YAML file in the blueprint archive.
 * **Blueprint icon** (optional) - to be presented in the Blueprints widget. Default: Cloudify logo.

--- a/widgets/blueprints/README.md
+++ b/widgets/blueprints/README.md
@@ -1,13 +1,13 @@
 # Blueprints
 
-Displays all the blueprints on the tenant, according to the user’s permissions and the blueprints visibility levels.
+Displays all the blueprints on the tenant, according to the user’s permissions and the blueprints visibility levels. 
  The data can be displayed as a table or a catalog.
-
+ 
 ## Features
 
 ### Blueprint basic information
 
-The following information is displayed:
+The following information is displayed: 
 
 * **Icon image file**
 * **Name**
@@ -29,9 +29,9 @@ There are also action buttons to upload a blueprint, create deployment, delete b
 #### Uploading a Blueprint
 
 1. Click the **Upload** button.
-2. In the Upload Blueprint dialog, provide the URL of the remote archive in which the blueprint is located or select a local blueprint archive.
+2. In the Upload Blueprint dialog, provide the URL of the remote archive in which the blueprint is located or select a local blueprint archive. 
 3. Enter the `Blueprint name` and `Blueprint YAML file`.   
-   `Blueprint name` is the name with which you want to identify this blueprint once uploaded.<br>
+   `Blueprint name` is the name with which you want to identify this blueprint on the Cloudify Manager instance.<br>
    `Blueprint YAML file` is the name of the YAML file in the archive that you want to upload as the main blueprint - as there can be multiple files in the archive. If a blueprint filename field is omitted, the default `blueprint.yaml` filename is used, but if a file under that name does not exist in the archive, an error message will appear.    
 4. (Optional) Provide a .png file URL or select a local one, to appear as an icon in the catalog or table view next to the blueprint name.   
 5. Choose the blueprint's visibility by clicking on the icon in the top right corner:<br>
@@ -45,9 +45,9 @@ The default visibility is "Tenant", and according to the logged-in user's permis
 1. Click the deploy icon ![Deploy icon]( /images/ui/icons/deploy-icon.png ).   
 2. In the Deploy Blueprint dialog, specify a name for your deployment.
 3. Specify the required deployment inputs.   
-   The names of the default input values appear in the inputs fields. You can leave these defaults or override them with new values.
-   Input's description (on hovering help icon ![Help icon]( /images/ui/icons/help-icon.png )) might help you understand how to fill-in the proper value.
-   An alternative for providing the inputs is to specify a .yaml file containing the relevant values.
+   The names of the default input values appear in the inputs fields. You can leave these defaults or override them with new values. 
+   Input's description (on hovering help icon ![Help icon]( /images/ui/icons/help-icon.png )) might help you understand how to fill-in the proper value. 
+   An alternative for providing the inputs is to specify a .yaml file containing the relevant values. 
 4. Click **Deploy** to deploy the blueprint or **Deploy & Install** to deploy and execute `install` workflow on it.
 
 ![Create a deployment]( /images/ui/widgets/blueprints_deployment_creation.png )
@@ -61,7 +61,7 @@ Click the delete icon ![Delete icon]( /images/ui/icons/delete-icon.png ) and con
 ### Blueprint details
 
 When you click the blueprint row (element) in the blueprints table (catalog), a blueprint-specific page opens (it's also called blueprint's drill-down page).
-
+ 
 The page displays the following widgets with details about the selected blueprint:
 
 * [Blueprint Action Buttons](/working_with/console/widgets/blueprintActionButtons)
@@ -78,4 +78,4 @@ See Settings section for details on how to turn on/off this feature.
 
 * `Refresh time interval` - The time interval in which the widget’s data will be refreshed, in seconds. Default: 10 seconds
 * `Enable click to drill down` - This option enables redirecting to the blueprint’s drill-down page upon clicking on a specific blueprint. Default: True
-* `Display style` - Can be either Catalog or table. The deployments status column is only available in list mode.  Default: table
+* `Display style` - Can be either Catalog or table. The deployments status column is only available in list mode.  Default: table 

--- a/widgets/buttonLink/README.md
+++ b/widgets/buttonLink/README.md
@@ -5,8 +5,8 @@ Opens the specified URL in a separate tab. You can define the label that appears
 
 
 ## Settings
-
+ 
 * `Button label` - The text to appear on the button
-* `URL address` - The URL to be opened upon clicking on the button.
+* `URL address` - The URL to be opened upon clicking on the button. 
 * `Full height` - Stretches the button vertically to fill entire widget's height
 * `Color` - The button's color

--- a/widgets/composerLink/README.md
+++ b/widgets/composerLink/README.md
@@ -1,5 +1,5 @@
 # Composer link
-Opens the [{{< param cfy_composer_name >}}]({{< param cfy_composer_link >}}), which allows creating blueprints with a graphical drag-and-drop tool.
+Opens the [{{< param cfy_composer_name >}}]({{< param cfy_composer_link >}}), which allows creating blueprints with a graphical drag-and-drop tool. 
 
 <div class="ui message info">
 The {{< param cfy_composer_name >}} comes as part of the {{< param mgr_premium_title >}}, and is only available for users with certain roles.

--- a/widgets/deploymentActionButtons/README.md
+++ b/widgets/deploymentActionButtons/README.md
@@ -1,9 +1,9 @@
 # Deployment action buttons
-Buttons which allow running workflows of a specific deployment, updating it or deleting it. The deployment can be selected in one of the following ways:
+Buttons which allow running workflows of a specific deployment, updating it or deleting it. The deployment can be selected in one of the following ways: 
 
-* By placing the deployment action buttons in the deployments drill-down page, meaning the deployment has been selected before entering the page, and its id is included in the page’s context.
+* By placing the deployment action buttons in the deployments drill-down page, meaning the deployment has been selected before entering the page, and its id is included in the page’s context. 
 * By adding to the page a widget allowing to select deployments, such as the resources filter or the blueprint deployments
-
+ 
 ![deployment-action-buttons.png]( /images/ui/widgets/deployment-action-buttons.png )
 
 

--- a/widgets/deploymentButton/README.md
+++ b/widgets/deploymentButton/README.md
@@ -1,5 +1,5 @@
 # Create deployment button
-Allows creating a deployment of a chosen blueprint. After choosing a name for the deployment, the desired blueprint and the visibility of the deployment (private/tenant), a screen will open, allowing to specify values for the inputs required by the chosen blueprint.
+Allows creating a deployment of a chosen blueprint. After choosing a name for the deployment, the desired blueprint and the visibility of the deployment (private/tenant), a screen will open, allowing to specify values for the inputs required by the chosen blueprint. 
 
 ![create_deployment_button]( /images/ui/widgets/create_deployment_button.png )
 

--- a/widgets/deploymentInfo/README.md
+++ b/widgets/deploymentInfo/README.md
@@ -1,5 +1,5 @@
 # Deployment Info
-Displays the following information about a specific deployment:
+Displays the following information about a specific deployment: 
 
 * **Name**
 * **Description**

--- a/widgets/deploymentNum/README.md
+++ b/widgets/deploymentNum/README.md
@@ -1,6 +1,6 @@
 # Number of deployments
-Displays the total number of deployments in the tenant, according to the user’s permissions and the blueprints’ visibility levels.
-The widget is clickable, and upon clicking will redirect by default to the “Deployments” page. You can set the widget’s configuration to lead to a different page.
+Displays the total number of deployments in the tenant, according to the user’s permissions and the blueprints’ visibility levels. 
+The widget is clickable, and upon clicking will redirect by default to the “Deployments” page. You can set the widget’s configuration to lead to a different page. 
 
 ![number_of_deployments]( /images/ui/widgets/num_of_deployments.png )
 

--- a/widgets/deploymentWizardButtons/README.md
+++ b/widgets/deploymentWizardButtons/README.md
@@ -1,5 +1,5 @@
 # Deployment wizard buttons
-Allows installing a deployment of a Hello World example or chosen blueprint.
+Allows installing a deployment of a Hello World example or chosen blueprint. 
 
 ![deployment_wizard_buttons]( /images/ui/widgets/deployment_wizard_buttons.png )
 
@@ -12,21 +12,21 @@ Details about the steps in wizard are described below.
 ### Infrastructure step (only in Hello World Wizard)
 ![hw_wizard_0]( /images/ui/widgets/deployment_wizard_buttons_hw_wizard_0.png )
 
-In the first step, the Hello World blueprint is already selected from the blueprint examples. You just need to select the type of the infrastructure you want to deploy that example on.
+In the first step Hello World blueprint is already selected from Cloudify blueprint examples. You just need to select the type of the infrastracture you want to deploy that example on.
 
 Click `Next` button to go the next step.
 
 ### Blueprint step (only in Deployment Wizard)
 ![deployment_wizard_0]( /images/ui/widgets/deployment_wizard_buttons_deployment_wizard_0.png )
 
-In the first step you need to provide blueprint package (either by URL or local archive file), set blueprint name and choose the YAML file from the blueprint package.
+In the first step you need to provide blueprint package (either by URL or local archive file), set blueprint name and choose the YAML file from the blueprint package. 
 
 Set blueprint and deployment visibility by clicking on the icon on the top right part of the modal window.
 
 Click `Next` button to go the next step.
-
-### Plugins step
-In this step you see list of plugins detected in blueprint's YAML file imports section.
+ 
+### Plugins step 
+In this step you see list of plugins detected in blueprint's YAML file imports section. 
 
 ![wizard_plugins_step]( /images/ui/widgets/deployment_wizard_buttons_hw_wizard_plugins.png )
 
@@ -34,8 +34,8 @@ Some of them may be automatically installed, for some of them you will need to p
 
 Hover over icon in `Action` column to see details and check if you need to provide any additional data. Set visibility by clicking on the icon on the right side in `Action` column. Click `Back` or `Next` button to navigate between steps.
 
-### Secrets step
-In this step you see list of secrets detected in blueprint's YAML file.
+### Secrets step 
+In this step you see list of secrets detected in blueprint's YAML file. 
 
 ![wizard_secrets_step]( /images/ui/widgets/deployment_wizard_buttons_hw_wizard_secrets.png )
 
@@ -43,8 +43,8 @@ Some of them may already be set, for some of them you will need to provide value
 
 Hover over icon in `Action` column to see details and check if you need to provide value for the secret. Set visibility by clicking on the icon on the right side in `Action` column. Click `Back` or `Next` button to navigate between steps.
 
-### Inputs step
-In this step you see list of blueprint inputs.
+### Inputs step 
+In this step you see list of blueprint inputs. 
 
 ![wizard_inputs_step]( /images/ui/widgets/deployment_wizard_buttons_hw_wizard_inputs.png )
 
@@ -52,17 +52,17 @@ If input has default value you won't need to provide it. You need to set values 
 
 Hover over icon in `Action` column to see details and check if you need to provide value for the input. Click `Back` or `Next` button to navigate between steps.
 
-### Confirm step
-In this step you see list of task to be performed during installation process.
+### Confirm step 
+In this step you see list of task to be performed during installation process. 
 
-You can also modify deployment name, which is automatically set using blueprint name and index suffix.
+You can also modify deployment name, which is automatically set using blueprint name and index suffix. 
 
 ![wizard_confirm_step]( /images/ui/widgets/deployment_wizard_buttons_hw_wizard_confirm.png )
 
 Click `Install` to start resources installation procedure or click `Back` button to go to the previous steps. Deployment name availability is verified upon clicking on `Install` button.
 
-### Install step
-In this step you see list of ongoing tasks and its status.
+### Install step 
+In this step you see list of ongoing tasks and its status. 
 
 ![wizard_install_step]( /images/ui/widgets/deployment_wizard_buttons_hw_wizard_install.png )
 
@@ -76,4 +76,4 @@ When something goes wrong you will be able to see error message and you start ov
 * `Show Hello World Wizard button` - if set then Hello World Wizard button will be shown
 * `Hello World Wizard button label` - label for Hello World Wizard button
 * `Show Deployment Wizard button` - if set then Deployment Wizard button will be shown
-* `Deployment Wizard button label` - label for Deployment Wizard button
+* `Deployment Wizard button label` - label for Deployment Wizard button 

--- a/widgets/deployments/README.md
+++ b/widgets/deployments/README.md
@@ -1,5 +1,5 @@
 # Blueprint deployments
-Displays the list of the deployments in the current tenant, according to the user’s permissions. The data can be displayed as a table or list.
+Displays the list of the deployments in the current tenant, according to the user’s permissions. The data can be displayed as a table or list. 
 
 ![Blueprint Deployments widget]( /images/ui/widgets/blueprint-deployments.png )
 
@@ -8,8 +8,8 @@ Displays the list of the deployments in the current tenant, according to the use
 
 ### Deployment basic information
 
-The Deployments widget displays a list of deployments in the current tenant. The displayed information is: Deployment name,
-the blueprint which the deployment is derived from, the deployments creation and last update dates,
+The Deployments widget displays a list of deployments in the current tenant. The displayed information is: Deployment name, 
+the blueprint which the deployment is derived from, the deployments creation and last update dates, 
 the name of the user who created the deployment, and the number of node instances per state.
 
 
@@ -17,7 +17,7 @@ the name of the user who created the deployment, and the number of node instance
 
 You can also quickly check status and logs of the last workflow executed on the deployment by hovering over the status icon in the top left corner of deployment. Depending on the type of the execution there are additional action buttons there.
 
-![Last Execution Status]( /images/ui/widgets/blueprint-deployments_last-execution-status.png )
+![Last Execution Status]( /images/ui/widgets/blueprint-deployments_last-execution-status.png ) 
 
 The last execution status is indicated as follows:
 
@@ -49,19 +49,19 @@ The hamburger menu on the right of every deployment allows performing the follow
 * Update deployment
 * Set site for deployment
 * Delete deployment
-
+ 
 ![Deployment actions menu]( /images/ui/widgets/blueprint-deployments_action-menu.png )
 
 
 #### Executing a Workflow
 
 1. Go to **Execute workflow** section in the menu and click the workflow you want to execute.
-2. Provide values for workflow parameters.
+2. Provide values for workflow parameters. 
 3. Click **Execute**.
 
 You can also use **Install** or **Uninstall** menu options to execute those specific workflows.
-For these two workflows you will also be able to track the progress of the execution as at the bottom of the deployment row there will be thin line visible. Progress is calculated based on number of node instances installed (in case of install workflow) or deleted (in case of uninstall workflow).
-
+For these two workflows you will also be able to track the progress of the execution as at the bottom of the deployment row there will be thin line visible. Progress is calculated based on number of node instances installed (in case of install workflow) or deleted (in case of uninstall workflow). 
+ 
 ![Deployment progress]( /images/ui/widgets/blueprint-deployments_progress-bar.png )
 
 The color of the line indicates the status of the execution:
@@ -90,7 +90,7 @@ For more information about creating custom workflows, [click here](/working_with
 #### Setting a Site
 
 1. Click **Set Site** in the action menu.
-2. Select a new site for the deployment. The selected site must be in the same visibility context as the deployment or in a higher visibility context. (i.e. both site and deployment are in the same tenant or the site is defined as global)
+2. Select a new site for the deployment. The selected site must be in the same visibility context as the deployment or in a higher visibility context. (i.e. both site and deployment are in the same tenant or the site is defined as global) 
 3. Click **Update**.
 
 For detaching the current site, leave the `Site name` input empty and toggle the `Detach` button.
@@ -106,12 +106,12 @@ For detaching the current site, leave the `Site name` input empty and toggle the
 
 ### Deployments details
 
-Clicking on a deployment's name will bring us to deployment's drill-down page,
+Clicking on a deployment's name will bring us to deployment's drill-down page, 
 which provides additional data about the deployment.
 
 ![Deployment page]( /images/ui/widgets/blueprint-deployments_deployment-page.png )
 
-By default, that page displays the following:
+By default, that page displays the following: 
 
 * [Deployment Info widget](/working_with/console/widgets/deploymentInfo)
 * [Deployment Action Buttons widget](/working_with/console/widgets/deploymentActionButtons)
@@ -130,7 +130,7 @@ By default, that page displays the following:
       * [Executions](/working_with/console/widgets/executions) (configured to display list of executions)
       * [Deployment Events/Logs filter](/working_with/console/widgets/eventsFilter)
       * [Deployment Events/Logs](/working_with/console/widgets/events)
-
+  
 
 ## Settings
 

--- a/widgets/events/README.md
+++ b/widgets/events/README.md
@@ -1,5 +1,5 @@
 # Events and Logs
-Displays the logs and events of all the executions in the current tenant, according to the user’s permissions.
+Displays the logs and events of all the executions in the current tenant, according to the user’s permissions. 
 
 You can configure the fields that are displayed and can choose to indicate in colors success and failure messages.
 
@@ -15,7 +15,7 @@ Sometimes error logs may contain additional information about error cause. This 
 ## Settings
 
 * `Refresh time interval` - The time interval in which the widget’s data will be refreshed, in seconds. Default: 2 seconds
-* `List of fields to show in the table` - You can choose which fields to present. By default, these are the fields presented:
+* `List of fields to show in the table` - You can choose which fields to present. By default, these are the fields presented: 
 
    * Icon
    * Timestamp
@@ -26,9 +26,9 @@ Sometimes error logs may contain additional information about error cause. This 
    * Workflow
    * Operation
    * Message
-
-You can also choose to add the field "Type", which will present the log level in case of a log, and event type in case of an event.
+   
+You can also choose to add the field "Type", which will present the log level in case of a log, and event type in case of an event. 
 
 * `Color message based on type` - when marked as “on”, successful events will be coloured in blue, and failures in red. Default: On
 
-* `Maximum message length before truncation` - Allow to define the length of the messages presented in the table. Default: 200. Please note that even if the message is being truncated in the table itself, you can see the full message upon hovering.
+* `Maximum message length before truncation` - Allow to define the length of the messages presented in the table. Default: 200. Please note that even if the message is being truncated in the table itself, you can see the full message upon hovering. 

--- a/widgets/eventsFilter/README.md
+++ b/widgets/eventsFilter/README.md
@@ -2,10 +2,10 @@
 Displays a filter pane for events and logs. The following filtering options are available:
 
 * **Type** - Logs/Events
-* **Event Types** - predefined event types: Policy end successfully started, Policy failed, Processing trigger, Task ended successfully, Task failed, Task received, Task rescheduled, Task retried, Task sent, Task started, Trigger failed, Trigger succeeded, Workflow cancelled, Workflow ended successfully, Workflow event, Workflow failed, Workflow initializing node, Workflow initializing policies, Workflow node event, Workflow received, Workflow staged, Workflow started.
-You can also specify your log level by typing in text. Multiselection available.
-* **Log Levels** - predefined log levels: Debug, Info, Warning. Error, Critical.
-You can also specify your log level by typing in text. Multiselection available.
+* **Event Types** - predefined event types: Policy end successfully started, Policy failed, Processing trigger, Task ended successfully, Task failed, Task received, Task rescheduled, Task retried, Task sent, Task started, Trigger failed, Trigger succeeded, Workflow cancelled, Workflow ended successfully, Workflow event, Workflow failed, Workflow initializing node, Workflow initializing policies, Workflow node event, Workflow received, Workflow staged, Workflow started. 
+You can also specify your log level by typing in text. Multiselection available. 
+* **Log Levels** - predefined log levels: Debug, Info, Warning. Error, Critical. 
+You can also specify your log level by typing in text. Multiselection available. 
 * **Operation** - part of log/event operation
 * **Message Text** - part of log/event message
 * **Time Range** - time range to get log/events

--- a/widgets/executions/README.md
+++ b/widgets/executions/README.md
@@ -1,6 +1,6 @@
 # Executions
 
-Displays data about the executions in the current tenant, according to the user’s permissions.
+Displays data about the executions in the current tenant, according to the user’s permissions. 
 
 ## Features
 
@@ -14,8 +14,8 @@ By default, the presented details include the blueprint and deployment of the ex
 
 In **Attributes** column you can see one of these icons:
 
-* ![Dry Run icon]( /images/ui/icons/dry-run-icon.png ) - [Dry-run execution](/working_with/workflows/dry-run)
-* ![System Workflow icon]( /images/ui/icons/system-workflow-icon.png ) - [System-wide execution](/working_with/workflows/index.html)
+* ![Dry Run icon]( /images/ui/icons/dry-run-icon.png ) - **Dry Run** 
+* ![System Workflow icon]( /images/ui/icons/system-workflow-icon.png ) - **System Workflow**
 
 #### Actions
 
@@ -23,12 +23,12 @@ In the actions menu on the right side of the execution row (click ![List icon]( 
 
 * `Show Execution Parameters` - shows details in modal window about execution parameters,    
 * `Show Update Details` - shows details in modal window about blueprint and inputs change (available only for 'update' executions),
-* `Show Error Details` - shows error details in modal window (available only for failed executions),
+* `Show Error Details` - shows error details in modal window (available only for failed executions), 
 * `Resume` - resume the execution (available only for cancelled or failed executions)
 * `Cancel` - cancels the execution (available only for active executions),
-* `Force Cancel` - enforces cancellation of the execution (available only for active executions),
+* `Force Cancel` - enforces cancellation of the execution (available only for active executions), 
 * `Kill Cancel` - the process executing the workflow is forcefully stopped, even if it is stuck or unresponsive.
-
+ 
  For details about cancelling executions, see [cancelling workflow executions](/working_with/workflows/cancelling-execution)
 
 
@@ -38,16 +38,16 @@ Workflow defines tasks that can be executed on a node or a group of nodes. Most 
 
 See [Workflow Execution Model](//developer/execution_model) for deeper understanding of how executions and task graphs are designed.
 
-#### Visualization modes
+#### Visualization modes 
 
 Visualization of the workflow execution task graph can be displayed in Executions widget in two ways depending on `Show most recent execution only` parameter value (see [Settings](#settings) for details):
 
 * **Off** - default view (Executions list) - after selecting an execution by clicking its row in the table a corresponding task graph is displayed
   ![executions]( /images/ui/widgets/executions-tasks-graph.png )
 
-* **On** - single execution view - the last execution for the selected deployment is displayed
+* **On** - single execution view - the last execution for the selected deployment is displayed 
   ![executions]( /images/ui/widgets/executions-tasks-graph-single.png )
-
+ 
 #### Task state
 
 Each graph node represents a task that is part of the execution. Each node is colored depending on task state:
@@ -59,14 +59,14 @@ Each graph node represents a task that is part of the execution. Each node is co
 
 #### Actions
 
-In the upper right corner you can see a toolbar:
+In the upper right corner you can see a toolbar: 
 
 ![executions]( /images/ui/widgets/executions-tasks-graph-toolbar.png )
 
 By clicking icons from the toolbar you can:
 
 * Enter **Play mode** in which the view tracks the progress by following tasks in progress
-* **Fit to view** to display entire graph inside widget borders
+* **Fit to view** to display entire graph inside widget borders 
 * **Open in window** to display graph in modal view with miniature view for extremely large workflows
 
 A task node may contain an icon in the bottom right corner:
@@ -84,12 +84,12 @@ It allows you to automatically set an operation in [Events/Log Filter widget](/w
     * Deployment
     * Workflow
     * Created
-    * Ended
+    * Ended 
     * Creator
     * Attributes
     * Status
     * Actions
-
+   
     You can also choose to add `Id` column from the list, which will present the execution id. By default this value is not presented as a column in the table, but as a pop up shown by hovering over ID label.
 * `Show system executions`- allow to include or exclude executions of system workflows in the list. Default: On
 * `Show most recent execution only` - if enabled the widget only shows a tasks graph for the most recent execution. Default: Off

--- a/widgets/filter/README.md
+++ b/widgets/filter/README.md
@@ -1,13 +1,13 @@
 # Resource Filter
 
-This widget provides the ability to filter the data presented in other widgets on the page according to a specific resource.
+This widget provides the ability to filter the data presented in other widgets on the page according to a specific resource. 
 By default, the widget allows filtering by blueprint, deployment and execution, and you can also add fields to filter by node, node instance and more, by configuring the widget’s settings.
 
 ![resource-filter]( /images/ui/widgets/resource_filter.png )
 
 
 ## Settings
-
+ 
 * `Refresh time interval` - The time interval in which the widget’s data will be refreshed, in seconds. Default: 10 seconds.
 * `Show blueprint filter` - Defines whether to expose filtering by Blueprint. Default: On
 * `Show deployment filter` - Defines whether to expose filtering by Deployment. Default: On

--- a/widgets/highAvailability/README.md
+++ b/widgets/highAvailability/README.md
@@ -1,10 +1,10 @@
 # Cluster Status
 
-Displays the status of the {{< param cfy_manager_name >}} cluster divided into 3 cluster services:
+Displays status of the Cloudify cluster divided into 3 cluster services: 
 
-* Manager,
+* Manager, 
 * Database,
-* Message Broker.
+* Message Broker. 
 
 ![cluster-status-widget]( /images/ui/widgets/cluster-status.png )      
 
@@ -16,11 +16,11 @@ Cluster services can have the following statuses:
 
 Each cluster node is presented with:
 
-* **Node Name**,
 * **Status** - on hovering status icon you can see popup with details, you can copy raw info about node status to clipboard to get even more details,
 * **Private IP**,
-* **Public IP / Load Balancer IP** - in case of Manager node, you can click on the IP to go to {{< param cfy_console_name >}} of that specific node,
-* **Version**.
+* **Public IP / Load Balancer IP** - in case of Manager node, you can click on the IP to go to Cloudify UI of that specific node,
+* **Version**,
+* **ID** - displayed in popup on hovering ID button.
 
 ![cluster-status-widget]( /images/ui/widgets/cluster-status-node-status.png )
 

--- a/widgets/inputs/README.md
+++ b/widgets/inputs/README.md
@@ -1,11 +1,11 @@
 # Deployment Inputs
 
-Presents the names and values of the inputs of a specific deployment. The deployment can be selected in one of the following ways:
+Presents the names and values of the inputs of a specific deployment. The deployment can be selected in one of the following ways: 
 
-* By placing the deployment inputs widget in the deployments drill-down page, meaning the deployment has been selected before entering the page, and its id is included in the page’s context.
+* By placing the deployment inputs widget in the deployments drill-down page, meaning the deployment has been selected before entering the page, and its id is included in the page’s context. 
 * By adding to the page a widget allowing to select deployments, such as the resources filter or the blueprint deployments.  
 
-If only a blueprint was selected, the widget will present the default values for the inputs, defined in the blueprint itself.
+If only a blueprint was selected, the widget will present the default values for the inputs, defined in the blueprint itself. 
 
 ![deployment-inputs]( /images/ui/widgets/deployment-inputs.png )
 

--- a/widgets/maintenanceModeButton/README.md
+++ b/widgets/maintenanceModeButton/README.md
@@ -10,7 +10,7 @@ Maintenance Mode can only be activated by `admin` users.
 You can activate Maintenance Mode by clicking **Activate Maintenance Mode** button. To enter Maintenance Mode, click **Yes** in the *Are you sure you want to enter maintenance mode?* dialog.
 
 In order for Maintenance Mode to be activated, all running workflows must be stopped.
-During the Maintenance Mode activation process, the {{< param cfy_manager_name >}} waits for all running executions to finish. 
+During the Maintenance Mode activation process, Cloudify Manager waits for all running executions to finish. 
 During this time, you can see all running executions and cancel them manually, if necessary.
 
 ![Remaining executions]( /images/ui/widgets/maintenance-mode-button_remaining-executions.png )

--- a/widgets/managers/README.md
+++ b/widgets/managers/README.md
@@ -1,9 +1,9 @@
 # Spire Manager
 
-Displays the list of the deployments created using [{{< param cfy_spire_name >}} plugin](https://github.com/cloudify-cosmo/cloudify-spire-plugin) in the current tenant, according to the user’s permissions. The data is displayed in a table.
+Displays the list of the deployments created using [Cloudify Spire plugin](https://github.com/cloudify-cosmo/cloudify-spire-plugin) in the current tenant, according to the user’s permissions. The data is displayed in a table.
 
 <div class="ui message info">
-The {{< param cfy_spire_name >}} widget can only be used on a {{< param cfy_manager_name >}} with the {{< param cfy_spire_name >}} license.
+Spire Manager can only be used on Cloudify with Spire license edition.
 </div>
 
 
@@ -13,7 +13,7 @@ The {{< param cfy_spire_name >}} widget can only be used on a {{< param cfy_mana
 
 ### Presented data
 
-You can see IP addresses, names and status of the cluster created by Spire deployment.
+You can see IP addresses, names and status of the cluster created by Spire deployment. 
 
 Detailed status about specific cluster is presented after hovering the status icon:
 
@@ -21,18 +21,18 @@ Detailed status about specific cluster is presented after hovering the status ic
 
 Similarly to Deployments widget you can see detailed information about last execution by hovering the cell in Last Execution column:
 
-![Spire Manager - last execution]( /images/ui/widgets/spire-manager-last-execution.png )
+![Spire Manager - last execution]( /images/ui/widgets/spire-manager-last-execution.png ) 
 
 
 ### User actions
 
 You can perform the following actions:
 
-* **Open Console** (![Open Console icon]( /images/ui/icons/open-console-icon.png )) - Open the {{< param cfy_console_name >}} of that {{< param cfy_manager_name >}}.
-* **Refresh Status** (![Refresh Status icon]( /images/ui/icons/refresh-status-icon.png )) - Refresh the status of the {{< param cfy_manager_name >}}.
-* **Execute Workflow** (![Execute Workflow icon]( /images/ui/icons/execute-workflow-icon.png )) - Execute a workflow through the selected {{< param cfy_manager_name >}}.
+* **Open Console** (![Open Console icon]( /images/ui/icons/open-console-icon.png )) of Cloudify Manager created by selected Spire deployment,
+* **Refresh Status** (![Refresh Status icon]( /images/ui/icons/refresh-status-icon.png )) of Cloudify Manager created by selected Spire deployment,
+* **Execute Workflow** (![Execute Workflow icon]( /images/ui/icons/execute-workflow-icon.png )) on selected Spire deployment. 
 
-You can also refresh status or execute any workflow available on the Spire deployment on multiple managers using bulk operations.
+You can also refresh status or execute any workflow available on the Spire deployment on multiple managers using bulk operations. 
 To do so, select Spire deployments using checkboxes in the left column and click one of the buttons above the table - **Refresh Status** or **Execute Workflow**.
 
 

--- a/widgets/nodes/README.md
+++ b/widgets/nodes/README.md
@@ -1,7 +1,7 @@
 # Nodes List
 Displays a list of the existing nodes in the current tenant, according to the user’s permissions. The node’s blueprint and deployment, type, connected nodes, number of instances, and nodes groups of which the node is part are displayed.
 
-The nodes are listed by name. When you select a node, either by clicking its name in the table or by clicking it in the Topology pane, additional data about the node’s instances is displayed: The instances names, statuses, relationships and runtime properties.
+The nodes are listed by name. When you select a node, either by clicking its name in the table or by clicking it in the Topology pane, additional data about the node’s instances is displayed: The instances names, statuses, relationships and runtime properties. 
 
 Node type hierarchy can be shown by hovering over type hierarchy icon (![type-hierarchy-icon]( /images/ui/icons/type-hierarchy-icon.png )).
 
@@ -18,8 +18,8 @@ Node type hierarchy can be shown by hovering over type hierarchy icon (![type-hi
    * Blueprint
    * Deployment
    * Contained in
-   * Connected to
+   * Connected to 
    * Host
-   * Creator - name of the user who created the deployment
+   * Creator - name of the user who created the deployment 
    * \# instances - number of existing instances of this node
    * Groups - nodes groups which the node is part of

--- a/widgets/nodesComputeNum/README.md
+++ b/widgets/nodesComputeNum/README.md
@@ -5,5 +5,5 @@ Displays the total number of compute nodes created on the tenant, according to t
 
 
 ## Settings
-
+ 
 * `Refresh time interval` - The time interval in which the widget’s data will be refreshed, in seconds. Default: 30 seconds.

--- a/widgets/nodesStats/README.md
+++ b/widgets/nodesStats/README.md
@@ -1,5 +1,5 @@
 # Nodes Statistics
-Displays the number of node instances, according to their status.
+Displays the number of node instances, according to their status. 
 
 ![node-statistics]( /images/ui/widgets/node-statistics.png )
 

--- a/widgets/onlyMyResources/README.md
+++ b/widgets/onlyMyResources/README.md
@@ -1,5 +1,5 @@
 # Only my resources
-Shows a toggle allowing to filter only resources created by the logged in user. The supported resources are blueprints, deployments, plugins and snapshots.
+Shows a toggle allowing to filter only resources created by the logged in user. The supported resources are blueprints, deployments, plugins and snapshots. 
 
 ![only-my-resources]( /images/ui/widgets/only_my_resources.png )
 

--- a/widgets/outputs/README.md
+++ b/widgets/outputs/README.md
@@ -1,11 +1,11 @@
 # Deployment Outputs
 
-Presents the names and values of the outputs and capabilities of a specific deployment. The deployment can be selected in one of the following ways:
+Presents the names and values of the outputs and capabilities of a specific deployment. The deployment can be selected in one of the following ways: 
 
-* By placing the deployment outputs widget in the deployments drill-down page, meaning the deployment has been selected before entering the page, and its id is included in the page’s context.
+* By placing the deployment outputs widget in the deployments drill-down page, meaning the deployment has been selected before entering the page, and its id is included in the page’s context. 
 * By adding to the page a widget allowing to select deployments, such as the resources filter or the blueprint deployments.   
 
-If only a blueprint was selected, the widget will present the default values for the outputs, defined in the blueprint itself.
+If only a blueprint was selected, the widget will present the default values for the outputs, defined in the blueprint itself. 
 
 ![deployment-outputs]( /images/ui/widgets/deployment-outputs.png )
 
@@ -13,4 +13,4 @@ If only a blueprint was selected, the widget will present the default values for
 ## Settings
 
 * `Refresh time interval` - The time interval in which the widget’s data will be refreshed, in seconds. Default: 10 seconds
-* `Show capabilities` - Specify if deployment capabilities should be visible in table. Default: true
+* `Show capabilities` - Specify if deployment capabilities should be visible in table. Default: true 

--- a/widgets/pluginUploadButton/README.md
+++ b/widgets/pluginUploadButton/README.md
@@ -1,5 +1,5 @@
 # Plugin upload button
-Opens the plugin upload screen, from which permitted users can specify the plugin’s wagon and yaml file (URL or local files) and visibility level of the plugins they wish to upload to the current tenant.
+Opens the plugin upload screen, from which permitted users can specify the plugin’s wagon and yaml file (URL or local files) and visibility level of the plugins they wish to upload to the current tenant. 
 
 ![plugin upload button]( /images/ui/widgets/plugin_upload_button.png )
 

--- a/widgets/plugins/README.md
+++ b/widgets/plugins/README.md
@@ -1,5 +1,5 @@
 # Plugins List
-Displays a list of all the plugins uploaded to the current tenant, according to the user’s permissions, and enables their management. From this widget you can upload, delete, and download the plugins.
+Displays a list of all the plugins uploaded to the current tenant, according to the user’s permissions, and enables their management. From this widget you can upload, delete, and download the plugins. 
 
 ## Features
 
@@ -15,9 +15,9 @@ The widget displays the following information:
 * **Distribution the plugin is supported on**
 * **Distribute release**
 * **Uploaded at**
-* **Creator**
-
-Upon hovering over ID label a pop up with the plugin’s ID will open, allowing you to copy it to the clipboard.
+* **Creator** 
+   
+Upon hovering over ID label a pop up with the plugin’s ID will open, allowing you to copy it to the clipboard. 
 
 ![Plugins list]( /images/ui/widgets/plugins-list.png )
 
@@ -45,5 +45,5 @@ Click **Delete** icon on the right side of the plugin row and confirm deletion i
 
 
 ## Settings
-
+ 
 * `Refresh time interval` - The time interval in which the widget’s data will be refreshed, in seconds. Default: 30 seconds.

--- a/widgets/pluginsCatalog/README.md
+++ b/widgets/pluginsCatalog/README.md
@@ -1,10 +1,10 @@
 # Plugins Catalog
-A widget listing all the latest releases of the certified plugins, allowing plugin upload to the current tenant.
+A widget listing all the latest releases of the officially supported Cloudify plugins, and allows uploading them to the current tenant. 
 
 ![plugins_catalog]( /images/ui/widgets/plugins-catalog.png )
 
 
 ## Settings
 
-* `Plugins Catalog JSON Source`  - The json file from which the widget reads the plugins list.
+* `Plugins Catalog JSON Source`  - The json file from which the widget reads the plugins list. 
 * `Sort by name` -  if set to true, then plugins will be sorted by name. Default: No

--- a/widgets/pluginsNum/README.md
+++ b/widgets/pluginsNum/README.md
@@ -1,6 +1,6 @@
 # Number of plugins
-Displays the total number of plugins in the tenant, according to the user’s permissions and the blueprints’ visibility levels.
-The widget is clickable, and upon clicking will redirect by default to the "System Resources" page. You can set the widget’s configuration to lead to a different page.
+Displays the total number of plugins in the tenant, according to the user’s permissions and the blueprints’ visibility levels. 
+The widget is clickable, and upon clicking will redirect by default to the "System Resources" page. You can set the widget’s configuration to lead to a different page. 
 
 ![number_of_plugins]( /images/ui/widgets/num_of_plugins.png )
 

--- a/widgets/secrets/README.md
+++ b/widgets/secrets/README.md
@@ -2,7 +2,7 @@
 Displays all the secrets visible to the logged-in user in the current tenant (including global secrets). The widget provides the following information:
 
 * **Secret key**
-* **Secret visibility level** represented by the icon next to the key. Permitted users (the secret’s creator, sys admins or tenant managers of the current tenant) can set the secret’s visibility by clicking on this icon.
+* **Secret visibility level** represented by the icon next to the key. Permitted users (the secret’s creator, sys admins or tenant managers of the current tenant) can set the secret’s visibility by clicking on this icon. 
 * **Secret value** If the secret’s value is not hidden from the logged-in user, clicking on the “eye” icon will present its value, like in the following example, in which the logged-in user is a sys admin:
 
 
@@ -13,18 +13,18 @@ If the secret’s value is hidden and the logged-in user isn’t the secret’s 
 ![hidden-value-user]( /images/ui/widgets/hidden_secret_unauth_user.png )
 
 
-* **Hidden Value** Indicates if the secret’s value is hidden of not. If the logged-in user is the secret’s creator, or has admin/manager permissions in the tenant, checking/unchecking this field will be enabled, and will make the secret hidden/non-hidden.
+* **Hidden Value** Indicates if the secret’s value is hidden of not. If the logged-in user is the secret’s creator, or has admin/manager permissions in the tenant, checking/unchecking this field will be enabled, and will make the secret hidden/non-hidden. 
 * **Creation time**
 * **Last update time**
 * **Creator**
-* **Tenant** The name of the tenant the secret belongs to (if the secret is global, it might belong to a tenant different than the current one).
-
+* **Tenant** The name of the tenant the secret belongs to (if the secret is global, it might belong to a tenant different than the current one). 
+ 
 The right column of the table allows permitted users (secret creator, sys admin or tenant managers) to edit the secret’s value or delete it.
-Even if the secret’s value is hidden from users, they might still be able to use the secret by providing its key in the blueprint.
+Even if the secret’s value is hidden from users, they might still be able to use the secret by providing its key in the blueprint. 
 
-To better understand how secrets work in {{< param product_name >}}, go to [Secret Store page](/developer/blueprints/spec-secretstore) or [Using the Secret Store page](/working_with/manager/using-secrets).
+To better understand how secrets work in Cloudify, go to [Secret Store page](/developer/blueprints/spec-secretstore) or [Using the Secret Store page](/working_with/manager/using-secrets).
 
 
 ## Settings
-
+ 
 * `Refresh time interval` - The time interval in which the widget’s data will be refreshed, in seconds. Default: 30 seconds.

--- a/widgets/serversNum/README.md
+++ b/widgets/serversNum/README.md
@@ -5,5 +5,5 @@ Displays the total number of nodes created on the tenant, according to the userâ
 
 
 ## Settings
-
+ 
 * `Refresh time interval` - The time interval in which the widgetâ€™s data will be refreshed, in seconds. Default: 30 seconds.

--- a/widgets/sites/README.md
+++ b/widgets/sites/README.md
@@ -58,5 +58,5 @@ Deleting a site will remove the assignment of this site from all assigned deploy
 
 
 ## Settings
-
+ 
 * `Refresh time interval` - The time interval in which the widget’s data will be refreshed, in seconds. Default: 30 seconds.

--- a/widgets/sitesMap/README.md
+++ b/widgets/sitesMap/README.md
@@ -4,7 +4,7 @@ Displays the world map with defined sites marked. Only sites with defined locati
 ![sitesMap]( /images/ui/widgets/sitesMap.png )
 
 <div class="ui message info">
-This widget is available with Premium or Spire license.
+The widget is available only when Premium or Spire license is activated on the Cloudify Manager.
 </div>
 
 
@@ -26,12 +26,12 @@ Site details contain information about deployments' statuses, indicated as follo
 
 ## Map provider
 
-Sites Map widget uses [Leaflet](https://leafletjs.com/) library for displaying interactive map.
+Sites Map widget uses [Leaflet](https://leafletjs.com/) library for displaying interactive map. 
 The library can display various types of maps from different providers.
 The list of all supported providers can be found in [leaflet-providers](https://github.com/leaflet-extras/leaflet-providers) repository.
 
 Sites Map widget with default configuration displays map tiles provided by [Stadia Maps](https://stadiamaps.com/).
-You can change the provider in [User Configuration](/working_with/console/customization/user-configuration).
+You can change the provider in [User Configuration](/working_with/console/customization/user-configuration). 
 
 
 ## Settings

--- a/widgets/snapshots/README.md
+++ b/widgets/snapshots/README.md
@@ -1,6 +1,6 @@
 # Snapshots List
 
-Displays a list of snapshots of the Manager - both snapshots that were created on this manager, and snapshots uploaded to it.
+Displays a list of snapshots of the Manager - both snapshots that were created on this manager, and snapshots uploaded to it. 
 
 <div class="ui message info">
 * This widget is only available to users with the ‘admin’ role.
@@ -11,7 +11,7 @@ Displays a list of snapshots of the Manager - both snapshots that were created o
 
 ## Features
 
-### Snapshot basic information
+### Snapshot basic information 
 
 The widget exposes the following information on each snapshot:
 
@@ -37,7 +37,7 @@ The widget also exposes the following operations by the buttons on the top right
 
 #### Creating a Snapshot
 
-The snapshots creation process captures the data of the entire {{< param cfy_manager_name >}}, not just that of a specific tenant. However, the snapshot is created in the context of the current tenant, and therefore must be restored from it.
+The snapshots creation process captures data in the entire Cloudify Manager, not just that of a specific tenant. However, the snapshot is created in the context of the current tenant, and therefore must be restored from it.
 
 1. Click **Create** button above the Snapshots table.
 2. Specify a unique ID for the snapshot and click **Create** button.   
@@ -50,7 +50,7 @@ The snapshot is saved as a ZIP file and appears in the Snapshots table, together
 
 #### Restoring a Snapshot
 
-If you restore a snapshot to a {{< param cfy_manager_name >}} instance that already contains data, that data is overwritten. To prevent inadvertent overwriting of existing data, you must explicitly state that you want to force data overwrite.
+If you restore a snapshot to a Cloudify Manager instance that already contains data, that data is overwritten. To prevent inadvertent overwriting of existing data, you must explicity state that you want to force data overwrite.
 
 1. Click **Upload** button in the widget.
 2. Either enter the URL of the snapshot or select the snapshot file from your file repository.
@@ -58,8 +58,8 @@ If you restore a snapshot to a {{< param cfy_manager_name >}} instance that alre
 4. Click **Upload** button and see that snapshot was uploaded and is available in Snapshots table.
 5. Click Restore icon ![Restore icon]( /images/ui/icons/restore-icon.png ) on the far right of newly uploaded snapshot's row
    * To restore a snapshot from a tenant-less (legacy) environment, toggle the relevant button.
-   * To overwrite all content in the existing {{< param cfy_manager_name >}}, toggle the relevant button.
-6. Click **Restore**.
+   * To overwrite all content in the existing Cloudify Manager, toggle the relevant button.
+6. Click **Restore**. 
 7. The snapshot is restored and its details appear in the Snapshots table.
 
 #### Downloading a Snapshot
@@ -71,7 +71,7 @@ If you restore a snapshot to a {{< param cfy_manager_name >}} instance that alre
 #### Deleting a Snapshot
 
 1. Click Delete icon ![Delete icon]( /images/ui/icons/delete-icon.png ) for the snapshot entry that you want to delete.
-2. Click **Yes** to delete the snapshot from the {{< param cfy_manager_name >}}.
+2. Click **Yes** to delete the snapshot from Cloudify Manager.
 
 
 ## Settings

--- a/widgets/tenants/README.md
+++ b/widgets/tenants/README.md
@@ -1,5 +1,5 @@
 # Tenant Management
-Displays a list of tenants on the Manager and enables tenant management.
+Displays a list of tenants on the Manager and enables tenant management. 
 
 <div class="ui message info">
 This widget is only available to admin users.
@@ -17,19 +17,19 @@ The widget displays the following information regarding each of the tenants:
 * **Name**
 * **Number of user-groups assigned to the tenant**
 * **Number of users directly assigned to the tenant** (not as part of groups)
-
+ 
 
 ### Tenants actions
 
 The hamburger menu on the right of every tenant allows performing the following operations:
 
 * Adding/removing users to/from the tenant
-* Adding/removing user-groups to/from the tenant
-* Deleting the tenant - possible only if the tenant has no users. User-groups or resources associated with it.
+* Adding/removing user-groups to/from the tenant 
+* Deleting the tenant - possible only if the tenant has no users. User-groups or resources associated with it. 
 
-Also, using the “Add” button on the right top corner of the widget, you will be able to create new tenants.
+Also, using the “Add” button on the right top corner of the widget, you will be able to create new tenants. 
 
 
 ## Settings
-
+ 
 * `Refresh time interval` - The time interval in which the widget’s data will be refreshed, in seconds. Default: 30 seconds.

--- a/widgets/text/README.md
+++ b/widgets/text/README.md
@@ -1,13 +1,13 @@
 # Text
-Displays text provided in the configuration of the widget in markdown syntax.
+Displays text provided in the configuration of the widget in markdown syntax. 
 
 ![text-widget]( /images/ui/widgets/text_widget_content.png )
 
 
 ## Settings
-
+ 
 * `Header` - the header to be presented as the textbox’s title
-* `Content` - the text to be presented in the textbox itself, in Markdown syntax.
+* `Content` - the text to be presented in the textbox itself, in Markdown syntax. 
 * `Header text color` - Can be picked out of the suggested colors
 * `Header text size (px)` - Size of the header
 * `Header text font` - Font of the header

--- a/widgets/topology/README.md
+++ b/widgets/topology/README.md
@@ -2,9 +2,9 @@
 
 Displays the topology of a selected blueprint or deployment.
 
-The blueprint or deployment ID must be selected in one of the following ways:
+The blueprint or deployment ID must be selected in one of the following ways: 
 
-* By placing the widget in the blueprints/deployments drill-down page, meaning the blueprint/deployment has been selected before entering the page, and its id is included in the page’s context.
+* By placing the widget in the blueprints/deployments drill-down page, meaning the blueprint/deployment has been selected before entering the page, and its id is included in the page’s context. 
 * By adding to the page a widget allowing to select blueprints or deployments, such as the resources filter, the blueprints list or the blueprint deployments.  
 
 ![Topology]( /images/ui/widgets/topology.png )
@@ -13,17 +13,17 @@ The blueprint or deployment ID must be selected in one of the following ways:
 
 ### Presentation
 
-Each of the blueprint's nodes is displayed as a square container that can contain other nodes.
-Each node has a name, and an icon (upper right corner) to indicate its [node type](/developer/blueprints/spec-node-types).
+Each of the blueprint's nodes is displayed as a square container that can contain other nodes. 
+Each node has a name, and an icon (upper right corner) to indicate its [node type](/developer/blueprints/spec-node-types). 
 
 [Relationships](/developer/blueprints/spec-relationships) between nodes are indicated with arrows that start at the connected node and end at the target node.
 
 The number of node instances is marked in a bullet beside the node's type icon.
 
-Each node is provided with an icon (top left corner). For built-in node types it is the {{< param product_name >}} logo. For node types coming from [plugins](/developer/blueprints/spec-plugins) it is an icon selected during plugin upload (setting plugin icon is optional, by default a plug icon is used). 
+Each node is provided with an icon (top left corner). For built-in node types it is Cloudify logo. For node types coming from [plugins](/developer/blueprints/spec-plugins) it is an icon selected during plugin upload (setting plugin icon is optional, by default a plug icon is used). 
 See [Plugins widget](/working_with/console/widgets/plugins) or [Plugins Catalog widget](/working_with/console/widgets/pluginsCatalog) for more details.
 
-For **Component** nodes you can also see bottom right corner icons showing all plugins used by the component's internal nodes.
+For **Component** nodes you can also see bottom right corner icons showing all plugins used by the component's internal nodes. 
 
 ![Topology - multi plugins]( /images/ui/widgets/topology-widget_multi-plugins.png )
 
@@ -35,7 +35,7 @@ Node types used in [service composition](/working_with/service_composition/index
 ### Actions
 
 In Topology widget you can:
-
+ 
 * Pan around the view (drag'n'drop outside node)
 * Change location of the nodes (drag'n'drop inside node)
 * Zoom in/out (using mouse wheel)     
@@ -50,12 +50,12 @@ It allows you to make changes in the view:
 * **Zoom in** the topology
 * **Zoom out** the topology
 * **Fit topology to screen**
-* **Save layout** - save location of the nodes (the location is saved per blueprint per user)
+* **Save layout** - save location of the nodes (the location is saved per blueprint per user) 
 * **Revert layout changes** - revert the location of the nodes to the previous state
 * **Auto layout** - automatically distribute the nodes on the canvas
 
 
-### Terraform support
+### Terraform support 
 
 Terraform nodes created using [Terraform plugin](/working_with/official_plugins/orchestration/terraform)
 are treated in a special way. There are dedicated action icons in the bottom left corner of such nodes:
@@ -91,7 +91,7 @@ When executing a workflow for a deployment (e.g. the `install` workflow), the to
 When you hover over the badge and the topology is displayed for specific deployment (not a blueprint), then you will see summary of node instances states related to specific node:
 
 ![Deployment Topology Node Instances Details]( /images/ui/widgets/topology-widget-node-instances-details.png )
-
+ 
 
 #### Workflow states represented by badges
 
@@ -124,14 +124,14 @@ When you hover over the badge and the topology is displayed for specific deploym
     ![Deployment Topology Execution Completed Errors]( /images/ui/widgets/topology-widget-7.png )
 
 
-## Settings
+## Settings 
 
 * `Refresh time interval` - The time interval in which the widget’s data will be refreshed, in seconds. Default: 10 seconds.
 
-The following settings allow changing the presentation of the widget in different aspects, and are by default marked as “on”:
+The following settings allow changing the presentation of the widget in different aspects, and are by default marked as “on”: 
 
-* `Enable node click`
-* `Enable group click`
-* `Enable zoom`
-* `Enable drag`
-* `Show toolbar`
+* `Enable node click` 
+* `Enable group click` 
+* `Enable zoom` 
+* `Enable drag` 
+* `Show toolbar` 

--- a/widgets/userGroups/README.md
+++ b/widgets/userGroups/README.md
@@ -1,5 +1,5 @@
 # User Group Management
-Displays the list of user groups and enables their management.
+Displays the list of user groups and enables their management. 
 
 <div class="ui message info">
 This widget is only available to admin users.
@@ -14,25 +14,25 @@ This widget is only available to admin users.
 The widget displays the following information regarding each of the user groups:
 
 * **Name**
-* **LDAP group** When working with an ldap-based external authentication system, this fields identifies the LDAP user group which is connected to the current {{< param product_name >}} user-group.
-* **Admin** If checked, all users who are members of this groups will have the role of sys-admins on the manager.
+* **LDAP group** When working with an ldap-based external authentication system, this fields identifies the LDAP user group which is connected to the current Cloudify user-group. 
+* **Admin** If checked, all users who are members of this groups will have the role of sys-admins on the manager. 
 * **# Users** number of users who are members of the group
 * **# Tenants** number of tenants the user-group is assigned with.
 
-
+ 
 ### User Groups actions
 
 The hamburger menu on the right of every tenant allows performing the following operations:
 
-* **Adding/removing users to/from the group** available only if managing the users in {{< param product_name >}} itself
+* **Adding/removing users to/from the group** available only if managing the users in Cloudify itself
 * **Adding/removing user groups to/from the tenant**
-* **Deleting the user groups** - possible only if there are no users who are members in the groups, and the group is not assigned with any tenants.
-Also, using the “Add” button on the right top corner of the widget, you will be able to create new user groups.
+* **Deleting the user groups** - possible only if there are no users who are members in the groups, and the group is not assigned with any tenants. 
+Also, using the “Add” button on the right top corner of the widget, you will be able to create new user groups. 
 
 
 #### Adding a User Group
 
-Users groups are not mandatory when you manage users in {{< param product_name >}}, however creating groups might enable you to manage your users more efficiently. You can create groups of users and assign them to one or more tenants, specifying a tenant-role that will apply to all the users in the group.
+Users groups are not mandatory when you manage users in Cloudify, however creating groups might enable you to manage your users more efficiently. You can create groups of users and assign them to one or more tenants, specifying a tenant-role that will apply to all the users in the group.
 Please notice that by belonging to several groups, users might be assigned to a tenant with more than one role. As each role represents a set of permissions, if even one of those roles allows the users to perform an action in the tenant, they will indeed be able to perform it.
 
 1. Click **Add** in the User Groups Management widget.
@@ -42,7 +42,7 @@ Please notice that by belonging to several groups, users might be assigned to a 
 4. Check **Admin** checkbox if you want group members to have administrator privileges.
 5. Click **Add**.
 
-Like Users, User-Groups need to be assigned with tenants in order to access {{< param product_name >}} resources. The assignment of a group to a tenant is done in the exact same manner as single users, and likewise require specifying a role in the tenant.
+Like Users, User-Groups need to be assigned with tenants in order to access Cloudify resources. The assignment of a group to a tenant is done in the exact same manner as single users, and likewise require specifying a role in the tenant.
 
 
 #### Adding User Groups to a Tenant
@@ -62,5 +62,5 @@ All users within the group, unless they have a deactivated status, can perform a
 
 
 ## Settings
-
+ 
 * `Refresh time interval` - The time interval in which the widget’s data will be refreshed, in seconds. Default: 30 seconds.

--- a/widgets/userManagement/README.md
+++ b/widgets/userManagement/README.md
@@ -1,5 +1,5 @@
 # User Management
-Displays the list of users and enables their management.
+Displays the list of users and enables their management. 
 
 <div class="ui message info">
 This widget is only available to admin users.
@@ -10,26 +10,26 @@ This widget is only available to admin users.
 ## Features
 
 ### Users information
-
+ 
 The widget displays the following information regarding each of the user groups:
 
 * **Username**
 * **Last login timestamp**
-* **Admin** - whether or not the user is sys admin on the {{< param cfy_manager_name >}} (you can check and uncheck this filed to make changes)
-* **Active** - whether or not the user is active (you can check and uncheck this field to make changes)
+* **Admin** - whether or not the user is sys admin on the Cloudify manager (you can check and uncheck this filed to make changes)
+* **Active** - whether or not the user is active (you can check and uncheck this field to make changes) 
 * **# Groups** - number of groups the user is a member of
 * **# Tenants** - number of tenants the user is assigned with
 
 
 ### Users actions
-
+ 
 The hamburger menu on the right of every tenant allows performing the following operations:
 
 * **Setting the user’s password**
 * **Adding/removing the user to/from user groups**
-* **Assigning/Unassigning the user with/from the tenant**
-* **Deleting the user** - possible only if the user does not belong to any groups, assigned to any tenants and is the creator of any resources on the manager.
-
+* **Assigning/Unassigning the user with/from the tenant** 
+* **Deleting the user** - possible only if the user does not belong to any groups, assigned to any tenants and is the creator of any resources on the manager. 
+ 
 Also, using the “Add” button on the right top corner of the widget, you will be able to create new users.
 Please notice that if you choose to use external authentication for users (e.g. LDAP), creation or deletion of local users, as well as assignments of local users with groups are not allowed to prevent conflicts between the two systems which might cause security problems.
 
@@ -47,7 +47,7 @@ Please notice that if you choose to use external authentication for users (e.g. 
 
 #### Assigning Users to Tenants
 
-Users must be assigned to tenants with a specific role for each tenant. The roles are sets of permissions defining what actions the users can perform in the context of the tenant. Users can have different roles in different tenants, and as long as at least one of those roles allows them to perform an action in the tenant, they will be able to perform it. The available tenant-roles are: viewer, user, operations and manager. For more information regarding each role and the differences between them, see [Roles Management section](/working_with/manager/user-management#roles-management-with-ldap).
+Starting with Cloudify 4.2, users must be assigned to tenants with a specific role for each tenant. The roles are sets of permissions defining what actions the users can perform in the context of the tenant. Users can have different roles in different tenants, and as long as at least one of those roles allows them to perform an action in the tenant, they will be able to perform it. The available tenant-roles are: viewer, user, operations and manager. For more information regarding each role and the differences between them, see [Roles Management section](/working_with/manager/user-management#roles-management-with-ldap).
 
 1. Click the List icon ![List icon]( /images/ui/icons/list-icon.png ) on the far right of the user entry in the table that you want to add to a tenant.
 2. Click **Edit user's tenants**.
@@ -66,7 +66,7 @@ Unless the users have a deactivated status, they can perform actions on the tena
 You can remove a user from a group or a tenant, without deleting them from the system.
 
 1. Click the List icon ![List icon]( /images/ui/icons/list-icon.png ) for the user that you want to remove.
-2. Select **Edit user's groups** or **Edit user's Tenants**.
+2. Select **Edit user's groups** or **Edit user's Tenants**. 
 3. Remove the desired groups/tenants from the user's list.
 4. Click **Save**.
 
@@ -81,6 +81,6 @@ Users can only be deleted from the system if they are not assigned to a group or
 2. Click **Delete**.   
 
 
-## Settings
+## Settings 
 
 * `Refresh time interval` - The time interval in which the widget’s data will be refreshed, in seconds. Default: 30 seconds.


### PR DESCRIPTION
As per discussion with Ofer:
* we don't have branch for 5.2.x releases
* 5.2 documentation is expected to be at `5.1-build` branch
I'm changing `rawContentBasePath` to point to `5.1-build` branch and updating all `README.md` files accordingly.

This is mainly to unblock https://github.com/cloudify-cosmo/cloudify-stage/pull/1407.