### PR TITLE
RD-2626 Improve Filters spec to be more robust by more precise dropdown option selection

### DIFF
--- a/test/cypress/integration/widgets/filters_spec.ts
+++ b/test/cypress/integration/widgets/filters_spec.ts
@@ -439,7 +439,7 @@ describe('Filters widget', () => {
                             cy.get('input').type(`${value}`);
                             if (withAutocomplete) cy.wait(`@valueSearch_${value}`);
 
-                            if (isNew) cy.contains('[role="option"]', 'Add ').click();
+                            if (isNew) cy.contains('[role="option"]', `Add ${value}`).click();
                             else cy.get(`div[option-value="${value}"]`).click();
 
                             cy.get(`.label[value="${value}"]`).should('exist');
@@ -455,7 +455,7 @@ describe('Filters widget', () => {
                     cy.get('input').type(key);
                     cy.wait(`@keySearch_${key}`);
 
-                    if (isNew) cy.contains('[role="option"]', 'New key ').click();
+                    if (isNew) cy.contains('[role="option"]', `New key ${key}`).click();
                     else cy.get(`div[option-value="${key}"]`).click();
 
                     cy.get(`input.search`).should('not.have.value');
@@ -478,7 +478,7 @@ describe('Filters widget', () => {
                             cy.get('input').type(value);
                             cy.wait(`@valueSearch_${value}`);
 
-                            if (isNew) cy.contains('[role="option"]', 'New value ').click();
+                            if (isNew) cy.contains('[role="option"]', `New value ${value}`).click();
                             else cy.get(`div[option-value="${value}"]`).click();
 
                             cy.get(`.label[value="${value}"]`).should('exist');


### PR DESCRIPTION
### Changes

Instead of waiting for the part which is generic, we are now waiting for the exact value in the dropdown option.

### System Tests

Filters spec passed locally two times in a row.

[Stage-UI-System-Test/797](https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/797/pipeline) (only Filters spec)
```
[2021-06-17T11:40:19.231Z]        Spec                                              Tests  Passing  Failing  Pending  Skipped  
[2021-06-17T11:40:19.231Z]   ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
[2021-06-17T11:40:19.231Z]   │ ✔  widgets/filters_spec.ts                  01:35       19       19        -        -        - │
[2021-06-17T11:40:19.231Z]   └────────────────────────────────────────────────────────────────────────────────────────────────┘
[2021-06-17T11:40:19.231Z]     ✔  All specs passed!                        01:35       19       19        -        -        -  
```
