### PR TITLE
RD-2600 Disable failing topology test

### DIFF
--- a/test/cypress/integration/widgets/topology_spec.ts
+++ b/test/cypress/integration/widgets/topology_spec.ts
@@ -144,7 +144,8 @@ describe('Topology', () => {
             cy.get('.scrollGlass').click();
         });
 
-        it('allows to open component deployment page', () => {
+        // TODO(RD-2600): fix the test and enable it
+        it.skip('allows to open component deployment page', () => {
             getGoToDeploymentPageButton().click({ force: true });
 
             cy.verifyLocation(


### PR DESCRIPTION
That test failed in https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/753/tests/ so according to our new rules, I am disabling it.

I have added RD-2600 to the next sprint.

## System tests

https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/754/pipeline

Queued 2021-06-11 13:46 CEST