### PR TITLE
RD-2516 Use search name in Deployments View

### DIFF
--- a/test/cypress/integration/widgets/deployments_view_spec.ts
+++ b/test/cypress/integration/widgets/deployments_view_spec.ts
@@ -79,8 +79,8 @@ describe('Deployments View widget', () => {
 
     const getDeploymentsViewWidget = () =>
         cy.get('.widget').filter('.deploymentsViewWidget, .deploymentsViewDrilledDownWidget').find('.widgetItem');
-    const getDeploymentsViewTable = () => getDeploymentsViewWidget().get('.gridTable');
-    const getDeploymentsViewDetailsPane = () => getDeploymentsViewWidget().get('.detailsPane');
+    const getDeploymentsViewTable = () => getDeploymentsViewWidget().find('.gridTable');
+    const getDeploymentsViewDetailsPane = () => getDeploymentsViewWidget().find('.detailsPane');
     const getDeploymentsViewMap = () => getDeploymentsViewWidget().find('.leaflet-container');
     const getDeploymentsMapToggleButton = () => getDeploymentsViewWidget().contains('button', 'Map');
 

--- a/test/cypress/integration/widgets/deployments_view_spec.ts
+++ b/test/cypress/integration/widgets/deployments_view_spec.ts
@@ -617,6 +617,31 @@ describe('Deployments View widget', () => {
         cy.contains('Unexpected widget usage');
     });
 
+    it('should search both by the ID and the display name of deployments', () => {
+        useDeploymentsViewWidget();
+
+        const interceptSearchDeploymentsRequest = (searchPhrase: string) =>
+            // eslint-disable-next-line security/detect-non-literal-regexp
+            cy.interceptSp('POST', new RegExp(`^\\/searches\\/deployments\\?.*_search_name=${searchPhrase}`));
+
+        const showEmptyTable = () => {
+            cy.getSearchInput().type('some gibberish to make the table display no results');
+            getDeploymentsViewTable().contains('No Results Found');
+        };
+
+        showEmptyTable();
+        interceptSearchDeploymentsRequest(deploymentId).as('searchForDeploymentId');
+        cy.getSearchInput().clear().type(deploymentId);
+        cy.wait('@searchForDeploymentId');
+        getDeploymentsViewTable().contains('tbody tr', deploymentName);
+
+        showEmptyTable();
+        interceptSearchDeploymentsRequest(deploymentName).as('searchForDeploymentName');
+        cy.getSearchInput().clear().type(deploymentName);
+        cy.wait('@searchForDeploymentName');
+        getDeploymentsViewTable().contains('tbody tr', deploymentName);
+    });
+
     describe('map', () => {
         const siteNames = {
             olsztyn: exampleSiteName,

--- a/test/cypress/integration/widgets/deployments_view_spec.ts
+++ b/test/cypress/integration/widgets/deployments_view_spec.ts
@@ -17,7 +17,7 @@ describe('Deployments View widget', () => {
     const blueprintUrl = exampleBlueprintUrl;
     const widgetConfiguration: import('../../../../widgets/deploymentsView/src/widget').DeploymentsViewWidgetConfiguration = {
         filterByParentDeployment: false,
-        fieldsToShow: ['status', 'name', 'blueprintName', 'location', 'subenvironmentsCount', 'subservicesCount'],
+        fieldsToShow: ['status', 'id', 'name', 'blueprintName', 'location', 'subenvironmentsCount', 'subservicesCount'],
         pageSize: 100,
         customPollingTime: 10,
         sortColumn: 'created_at',
@@ -43,9 +43,9 @@ describe('Deployments View widget', () => {
     /** Column numbers as they appear in the table */
     const columnNumbers = {
         status: 1,
-        environmentType: 4,
-        subenvironments: 6,
-        subservices: 7
+        environmentType: 5,
+        subenvironments: 7,
+        subservices: 8
     };
 
     before(() => {

--- a/test/cypress/integration/widgets/deployments_view_spec.ts
+++ b/test/cypress/integration/widgets/deployments_view_spec.ts
@@ -6,6 +6,7 @@ import type { SystemLabel } from '../../support/deployments';
 import { exampleBlueprintUrl } from '../../support/resource_urls';
 import { FilterRuleAttribute, FilterRuleOperators, FilterRuleType } from '../../../../widgets/common/src/filters/types';
 import type {} from '../../../../widgets/common/src/deploymentsView';
+import { secondsToMs } from '../../support/resource_commons';
 
 describe('Deployments View widget', () => {
     const widgetId = 'deploymentsView';
@@ -74,7 +75,7 @@ describe('Deployments View widget', () => {
             { additionalWidgetIdsToLoad, widgetsWidth: 12, additionalPageTemplates: ['drilldownDeployments'] }
         ).mockLoginWithoutWaiting();
         cy.interceptSp('POST', /^\/searches\/deployments/, routeHandler).as('deployments');
-        cy.wait('@deployments');
+        cy.wait('@deployments', { requestTimeout: secondsToMs(10) });
     };
 
     const getDeploymentsViewWidget = () =>

--- a/test/cypress/integration/widgets/deployments_view_spec.ts
+++ b/test/cypress/integration/widgets/deployments_view_spec.ts
@@ -375,7 +375,7 @@ describe('Deployments View widget', () => {
 
             const getSelectedDeployment = () => getDeploymentsViewTable().find('tbody tr.active');
 
-            cy.setDeploymentContext(deploymentName);
+            cy.setDeploymentContext(deploymentId);
             getSelectedDeployment().contains(deploymentName);
             cy.setDeploymentContext(deploymentNameThatMatchesFilter);
             getSelectedDeployment().contains(deploymentNameThatMatchesFilter);

--- a/test/cypress/integration/widgets/deployments_view_spec.ts
+++ b/test/cypress/integration/widgets/deployments_view_spec.ts
@@ -75,7 +75,7 @@ describe('Deployments View widget', () => {
             { additionalWidgetIdsToLoad, widgetsWidth: 12, additionalPageTemplates: ['drilldownDeployments'] }
         ).mockLoginWithoutWaiting();
         cy.interceptSp('POST', /^\/searches\/deployments/, routeHandler).as('deployments');
-        cy.wait('@deployments', { requestTimeout: secondsToMs(10) });
+        cy.wait('@deployments', { requestTimeout: secondsToMs(15) });
     };
 
     const getDeploymentsViewWidget = () =>

--- a/test/cypress/support/deployments.ts
+++ b/test/cypress/support/deployments.ts
@@ -32,11 +32,17 @@ export type Label = SystemLabel & {
 
 const commands = {
     getDeployment: (deploymentId: string) => cy.cfyRequest(`/deployments/${deploymentId}`, 'GET'),
-    deployBlueprint: (blueprintId: string, deploymentId: string, inputs = {}) => {
+    deployBlueprint: (
+        blueprintId: string,
+        deploymentId: string,
+        inputs = {},
+        deploymentProperties: Record<string, any> = {}
+    ) => {
         cy.cfyRequest(`/deployments/${deploymentId}`, 'PUT', null, {
             blueprint_id: blueprintId,
             inputs,
-            visibility: 'tenant'
+            visibility: 'tenant',
+            ...deploymentProperties
         });
     },
     setSite: (deploymentId: string, siteName: string) => {

--- a/widgets/common/src/SearchActions.ts
+++ b/widgets/common/src/SearchActions.ts
@@ -2,6 +2,10 @@ import { FilterRule } from './filters/types';
 
 type ResourceName = 'blueprints' | 'deployments' | 'workflows';
 type Params = Record<string, any>;
+type ListDeploymentsParams = Stage.Types.ManagerGridParams & {
+    // eslint-disable-next-line camelcase
+    _search_name?: string;
+};
 
 export default class SearchActions {
     constructor(private toolbox: Stage.Types.Toolbox) {}
@@ -16,17 +20,30 @@ export default class SearchActions {
         return this.toolbox.getManager().doPostFull(`/searches/${resourceName}`, params, { filter_rules: filterRules });
     }
 
-    doListDeployments(filterRules: FilterRule[], params?: Params) {
-        return this.doList('deployments', filterRules, params);
+    doListDeployments(filterRules: FilterRule[], params?: ListDeploymentsParams) {
+        return this.doList('deployments', filterRules, searchAlsoByDeploymentName(params));
     }
 
-    doListAllDeployments(filterRules: FilterRule[], params?: Params) {
-        return this.doListAll('deployments', filterRules, params);
+    doListAllDeployments(filterRules: FilterRule[], params?: ListDeploymentsParams) {
+        return this.doListAll('deployments', filterRules, searchAlsoByDeploymentName(params));
     }
 
     doListAllWorkflows(filterRules: FilterRule[], params?: Params) {
         return this.doListAll('workflows', filterRules, params);
     }
+}
+function searchAlsoByDeploymentName(params?: ListDeploymentsParams): ListDeploymentsParams | undefined {
+    // NOTE: that's how backend properties are named
+    /* eslint-disable camelcase, no-underscore-dangle */
+    if (!params || params._search_name || !params._search) {
+        return params;
+    }
+
+    return {
+        ...params,
+        _search_name: params._search
+    };
+    /* eslint-enable camelcase, no-underscore-dangle */
 }
 
 declare global {


### PR DESCRIPTION
This PR implements specifying the `_search_name` query param when fetching deployments in the Deployments View widget. I have also added a test to verify that it works correctly, as well as a few minor improvements to the tests for that widget.

In my test, I needed to distinguish between the deployment ID and the name. Hence, I modified the deployments view spec to handle the ID and the display name for the main deployment (that is used in most tests) separately.

I have made it so that all consumers of `SearchActions` will now benefit from searching by both ID and display name of deployments.

Some changes may look confusing when looking at the full diff. If that's the case, look at a commit-by-commit view. I hope that helps.

## Dependency on the backend

https://github.com/cloudify-cosmo/cloudify-manager/pull/3123 is merged

## System tests

https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/834/pipeline

Queued 2021-06-24 10:30 CEST