### PR TITLE
RD-1829 Improve handling of incompatibilities between Resource Filter and Deployments View widgets

### DIFF
--- a/test/cypress/integration/widgets/deployments_view_spec.ts
+++ b/test/cypress/integration/widgets/deployments_view_spec.ts
@@ -202,6 +202,12 @@ describe('Deployments View widget', () => {
         });
     });
 
+    it('should select the first visible deployment by default', () => {
+        useDeploymentsViewWidget();
+
+        getDeploymentsViewTable().find('tbody tr:first-of-type.active').should('exist');
+    });
+
     describe('with filters', () => {
         const deploymentNameThatMatchesFilter = `${specPrefix}precious_deployment`;
         const filterId = 'only-precious';
@@ -270,6 +276,18 @@ describe('Deployments View widget', () => {
 
             cy.contains(deploymentName);
             cy.contains(deploymentNameThatMatchesFilter);
+        });
+
+        // NOTE: this test does not really belong to the filters functionality, but it needs at least two deployments to work
+        it('should allow selecting a deployment through the Resource Filter widget', () => {
+            useDeploymentsViewWidget();
+
+            const getSelectedDeployment = () => getDeploymentsViewTable().find('tbody tr.active');
+
+            cy.setDeploymentContext(deploymentName);
+            getSelectedDeployment().contains(deploymentName);
+            cy.setDeploymentContext(deploymentNameThatMatchesFilter);
+            getSelectedDeployment().contains(deploymentNameThatMatchesFilter);
         });
     });
 

