### PR TITLE
RD-2589 Disable flaky agents_spec tests

### DIFF
--- a/test/cypress/integration/widgets/agents_spec.ts
+++ b/test/cypress/integration/widgets/agents_spec.ts
@@ -1,4 +1,5 @@
-describe('Agents widget', () => {
+// TODO(RD-2589): fix the flakiness and enable the tests
+describe.skip('Agents widget', () => {
     const blueprintName = 'agents_test_blueprint';
     const deploymentName = 'agents_test_deployment';
 


### PR DESCRIPTION
The tests are failing from time to time which makes the CI runs unreliable.

The tests and the widget should be revisited in RD-2589 and fixed, after which the tests can be enabled.

## System tests

https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/753/pipeline

Queued 2021-06-11 12:27 CEST