### PR TITLE
RD-2589 Fix Agents widget tests

### DIFF
--- a/test/cypress/integration/widgets/agents_spec.ts
+++ b/test/cypress/integration/widgets/agents_spec.ts
@@ -83,7 +83,7 @@ describe('Agents widget', () => {
         function verifyExecution(
             executionPayload: Record<string, any>,
             expectedWorkflowId: string,
-            expectedInstallMethod: 'Remote' | 'Plugin' | 'Init Script' | 'Provided',
+            expectedInstallMethod: InstallMethods,
             expectedAdditionalParameters: Record<string, any> = {}
         ) {
             expect(executionPayload).to.deep.equal({

--- a/test/cypress/integration/widgets/agents_spec.ts
+++ b/test/cypress/integration/widgets/agents_spec.ts
@@ -1,41 +1,136 @@
-// TODO(RD-2589): fix the flakiness and enable the tests
-describe.skip('Agents widget', () => {
-    const blueprintName = 'agents_test_blueprint';
+import { camelCase, snakeCase, upperFirst } from 'lodash';
+import { secondsToMs } from '../../support/resource_commons';
+
+describe('Agents widget', () => {
+    const pollingTimeSeconds = 5;
     const deploymentName = 'agents_test_deployment';
+    const nodeName = 'host';
+    const nodeInstanceName = 'host_qz2p8t';
 
     before(() => {
         cy.usePageMock('agents', {
             fieldsToShow: ['Id', 'Node', 'Deployment', 'IP', 'Install Method', 'System', 'Version', 'Actions'],
-            pageSize: 15
+            pageSize: 15,
+            pollingTime: pollingTimeSeconds
         })
             .activate()
-            .mockLogin()
-            .deleteDeployments(deploymentName, true)
-            .deleteBlueprints(blueprintName, true)
-            .uploadBlueprint('blueprints/simple.zip', blueprintName)
-            .deployBlueprint(blueprintName, deploymentName, { server_ip: 'localhost' });
+            .mockLogin();
     });
 
-    it('should allow to validate agent', () => {
-        cy.contains('Validate').click();
-        cy.get('div[name=deploymentId] input').type(deploymentName);
-        cy.get('div[name=nodeId]').click();
-        cy.get('div[name=nodeId] .item').click();
-        cy.get('div[name=nodeInstanceId]').click();
-        cy.get('div[name=nodeInstanceId] .item').click();
-        cy.contains('.modal button', 'Validate').click();
-        cy.contains('Close').click();
-    });
+    describe('should allow to', () => {
+        beforeEach(() => {
+            function interceptResourceFetching(resourceName: string, resourceId: string) {
+                cy.interceptSp('GET', `/${resourceName}?_include=id`, {
+                    metadata: {
+                        pagination: { total: 1, size: 1000, offset: 0 },
+                        filtered: null
+                    },
+                    items: [{ id: resourceId }]
+                }).as(`fetch${upperFirst(camelCase(resourceName))}`);
+            }
 
-    it('should allow to install new agent', () => {
-        cy.contains('Install').click();
-        cy.get('div[name=deploymentId] input').type(deploymentName);
-        cy.get('div[name=nodeId]').click();
-        cy.get('div[name=nodeId] .item').click();
-        cy.get('div[name=nodeInstanceId]').click();
-        cy.get('div[name=nodeInstanceId] .item').click();
-        cy.contains('.modal button', 'Install').click();
-        cy.contains('Close').click();
+            cy.interceptSp('GET', '/agents', {
+                metadata: { pagination: { total: 1, size: 15, offset: 0 }, filtered: null },
+                items: [
+                    {
+                        id: 'host_qz2p8t_1cc7dac9-e9c4-492e-ba36-6f5146ed1bd5',
+                        host_id: nodeInstanceName,
+                        ip: '10.239.2.130',
+                        install_method: 'remote',
+                        system: 'centos core',
+                        version: '6.1.0-.dev1',
+                        node: nodeName,
+                        deployment: deploymentName,
+                        tenant_name: 'default_tenant'
+                    }
+                ]
+            }).as('fetchAgents');
+
+            cy.interceptSp('POST', '/executions').as('postExecution');
+
+            interceptResourceFetching('deployments', deploymentName);
+            interceptResourceFetching('nodes', nodeName);
+            interceptResourceFetching('node-instances', nodeInstanceName);
+
+            cy.wait('@fetchAgents', { requestTimeout: secondsToMs(pollingTimeSeconds + 1) });
+            cy.contains(deploymentName);
+            cy.killExecutions(deploymentName);
+        });
+
+        function selectResourceFromDropdown(dropdownName: string, value: string) {
+            cy.get(`div[name=${dropdownName}]`).click();
+            cy.get(`div[name=${dropdownName}] input`).type(value);
+            cy.get(`div[name=${dropdownName}] .item`).click();
+        }
+
+        function fillNodesFilter() {
+            cy.wait('@fetchDeployments');
+            cy.wait('@fetchNodes');
+            cy.wait('@fetchNodeInstances');
+
+            selectResourceFromDropdown('deploymentId', deploymentName);
+            selectResourceFromDropdown('nodeId', nodeName);
+            selectResourceFromDropdown('nodeInstanceId', nodeInstanceName);
+        }
+
+        type InstallMethods = 'Remote' | 'Plugin' | 'Init Script' | 'Provided';
+        function selectInstallMethod(installMethod: InstallMethods) {
+            cy.get('div[name="installMethods"]').click();
+            cy.contains(installMethod).click();
+            cy.get('div[name="installMethods"]').click();
+        }
+
+        function verifyExecution(
+            executionPayload: Record<string, any>,
+            expectedWorkflowId: string,
+            expectedInstallMethod: 'Remote' | 'Plugin' | 'Init Script' | 'Provided',
+            expectedAdditionalParameters: Record<string, any> = {}
+        ) {
+            expect(executionPayload).to.deep.equal({
+                deployment_id: deploymentName,
+                workflow_id: expectedWorkflowId,
+                dry_run: false,
+                force: false,
+                queue: false,
+                parameters: {
+                    node_ids: [nodeName],
+                    node_instance_ids: [nodeInstanceName],
+                    install_methods: [snakeCase(expectedInstallMethod)],
+                    ...expectedAdditionalParameters
+                }
+            });
+        }
+
+        it('validate agent', () => {
+            cy.contains('Validate').click();
+            cy.get('.modal').within(() => {
+                fillNodesFilter();
+                selectInstallMethod('Plugin');
+                cy.contains('button', 'Validate').click();
+            });
+
+            cy.wait('@postExecution').then(({ request }) => {
+                verifyExecution(request.body, 'validate_agents', 'Plugin');
+            });
+            cy.contains('Execution started').should('be.visible');
+            cy.contains('Close').click();
+        });
+
+        it('install new agent', () => {
+            cy.contains('Install').click();
+            cy.get('.modal').within(() => {
+                fillNodesFilter();
+                selectInstallMethod('Remote');
+                cy.contains('button', 'Install').click();
+            });
+
+            cy.wait('@postExecution').then(({ request }) => {
+                verifyExecution(request.body, 'install_new_agents', 'Remote', { stop_old_agent: false });
+            });
+
+            cy.contains('Execution started').should('be.visible');
+            cy.contains('Close').click();
+        });
     });
 
     it('should display agents that match the search phrase', () => {

--- a/test/cypress/integration/widgets/agents_spec.ts
+++ b/test/cypress/integration/widgets/agents_spec.ts
@@ -46,7 +46,9 @@ describe('Agents widget', () => {
                 ]
             }).as('fetchAgents');
 
-            cy.interceptSp('POST', '/executions').as('postExecution');
+            cy.interceptSp('POST', '/executions', { body: { id: '0060e00c-ffbf-4d9b-bc4e-c490760bdf01' } }).as(
+                'postExecution'
+            );
 
             interceptResourceFetching('deployments', deploymentName);
             interceptResourceFetching('nodes', nodeName);
@@ -54,7 +56,6 @@ describe('Agents widget', () => {
 
             cy.wait('@fetchAgents', { requestTimeout: secondsToMs(pollingTimeSeconds + 1) });
             cy.contains(deploymentName);
-            cy.killExecutions(deploymentName);
         });
 
         function selectResourceFromDropdown(dropdownName: string, value: string) {

--- a/test/cypress/integration/widgets/agents_spec.ts
+++ b/test/cypress/integration/widgets/agents_spec.ts
@@ -58,20 +58,14 @@ describe('Agents widget', () => {
             cy.contains(deploymentName);
         });
 
-        function selectResourceFromDropdown(dropdownName: string, value: string) {
-            cy.get(`div[name=${dropdownName}]`).click();
-            cy.get(`div[name=${dropdownName}] input`).type(value);
-            cy.get(`div[name=${dropdownName}] .item`).click();
-        }
-
         function fillNodesFilter() {
             cy.wait('@fetchDeployments');
             cy.wait('@fetchNodes');
             cy.wait('@fetchNodeInstances');
 
-            selectResourceFromDropdown('deploymentId', deploymentName);
-            selectResourceFromDropdown('nodeId', nodeName);
-            selectResourceFromDropdown('nodeInstanceId', nodeInstanceName);
+            cy.setDropdownValue('Deployment', deploymentName);
+            cy.setDropdownValue('Node', nodeName);
+            cy.setDropdownValue('Node Instance', nodeInstanceName);
         }
 
         type InstallMethods = 'Remote' | 'Plugin' | 'Init Script' | 'Provided';

--- a/test/cypress/integration/widgets/agents_spec.ts
+++ b/test/cypress/integration/widgets/agents_spec.ts
@@ -63,14 +63,14 @@ describe('Agents widget', () => {
             cy.wait('@fetchNodes');
             cy.wait('@fetchNodeInstances');
 
-            cy.setDropdownValue('Deployment', deploymentName);
-            cy.setDropdownValue('Node', nodeName);
-            cy.setDropdownValue('Node Instance', nodeInstanceName);
+            cy.setSearchableDropdownValue('Deployment', deploymentName);
+            cy.setSearchableDropdownValue('Node', nodeName);
+            cy.setSearchableDropdownValue('Node Instance', nodeInstanceName);
         }
 
         type InstallMethod = 'Remote' | 'Plugin' | 'Init Script' | 'Provided';
         function selectInstallMethod(installMethods: InstallMethod[]) {
-            cy.selectDropdownValue('Install Methods filter', installMethods);
+            cy.setDropdownValues('Install Methods filter', installMethods);
         }
 
         function verifyExecution(

--- a/test/cypress/integration/widgets/deployment_button_spec.ts
+++ b/test/cypress/integration/widgets/deployment_button_spec.ts
@@ -52,7 +52,7 @@ describe('Create Deployment Button widget', () => {
         cy.get('.modal').within(() => {
             const blueprintName = `${resourcePrefix}${type}_type`;
             cy.log(`Selecting blueprint: ${blueprintName}.`);
-            cy.setDropdownValue('Blueprint', blueprintName);
+            cy.setSearchableDropdownValue('Blueprint', blueprintName);
 
             cy.log('Waiting for blueprint to load and modal to be operational.');
             cy.contains('Deployment inputs').should('be.visible');
@@ -70,7 +70,7 @@ describe('Create Deployment Button widget', () => {
 
     const fillDeployBlueprintModal = (deploymentId, deploymentName, blueprintId) => {
         cy.get('div.deployBlueprintModal').within(() => {
-            cy.setDropdownValue('Blueprint', blueprintId);
+            cy.setSearchableDropdownValue('Blueprint', blueprintId);
             cy.get('input[name="deploymentName"]').click().type(deploymentName);
             cy.get('input[name="deploymentId"]').clear().type(deploymentId);
         });

--- a/test/cypress/integration/widgets/deployments_view_spec.ts
+++ b/test/cypress/integration/widgets/deployments_view_spec.ts
@@ -842,7 +842,7 @@ describe('Deployments View widget', () => {
             cy.get('.modal').within(() => {
                 cy.wait('@searchWorkflows');
 
-                cy.setDropdownValue('Workflow', 'restart');
+                cy.setSearchableDropdownValue('Workflow', 'restart');
                 cy.contains('button', 'Run').click();
 
                 cy.wait('@createDeploymentGroup')
@@ -866,7 +866,7 @@ describe('Deployments View widget', () => {
             const labelKey = 'label_key';
             const labelValue = 'label_value';
             cy.get('.modal').within(() => {
-                cy.setDropdownValue('Blueprint', blueprintName);
+                cy.setSearchableDropdownValue('Blueprint', blueprintName);
 
                 cy.contains('.field', 'Labels').find('.selection').click();
                 cy.get('div[name=labelKey] > input').type(labelKey);

--- a/test/cypress/integration/widgets/maintenance_mode_button_spec.ts
+++ b/test/cypress/integration/widgets/maintenance_mode_button_spec.ts
@@ -9,9 +9,7 @@ describe('Maintenance mode button widget', () => {
     const getDeactivateButton = () => cy.contains('Deactivate Maintenance Mode');
 
     it('should enter maintenance mode on click', () => {
-        waitUntilEmpty(
-            'executions?status=scheduled&status=queued&status=pending&status=started&status=cancelling&status=force_cancelling&status=kill_cancelling'
-        );
+        cy.waitUntilNoExecutionIsActive();
         getActivateButton().click();
         cy.contains('Yes').click();
         getDeactivateButton().click();

--- a/test/cypress/support/commands.ts
+++ b/test/cypress/support/commands.ts
@@ -333,7 +333,7 @@ const commands = {
             .then(commandResult => commandResult.stdout);
     },
 
-    setDropdownValue: (fieldName: string, value: string) => {
+    setSearchableDropdownValue: (fieldName: string, value: string) => {
         cy.contains('.field', fieldName)
             .click()
             .within(() => {
@@ -342,7 +342,7 @@ const commands = {
             });
     },
 
-    selectDropdownValue: (fieldName: string, values: string[]) => {
+    setDropdownValues: (fieldName: string, values: string[]) => {
         cy.contains('.field', fieldName)
             .click()
             .within(() => values.forEach(value => cy.contains('div[role=option]', value).click()))

--- a/test/cypress/support/commands.ts
+++ b/test/cypress/support/commands.ts
@@ -334,10 +334,12 @@ const commands = {
     },
 
     setDropdownValue: (fieldName: string, value: string) => {
-        cy.contains('.field', fieldName).within(() => {
-            cy.get('input').type(value);
-            cy.get(`div[option-value="${value}"]`).click();
-        });
+        cy.contains('.field', fieldName)
+            .click()
+            .within(() => {
+                cy.get('input').type(value);
+                cy.get(`div[option-value="${value}"]`).click();
+            });
     },
 
     openTab: (tabName: string) => {

--- a/test/cypress/support/commands.ts
+++ b/test/cypress/support/commands.ts
@@ -342,6 +342,13 @@ const commands = {
             });
     },
 
+    selectDropdownValue: (fieldName: string, values: string[]) => {
+        cy.contains('.field', fieldName)
+            .click()
+            .within(() => values.forEach(value => cy.contains('div[role=option]', value).click()))
+            .click();
+    },
+
     openTab: (tabName: string) => {
         cy.get('.tabular.menu').contains(tabName).click();
     },

--- a/test/cypress/support/executions.ts
+++ b/test/cypress/support/executions.ts
@@ -1,20 +1,47 @@
-Cypress.Commands.add('getExecutions', (filter = '') => {
-    cy.cfyRequest(`/executions${filter ? `?${filter}` : ''}`, 'GET');
-});
+import { addCommands, GetCypressChainableFromCommands } from 'cloudify-ui-common/cypress/support';
+import { waitUntilEmpty } from './resource_commons';
 
-Cypress.Commands.add('executeWorkflow', (deploymentId, workflowId, parameters = {}, force = false) => {
-    cy.cfyRequest('/executions', 'POST', null, {
-        deployment_id: deploymentId,
-        workflow_id: workflowId,
-        parameters,
-        force
-    });
-});
+declare global {
+    namespace Cypress {
+        // NOTE: necessary for extending the Cypress API
+        // eslint-disable-next-line @typescript-eslint/no-empty-interface
+        export interface Chainable extends GetCypressChainableFromCommands<typeof commands> {}
+    }
+}
 
-// NOTE: This function was not tested. Remove this comment once tested and used in test cases.
-Cypress.Commands.add('cancelExecution', (executionId, deploymentId, action = 'force-cancel') => {
-    cy.cfyRequest(`/executions/${executionId}`, 'POST', null, {
-        deployment_id: deploymentId,
-        action
-    });
-});
+const plannedOrStartedExecutionsOnDeployment = (deploymentId: string) =>
+    `/executions?deployment_id=${deploymentId}&status=scheduled&status=queued&status=pending&status=started`;
+
+const commands = {
+    getExecutions: (filter = '') => {
+        cy.cfyRequest(`/executions${filter ? `?${filter}` : ''}`, 'GET');
+    },
+
+    executeWorkflow: (deploymentId: string, workflowId: string, parameters = {}, force = false) => {
+        cy.cfyRequest('/executions', 'POST', null, {
+            deployment_id: deploymentId,
+            workflow_id: workflowId,
+            parameters,
+            force
+        });
+    },
+
+    killExecution: (executionId: string) => {
+        cy.cfyRequest(`/executions/${executionId}`, 'POST', null, { action: 'kill' });
+    },
+
+    killExecutions: (deploymentId: string) => {
+        cy.cfyRequest(plannedOrStartedExecutionsOnDeployment(deploymentId), 'GET')
+            .then(response => response.body.items.forEach(({ id }: { id: string }) => cy.killExecution(id)))
+            .then(() => cy.waitUntilNoExecutionIsActive(deploymentId));
+    },
+
+    waitUntilNoExecutionIsActive: (deploymentId: string) => {
+        const activeExecutionsOnDeployment = `${plannedOrStartedExecutionsOnDeployment(
+            deploymentId
+        )}&status=cancelling&status=force_cancelling&status=kill_cancelling`;
+        waitUntilEmpty(activeExecutionsOnDeployment);
+    }
+};
+
+addCommands(commands);

--- a/test/cypress/support/executions.ts
+++ b/test/cypress/support/executions.ts
@@ -9,7 +9,7 @@ declare global {
     }
 }
 
-const plannedOrStartedExecutionsOnDeployment = (deploymentId: string) =>
+const getPlannedOrStartedExecutionsUrl = (deploymentId: string) =>
     `/executions?deployment_id=${deploymentId}&status=scheduled&status=queued&status=pending&status=started`;
 
 const commands = {
@@ -31,16 +31,16 @@ const commands = {
     },
 
     killExecutions: (deploymentId: string) => {
-        cy.cfyRequest(plannedOrStartedExecutionsOnDeployment(deploymentId), 'GET')
+        cy.cfyRequest(getPlannedOrStartedExecutionsUrl(deploymentId), 'GET')
             .then(response => response.body.items.forEach(({ id }: { id: string }) => cy.killExecution(id)))
             .then(() => cy.waitUntilNoExecutionIsActive(deploymentId));
     },
 
     waitUntilNoExecutionIsActive: (deploymentId: string) => {
-        const activeExecutionsOnDeployment = `${plannedOrStartedExecutionsOnDeployment(
+        const activeExecutionsUrl = `${getPlannedOrStartedExecutionsUrl(
             deploymentId
         )}&status=cancelling&status=force_cancelling&status=kill_cancelling`;
-        waitUntilEmpty(activeExecutionsOnDeployment);
+        waitUntilEmpty(activeExecutionsUrl);
     }
 };
 

--- a/widgets/agents/src/InstallAgentsModal.tsx
+++ b/widgets/agents/src/InstallAgentsModal.tsx
@@ -56,7 +56,7 @@ export default function InstallAgentsModal({
             setInputValues(getInitialInputValues());
             setAllowedDeployments(getAgentsAttributeList('deployment'));
             setAllowedNodes(getAgentsAttributeList('node'));
-            setAllowedNodeInstances(getAgentsAttributeList('id'));
+            setAllowedNodeInstances(getAgentsAttributeList('host_id'));
         }
     }, [open]);
 

--- a/widgets/agents/src/ValidateAgentsModal.tsx
+++ b/widgets/agents/src/ValidateAgentsModal.tsx
@@ -53,7 +53,7 @@ export default function ValidateAgentsModal({
             setInputValues(getInitialInputValues());
             setAllowedDeployments(getAgentsAttributeList('deployment'));
             setAllowedNodes(getAgentsAttributeList('node'));
-            setAllowedNodeInstances(getAgentsAttributeList('id'));
+            setAllowedNodeInstances(getAgentsAttributeList('host_id'));
         }
     }, [open]);
 

--- a/widgets/common/src/NodeFilter.tsx
+++ b/widgets/common/src/NodeFilter.tsx
@@ -43,12 +43,13 @@ export default class NodeFilter extends React.Component {
     }
 
     handleInputChange(state, event, field, onStateChange) {
-        const { blueprintId, deploymentId, nodeId, nodeInstanceId } = this.state;
         const { name, onChange } = this.props;
         this.setState({ ...state, [field.name]: field.value }, () => {
             if (_.isFunction(onStateChange)) {
                 onStateChange();
             }
+
+            const { blueprintId, deploymentId, nodeId, nodeInstanceId } = this.state;
             onChange(event, {
                 name,
                 value: {


### PR DESCRIPTION
### Changes

1. Fixed two places related to Agents widget (see comments in the code).
2. Refactored `executions` Cypress commands
3. Refactored Install and Validate agents tests - I mocked all the necessary data as having a deployment with agent installed as AFAIR we would need to install a blueprint with access to the VM (know VM IP, upload an SSH key to the VM)

### Plan

This PR does not fix issues listed in https://cloudifysource.atlassian.net/browse/RD-2589?focusedCommentId=72156 .
I discussed with @geokala yesterday my concerns about Agents widget and as for now we have kind of proposal how to change Agents widget. It seems like it would be reasonable to do a major change (remove `Install` and `Validate` buttons + Have `Validate` button available in the action column per each agent row). That needs to be discussed beforehand of course with Alex and Product Team, so I'll probably start an e-mail thread about it. With that change we will probably avoid some (or maybe all?) problems we encounter today.

Summing up: The mentioned change won't be ready before my long vacation, so I decided to do just test fix within that PR.

### System tests

1. [Stage-UI-System-Test/792](https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/792/pipeline/) (only for Agents widget test) - FAILED 
2. [Stage-UI-System-Test/796](https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/796/pipeline) (only for Agents widget test) - PASSED (with fix implemented as part of: https://github.com/cloudify-cosmo/cloudify-stage/pull/1439/commits/2eb7d08a82e7d61c6ffef157cacf17cf63d2e3b7)
3. [Stage-UI-System-Test/799](https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/799/pipeline) (all tests) - PASSED (after first code review round)
4. [Stage-UI-System-Test/800](https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/800/pipeline) (all tests) - FAILED (after second code review round, with https://github.com/cloudify-cosmo/cloudify-stage/commit/0aadab464baa9c5acd3759f63a2fd324a8506968, failure due to RD-2598)
5. [Stage-UI-System-Test/801](https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/801/pipeline) (all tests) - PASSED