### PR TITLE
RD-1072 Fix misalignment when displaying parameter values

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "react-sortable-hoc": "^1.11.0",
     "react-splitter-layout": "^3.0.0",
     "react-svg-pan-zoom": "^3.8.0",
+    "react-syntax-highlighter": "^15.4.3",
     "react-visibility-sensor": "^5.1.1",
     "recharts": "^1.4.1",
     "redux": "^4.0.4",

--- a/widgets/common/src/ParameterValue.tsx
+++ b/widgets/common/src/ParameterValue.tsx
@@ -1,5 +1,6 @@
 // @ts-nocheck File not migrated fully to TS
 import { types } from 'cloudify-ui-common';
+import highlighterStyles from 'react-syntax-highlighter/dist/esm/styles/hljs/idea';
 
 /**
  * ParameterValue is a component which shows parameters (e.g. deployment/blueprint inputs, outputs, runtime properties, ...)
@@ -26,40 +27,21 @@ export default class ParameterValue extends React.Component {
             case 'array':
             case 'object':
                 return <HighlightText language="json">{stringValue}</HighlightText>;
-            case 'boolean':
-                return (
-                    <code style={commonStyle} className="hljs-keyword">
-                        {stringValue}
-                    </code>
-                );
             case 'number':
-                return (
-                    <code style={commonStyle} className="hljs-number">
-                        {stringValue}
-                    </code>
-                );
+                return <code style={{ ...commonStyle, ...highlighterStyles['hljs-number'] }}>{stringValue}</code>;
+            case 'boolean':
             case 'null':
-                return (
-                    <code style={commonStyle} className="hljs-keyword">
-                        {stringValue}
-                    </code>
-                );
+                return <code style={{ ...commonStyle, ...highlighterStyles['hljs-keyword'] }}>{stringValue}</code>;
             case 'string':
                 return Url.isUrl(stringValue) ? (
                     <a rel="noopener noreferrer" target="_blank" href={stringValue}>
                         {stringValue}
                     </a>
                 ) : (
-                    <code style={commonStyle} className="hljs-string">
-                        {stringValue}
-                    </code>
+                    <code style={{ ...commonStyle, ...highlighterStyles['hljs-string'] }}>{stringValue}</code>
                 );
             default:
-                return (
-                    <code style={commonStyle} className="hljs-literal">
-                        {stringValue}
-                    </code>
-                );
+                return <code style={{ ...commonStyle, ...highlighterStyles['hljs-literal'] }}>{stringValue}</code>;
         }
     }
 

--- a/widgets/common/src/ParameterValue.tsx
+++ b/widgets/common/src/ParameterValue.tsx
@@ -14,7 +14,12 @@ export default class ParameterValue extends React.Component {
         const { HighlightText } = Stage.Basic;
         const { Url } = Stage.Utils;
 
-        const commonStyle = { padding: '0.5em', whiteSpace: 'pre-wrap', wordBreak: 'break-word' };
+        const commonStyle = {
+            display: 'inline-block',
+            padding: '0.5em',
+            whiteSpace: 'pre-wrap',
+            wordBreak: 'break-word'
+        };
         const { value: typedValue } = this.props;
 
         switch (types.toType(typedValue)) {

--- a/widgets/common/src/ParameterValueDescription.tsx
+++ b/widgets/common/src/ParameterValueDescription.tsx
@@ -11,7 +11,7 @@ export default function ParameterValueDescription() {
             flowing
             header="Value style"
             content={
-                <List bulleted>
+                <List>
                     <List.Item>
                         String:
                         <ParameterValue value="centos_core" showCopyButton={false} />,


### PR DESCRIPTION
Fixed misalignment coming from parameter values, e.g. in this case:

https://user-images.githubusercontent.com/5202105/121895224-437f5d00-cd20-11eb-93f4-6c8e6cbfa760.mp4

See comments about additional small fixes.
