### PR TITLE
RD-2027 Finalize renaming files to TS

### DIFF
--- a/scripts/getTsMigrationProgress.sh
+++ b/scripts/getTsMigrationProgress.sh
@@ -13,7 +13,7 @@ echo "Found $JS_FILES_COUNT JS/JSX files"
 TS_FILES=`find $DIRECTORIES_TO_CHECK -type f \( -name '*.ts' -o -name '*.tsx' \) ! -path '*node_modules*'`
 TS_FILES_COUNT=`echo "$TS_FILES" | wc -l`
 echo "Found $TS_FILES_COUNT TS/TSX files"
-TS_NOCHECK_COUNT=`grep '@ts-nocheck' $TS_FILES | wc -l`
+TS_NOCHECK_COUNT=`grep '@ts-nocheck' $TS_FILES | wc -l || true`
 echo "$TS_NOCHECK_COUNT out of these TS/TSX files have a '@ts-nocheck' header"
 
 TOTAL_FILES_COUNT=$(($JS_FILES_COUNT+$TS_FILES_COUNT))

--- a/scripts/getTsMigrationProgress.sh
+++ b/scripts/getTsMigrationProgress.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Prints the summary of the migration to TypeScript
+
+set -euo pipefail
+
+DIRECTORIES_TO_CHECK="app widgets test backend"
+echo "Inspecting files in directories: $DIRECTORIES_TO_CHECK"
+
+cd ..
+JS_FILES_COUNT=`find $DIRECTORIES_TO_CHECK -type f \( -name '*.js' -o -name '*.jsx' \) ! -path '*node_modules*' ! -name 'babel.config.js' | wc -l`
+echo "Found $JS_FILES_COUNT JS/JSX files"
+
+TS_FILES=`find $DIRECTORIES_TO_CHECK -type f \( -name '*.ts' -o -name '*.tsx' \) ! -path '*node_modules*'`
+TS_FILES_COUNT=`echo "$TS_FILES" | wc -l`
+echo "Found $TS_FILES_COUNT TS/TSX files"
+TS_NOCHECK_COUNT=`grep '@ts-nocheck' $TS_FILES | wc -l`
+echo "$TS_NOCHECK_COUNT out of these TS/TSX files have a '@ts-nocheck' header"
+
+TOTAL_FILES_COUNT=$(($JS_FILES_COUNT+$TS_FILES_COUNT))
+
+function print_summary {
+    local name=$1
+    local files_count=$2
+    echo "$name: $files_count / $TOTAL_FILES_COUNT (`bc <<< "scale=2; $files_count * 100 / $TOTAL_FILES_COUNT"`%)"
+}
+
+TS_FULLY_MIGRATED_COUNT=$(($TS_FILES_COUNT - $TS_NOCHECK_COUNT))
+printf "\nSummary:\n"
+print_summary "JS/JSX" $JS_FILES_COUNT
+print_summary "TS/TSX" $TS_FILES_COUNT
+print_summary "Fully migrated TS/TSX" $TS_FULLY_MIGRATED_COUNT

--- a/test/cypress/tsconfig.json
+++ b/test/cypress/tsconfig.json
@@ -15,7 +15,7 @@
         "types": ["cypress"]
     },
     "include": ["**/*", "**/*.json"],
-    "files": ["../../app/typings/stage-api.d.ts", "../../babel.config.js"],
+    "files": ["../../app/typings/stage-api.d.ts"],
     // Some Stage.Common types used in tests are defined in widgets/common
     "references": [{ "path": "../../app" }, { "path": "../../widgets" }]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -4,6 +4,7 @@
         "declarationMap": false,
         "composite": true,
         "outDir": "./tsc-dist",
-        "rootDir": "."
+        "rootDir": ".",
+        "allowJs": false
     }
 }


### PR DESCRIPTION
This PR disables importing JS files in TS files, which is some automation to prevent us from going back to JS :smile: 

Besides, I have added a script for calculating how many JS/TS/fully migrated TS files are there in the repo.

I have created https://docs.google.com/spreadsheets/d/1pDXaJHCUZWTYbhoHl9pc07VdRwre85Yx7OoRH9xtLzg/edit#gid=0 to track it over time.

## System tests

The only changes are TS config, so if `npm run check-types` passes in Multibranch CI, the PR is good to go. There is no need for full tests.

Just to be sure, I'll run them on Monday, as the logs will probably be erased anyway over the weekend.