--- a/widgets/common/src/deploymentsView/DeploymentsView.tsx
+++ b/widgets/common/src/deploymentsView/DeploymentsView.tsx
@@ -149,6 +149,9 @@ export const DeploymentsView: FunctionComponent<DeploymentsViewProps> = ({
     );
 
     if (!selectedDeployment && fallbackDeployment) {
+        log.warn(
+            'The selected deployment is not visible in the Deployments View table. It will be overridden to the first one in the table'
+        );
         toolboxContext.setValue('deploymentId', fallbackDeployment.id);
     }
     // NOTE: use the fallback deployment if it is possible to avoid showing `undefined` as the selected deployment

--- a/widgets/common/src/deploymentsView/detailsPane/index.tsx
+++ b/widgets/common/src/deploymentsView/detailsPane/index.tsx
@@ -23,21 +23,9 @@ export interface DetailsPaneProps {
 
 const DetailsPane: FunctionComponent<DetailsPaneProps> = ({ deployment, widget, toolbox, mapOpen }) => {
     if (!deployment) {
-        const { Message } = Stage.Basic;
-
-        return (
-            // NOTE: 48px to align with the table
-            <div style={{ margin: '48px 10px 0' }}>
-                <Message warning>
-                    <Message.Header>Unknown deployment selected</Message.Header>
-                    <p>
-                        The selected deployment is either not in the table, or you are using a Resource Filter with
-                        multiple selection.
-                    </p>
-                    <p>Please select a deployment shown in the table on the left.</p>
-                </Message>
-            </div>
-        );
+        // NOTE: there is no known selected deployment and there are no other deployments in the table
+        // Thus, the table should show "No results found" and the details pane should be empty.
+        return null;
     }
 
     const drillDown: DrilldownButtonsProps['drillDown'] = (templateName, drilldownContext, drilldownPageName) =>

--- a/widgets/common/src/deploymentsView/getSelectedDeployment.ts
+++ b/widgets/common/src/deploymentsView/getSelectedDeployment.ts
@@ -33,12 +33,6 @@ const getSelectedDeployment = (
         id: deploymentIdInContext as string | undefined
     });
 
-    if (!selectedDeployment) {
-        log.warn(
-            'The selected deployment is not visible in the Deployments View table. It will be overridden to the first one in the table'
-        );
-    }
-
     return {
         selectedDeployment,
         fallbackDeployment

--- a/widgets/common/src/deploymentsView/getSelectedDeployment.ts
+++ b/widgets/common/src/deploymentsView/getSelectedDeployment.ts
@@ -1,0 +1,48 @@
+import { find } from 'lodash';
+import type { Deployment } from './types';
+
+interface SelectedDeploymentResult {
+    selectedDeployment: Deployment | undefined;
+    fallbackDeployment: Deployment | undefined;
+}
+
+const getSelectedDeployment = (
+    deploymentIdInContext: Stage.ContextEntries['deploymentId'] | undefined,
+    deployments: Deployment[]
+): SelectedDeploymentResult => {
+    const fallbackDeployment: Deployment | undefined = deployments[0];
+
+    if (Array.isArray(deploymentIdInContext)) {
+        if (deploymentIdInContext.length === 1) {
+            // NOTE: try to work nicely if there is a singleton array
+            return getSelectedDeployment(deploymentIdInContext[0], deployments);
+        }
+
+        log.warn(
+            'The Deployments View widget does not support selecting multiple deployments. ' +
+                'Most likely you are using a Resource Filter widget alongside it and the combination is not supported'
+        );
+
+        return {
+            selectedDeployment: undefined,
+            fallbackDeployment
+        };
+    }
+
+    const selectedDeployment = find(deployments, {
+        id: deploymentIdInContext as string | undefined
+    });
+
+    if (!selectedDeployment) {
+        log.warn(
+            'The selected deployment is not visible in the Deployments View table. It will be overridden to the first one in the table'
+        );
+    }
+
+    return {
+        selectedDeployment,
+        fallbackDeployment
+    };
+};
+
+export default getSelectedDeployment;

--- a/widgets/common/src/deploymentsView/table/DeploymentsTable.tsx
+++ b/widgets/common/src/deploymentsView/table/DeploymentsTable.tsx
@@ -29,6 +29,7 @@ interface DeploymentsTableProps {
     pageSize: number;
     totalSize: number;
     fieldsToShow: DeploymentsViewColumnId[];
+    selectedDeployment: Deployment | undefined;
 }
 
 const DeploymentsTable: FunctionComponent<DeploymentsTableProps> = ({
@@ -38,7 +39,8 @@ const DeploymentsTable: FunctionComponent<DeploymentsTableProps> = ({
     deployments,
     fieldsToShow,
     pageSize,
-    totalSize
+    totalSize,
+    selectedDeployment
 }) => {
     const { DataTable } = Stage.Basic;
 
@@ -71,7 +73,7 @@ const DeploymentsTable: FunctionComponent<DeploymentsTableProps> = ({
                     );
                 })}
 
-                {deployments.flatMap(renderDeploymentRow(toolbox, fieldsToShow))}
+                {deployments.flatMap(renderDeploymentRow(toolbox, fieldsToShow, selectedDeployment))}
             </DataTable>
         </TableContainer>
     );

--- a/widgets/common/src/deploymentsView/table/renderDeploymentRow.tsx
+++ b/widgets/common/src/deploymentsView/table/renderDeploymentRow.tsx
@@ -4,18 +4,19 @@ import { deploymentsViewColumnDefinitions, DeploymentsViewColumnId } from './col
 import { Deployment, LatestExecutionStatus } from '../types';
 import { selectDeployment } from '../common';
 
-const renderDeploymentRow = (toolbox: Stage.Types.Toolbox, fieldsToShow: DeploymentsViewColumnId[]) => (
-    deployment: Deployment
-) => {
+const renderDeploymentRow = (
+    toolbox: Stage.Types.Toolbox,
+    fieldsToShow: DeploymentsViewColumnId[],
+    selectedDeployment: Deployment | undefined
+) => (deployment: Deployment) => {
     const { DataTable } = Stage.Basic;
-    const selectedDeploymentId = toolbox.getContext().getValue('deploymentId');
     const progressUnderline = getDeploymentProgressUnderline(deployment);
 
     return [
         <DataTable.Row
             key={deployment.id}
             className={progressUnderline ? undefined : 'deployment-progressless-row'}
-            selected={deployment.id === selectedDeploymentId}
+            selected={deployment.id === selectedDeployment?.id}
             onClick={() => selectDeployment(toolbox, deployment.id)}
         >
             {Object.entries(deploymentsViewColumnDefinitions).map(([columnId, columnDefinition]) => (


### PR DESCRIPTION
This PR implements the new way of interoperability between the Resource Filter and the Deployments View widgets.

The behavior is described in points listed in the following Jira comment: https://cloudifysource.atlassian.net/browse/RD-1829?focusedCommentId=72281. The logic is as follows:

1. If there is no deployment selected (not in Resource Filter or Deployments View), select the first deployment from the table in Deployments View

    1.1. If there are no deployments (“No Results Found”), nothing is selected and there is only that information “No Results Found”. There is no warning now (the warning shown on https://user-images.githubusercontent.com/889383/122370093-1240a000-cf5f-11eb-98bb-e219ea25075d.png was unnecessary)

2. If the user selected a deployment in the Resource Filter widget (no matter whether the user has the “Allow multiple selection” enabled or not)

    2.1. If that deployment is on the current table page, select it

    2.2. If that deployment is on some other table page, select the first deployment in the table and show a warning in the developer console

3. If the user selected multiple deployments in the Resource Filter widget, try to unwrap the selected deployment from the array. If it's not possible, select the first deployment in the table and show a warning in the developer console

To sum up, the Deployments View will override any `deploymentId` picked by the Resource Filter in cases where otherwise there would be an "unknown deployments selected'. There is no user-facing warning, only warnings in the console in those rare scenarios.

Changes to the documentation of the Resource Filter widget are done in https://github.com/cloudify-cosmo/docs.getcloudify.org/pull/1880.

## System tests

https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/794/pipeline

Queued 2021-06-17 11:24 CEST