### PR TITLE
RD-1075 Reverted set of options accepted by doPatch

### DIFF
--- a/app/components/GettingStartedModal/installation/process.ts
+++ b/app/components/GettingStartedModal/installation/process.ts
@@ -65,11 +65,11 @@ export const createSecret = async (manager: Manager, secret: SecretInstallationT
 
 // TODO(RD-1874): use common api for backend requests
 export const updateSecret = async (manager: Manager, secret: SecretInstallationTask) => {
-    const data = {
+    const body = {
         value: secret.value
     };
     try {
-        await manager.doPatch(`/secrets/${encodeURIComponent(secret.name)}`, data);
+        await manager.doPatch(`/secrets/${encodeURIComponent(secret.name)}`, { body });
         return true;
     } catch (e) {
         log.error(e);

--- a/app/utils/External.ts
+++ b/app/utils/External.ts
@@ -49,8 +49,8 @@ export default class External {
         return this.ajaxCall(url, 'put', requestOptions);
     }
 
-    doPatch(url: string, body: Record<string, any>) {
-        return this.ajaxCall(url, 'PATCH', { body });
+    doPatch(url: string, requestOptions: RequestOptions) {
+        return this.ajaxCall(url, 'PATCH', requestOptions);
     }
 
     doDownload(url: string, fileName: string) {

--- a/widgets/common/src/BlueprintActions.ts
+++ b/widgets/common/src/BlueprintActions.ts
@@ -171,7 +171,7 @@ export default class BlueprintActions {
     }
 
     doSetVisibility(blueprintId: string, visibility: string) {
-        return this.toolbox.getManager().doPatch(`/blueprints/${blueprintId}/set-visibility`, { visibility });
+        return this.toolbox.getManager().doPatch(`/blueprints/${blueprintId}/set-visibility`, { body: { visibility } });
     }
 
     doListYamlFiles(blueprintUrl: string, file = null, includeFilename = false) {

--- a/widgets/common/src/DeploymentActions.ts
+++ b/widgets/common/src/DeploymentActions.ts
@@ -98,7 +98,9 @@ export default class DeploymentActions {
     }
 
     doSetVisibility(deploymentId: string, visibility: any) {
-        return this.toolbox.getManager().doPatch(`/deployments/${deploymentId}/set-visibility`, { visibility });
+        return this.toolbox
+            .getManager()
+            .doPatch(`/deployments/${deploymentId}/set-visibility`, { body: { visibility } });
     }
 
     doSetSite(deploymentId: string, siteName: string, detachSite: any) {
@@ -134,7 +136,7 @@ export default class DeploymentActions {
 
     doSetLabels(deploymentId: string, deploymentLabels: Stage.Common.Labels.Label[]) {
         const labels = DeploymentActions.toManagerLabels(deploymentLabels);
-        return this.toolbox.getManager().doPatch(`/deployments/${deploymentId}`, { labels });
+        return this.toolbox.getManager().doPatch(`/deployments/${deploymentId}`, { body: { labels } });
     }
 
     doGetLabel(key: string, value: string) {

--- a/widgets/common/src/PluginActions.ts
+++ b/widgets/common/src/PluginActions.ts
@@ -36,7 +36,7 @@ class PluginActions {
     }
 
     doSetVisibility(pluginId, visibility) {
-        return this.toolbox.getManager().doPatch(`/plugins/${pluginId}/set-visibility`, { visibility });
+        return this.toolbox.getManager().doPatch(`/plugins/${pluginId}/set-visibility`, { body: { visibility } });
     }
 }
 

--- a/widgets/common/src/SecretActions.ts
+++ b/widgets/common/src/SecretActions.ts
@@ -21,15 +21,15 @@ class SecretActions {
     }
 
     doUpdate(key, value) {
-        return this.toolbox.getManager().doPatch(`/secrets/${key}`, { value });
+        return this.toolbox.getManager().doPatch(`/secrets/${key}`, { body: { value } });
     }
 
     doSetIsHiddenValue(key, hidden) {
-        return this.toolbox.getManager().doPatch(`/secrets/${key}`, { is_hidden_value: hidden });
+        return this.toolbox.getManager().doPatch(`/secrets/${key}`, { body: { is_hidden_value: hidden } });
     }
 
     doSetVisibility(key, visibility) {
-        return this.toolbox.getManager().doPatch(`/secrets/${key}/set-visibility`, { visibility });
+        return this.toolbox.getManager().doPatch(`/secrets/${key}/set-visibility`, { body: { visibility } });
     }
 }
 

--- a/widgets/filters/src/FilterActions.ts
+++ b/widgets/filters/src/FilterActions.ts
@@ -23,6 +23,8 @@ export default class FilterActions {
     }
 
     doUpdate(filterId: string, filterRules: FilterRule[]) {
-        return this.toolbox.getManager().doPatch(`/filters/deployments/${filterId}`, { filter_rules: filterRules });
+        return this.toolbox
+            .getManager()
+            .doPatch(`/filters/deployments/${filterId}`, { body: { filter_rules: filterRules } });
     }
 }

--- a/widgets/tenants/src/actions.ts
+++ b/widgets/tenants/src/actions.ts
@@ -37,9 +37,11 @@ export default class {
 
     doUpdateUser(tenantName, username, role) {
         return this.toolbox.getManager().doPatch('/tenants/users', {
-            username,
-            tenant_name: tenantName,
-            role
+            body: {
+                username,
+                tenant_name: tenantName,
+                role
+            }
         });
     }
 
@@ -72,9 +74,11 @@ export default class {
 
     doUpdateUserGroup(tenantName, userGroup, role) {
         return this.toolbox.getManager().doPatch('/tenants/user-groups', {
-            group_name: userGroup,
-            tenant_name: tenantName,
-            role
+            body: {
+                group_name: userGroup,
+                tenant_name: tenantName,
+                role
+            }
         });
     }
 

--- a/widgets/userGroups/src/actions.ts
+++ b/widgets/userGroups/src/actions.ts
@@ -62,7 +62,7 @@ export default class Actions {
     doUpdateTenant(tenantName, groupName, role) {
         return this.toolbox
             .getManager()
-            .doPatch('/tenants/user-groups', { tenant_name: tenantName, group_name: groupName, role });
+            .doPatch('/tenants/user-groups', { body: { tenant_name: tenantName, group_name: groupName, role } });
     }
 
     doHandleUsers(groupName, usersToAdd, usersToDelete) {

--- a/widgets/userManagement/src/actions.ts
+++ b/widgets/userManagement/src/actions.ts
@@ -36,7 +36,7 @@ export default class Actions {
             this.toolbox.getManager().doDelete('/tenants/users', { body: { username, tenant_name: tenantName } })
         );
         const updateActions = _.map(tenantsToUpdate, (role, tenantName) =>
-            this.toolbox.getManager().doPatch('/tenants/users', { username, tenant_name: tenantName, role })
+            this.toolbox.getManager().doPatch('/tenants/users', { body: { username, tenant_name: tenantName, role } })
         );
 
         return Promise.all(_.concat(addActions, deleteActions, updateActions));


### PR DESCRIPTION
This is similar to #1412.

As part of #1402 I removed some options that could be used with `doPatch` method. Even though the removed options are not used in our code base they should actually stay as they may be used by customers as they are documented in API documentation.

System tests: https://jenkins.cloudify.co/view/UI/job/Stage-UI-System-Test/776/