### PR TITLE
RD-410 Fix "Show related entities" icon placement

### DIFF
--- a/widgets/executions/src/tasksGraph/GraphNode.tsx
+++ b/widgets/executions/src/tasksGraph/GraphNode.tsx
@@ -87,7 +87,8 @@ const GraphNode = ({ graphNode, toolbox }) => {
                 >
                     <Icon
                         name="file alternate outline"
-                        style={{ fontSize: '1.3em', cursor: 'pointer' }}
+                        // NOTE: `display: inline` to fix a rendering bug in webkit
+                        style={{ fontSize: '1.3em', cursor: 'pointer', display: 'inline' }}
                         title="Show related entries in Deployment Events/Logs widget"
                         onClick={() => {
                             const context = toolbox.getContext();


### PR DESCRIPTION
Fix the placement of the "Show related entities" icon of the task graph in the Executions widget.

On Safari and other webkit engines, the icon appeared to be positioned with respect to the root of the graph (the 0,0 position) instead of each graph node.

Adding `display: inline` to the icon fixes the problem and it is consistently positioned correctly across Chrome, Firefox, Epiphany (uses webkit on Ubuntu) browsers.

## Screenshots

<details>
<summary>Chrome</summary>

![image](https://user-images.githubusercontent.com/889383/121887734-68bb9d80-cd17-11eb-82fc-d4372286eb76.png)
![image](https://user-images.githubusercontent.com/889383/121887754-6d805180-cd17-11eb-8665-e4f208276cd9.png)

</details>

<details>
<summary>Firefox</summary>

![image](https://user-images.githubusercontent.com/889383/121887807-7cff9a80-cd17-11eb-86ad-d386aed40c5e.png)
![image](https://user-images.githubusercontent.com/889383/121887919-a9b3b200-cd17-11eb-89f2-40960d812119.png)

</details>

<details>
<summary>Epiphany browser (where the problem appeared before the PR)</summary>

Before:
![image](https://user-images.githubusercontent.com/889383/121888292-1a5ace80-cd18-11eb-90a9-537458570099.png)

After:
![image](https://user-images.githubusercontent.com/889383/121888002-c05a0900-cd17-11eb-87e7-33dbd660f004.png)
![image](https://user-images.githubusercontent.com/889383/121888064-d667c980-cd17-11eb-8f37-b4a37db82ae3.png)


</details>

## System tests

I don't see how it could break the system tests :smile: I have verified that the functionality is working by clicking on the icon manually. Thus, I do not plan to run system tests for this PR