### PR TITLE
RD-2005 Add subdeployment status icons in drill-down buttons

### DIFF
--- a/test/cypress/integration/widgets/deployments_view_spec.ts
+++ b/test/cypress/integration/widgets/deployments_view_spec.ts
@@ -452,13 +452,13 @@ describe('Deployments View widget', () => {
 
             getDeploymentsViewDetailsPane().within(() => {
                 getSubservicesButton().within(() => {
-                    cy.contains('1');
+                    cy.containsNumber(1);
                     cy.get('i[aria-label="Requires attention"]').should('exist');
                 });
                 cy.log('Drill down to subenvironments of app-env');
                 getSubenvironmentsButton()
                     .within(() => {
-                        cy.contains('1');
+                        cy.containsNumber(1);
                         cy.get('i[aria-label="Requires attention"]').should('exist');
                     })
                     .click();
@@ -478,9 +478,9 @@ describe('Deployments View widget', () => {
             verifySubdeploymentsOfAppEnv();
 
             getDeploymentsViewDetailsPane().within(() => {
-                getSubenvironmentsButton().contains('0').should('be.disabled');
+                getSubenvironmentsButton().containsNumber(0).should('be.disabled');
                 cy.log('Drill down to subservices of db-env');
-                getSubservicesButton().contains('2').click();
+                getSubservicesButton().containsNumber(2).click();
             });
 
             getBreadcrumbs().contains('db-env [Services]');
@@ -500,13 +500,13 @@ describe('Deployments View widget', () => {
                 getSubenvironmentsButton()
                     .should('be.disabled')
                     .within(() => {
-                        cy.contains('0');
+                        cy.containsNumber(0);
                         expectOnlySubdeploymentTypeIcon();
                     });
                 getSubservicesButton()
                     .should('be.disabled')
                     .within(() => {
-                        cy.contains('0');
+                        cy.containsNumber(0);
                         expectOnlySubdeploymentTypeIcon();
                     });
             });
@@ -519,10 +519,10 @@ describe('Deployments View widget', () => {
             getBreadcrumbs().contains('Test Page').click();
             getDeploymentsViewDetailsPane().within(() => {
                 cy.log('Drill down to subservices of app-env');
-                getSubservicesButton().contains('1').click();
+                getSubservicesButton().containsNumber(1).click();
             });
             getDeploymentsViewTable().within(() => {
-                cy.log('Subservices of app-end should be visible (web-app)');
+                cy.log('Subservices of app-env should be visible (web-app)');
                 cy.contains('web-app');
                 cy.contains('db-env').should('not.exist');
             });
@@ -578,7 +578,7 @@ describe('Deployments View widget', () => {
             cy.getSearchInput().type(deploymentName);
 
             getDeploymentsViewDetailsPane().within(() => {
-                getSubservicesButton().contains('0');
+                getSubservicesButton().containsNumber(0);
 
                 cy.interceptSp('GET', `${deploymentName}?all_sub_deployments=false`, req =>
                     req.reply(res => {
@@ -587,7 +587,7 @@ describe('Deployments View widget', () => {
                 ).as('deploymentDetails');
                 cy.wait('@deploymentDetails');
 
-                getSubservicesButton().contains('50');
+                getSubservicesButton().containsNumber(50);
             });
         });
     });
@@ -714,9 +714,9 @@ describe('Deployments View widget', () => {
                         cy.contains('Cloudify-Hello-World');
                         cy.contains(siteNames.london);
                         cy.contains('In progress').parent().find('i.orange.spinner');
-                        getTooltipSubenvironments().contains('5');
+                        getTooltipSubenvironments().containsNumber(5);
                         getTooltipSubservices().within(() => {
-                            cy.contains('80');
+                            cy.containsNumber(80);
                             cy.get('[aria-label="In progress"]');
                         });
                     }
@@ -730,11 +730,11 @@ describe('Deployments View widget', () => {
                         cy.contains(siteNames.olsztyn);
                         cy.contains('Requires attention').parent().find('i.red.exclamation');
                         getTooltipSubenvironments().within(() => {
-                            cy.contains('1');
+                            cy.containsNumber(1);
                             cy.get('[aria-label="In progress"]');
                         });
                         getTooltipSubservices().within(() => {
-                            cy.contains('3');
+                            cy.containsNumber(3);
                             cy.get('[aria-label="Requires attention"]');
                         });
                     }
@@ -747,8 +747,8 @@ describe('Deployments View widget', () => {
                         cy.contains('Cloudify-Hello-World');
                         cy.contains(siteNames.warsaw);
                         cy.contains('Good');
-                        getTooltipSubenvironments().contains('10');
-                        getTooltipSubservices().contains('8');
+                        getTooltipSubenvironments().containsNumber(10);
+                        getTooltipSubservices().containsNumber(8);
                     }
                 );
             });

--- a/test/cypress/integration/widgets/deployments_view_spec.ts
+++ b/test/cypress/integration/widgets/deployments_view_spec.ts
@@ -493,8 +493,7 @@ describe('Deployments View widget', () => {
             });
 
             const expectOnlySubdeploymentTypeIcon = () => {
-                // NOTE: expect only the deployment type icon. There should not be any deployment state icon
-                cy.get('i').should('have.length', 1);
+                cy.get('i').should('have.length', 1).not('.object.group.icon, .cube.icon').should('have.length', 0);
             };
 
             getDeploymentsViewDetailsPane().within(() => {

--- a/test/cypress/integration/widgets/deployments_view_spec.ts
+++ b/test/cypress/integration/widgets/deployments_view_spec.ts
@@ -451,9 +451,17 @@ describe('Deployments View widget', () => {
             });
 
             getDeploymentsViewDetailsPane().within(() => {
-                getSubservicesButton().contains('1');
+                getSubservicesButton().within(() => {
+                    cy.contains('1');
+                    cy.get('i[aria-label="Requires attention"]').should('exist');
+                });
                 cy.log('Drill down to subenvironments of app-env');
-                getSubenvironmentsButton().contains('1').click();
+                getSubenvironmentsButton()
+                    .within(() => {
+                        cy.contains('1');
+                        cy.get('i[aria-label="Requires attention"]').should('exist');
+                    })
+                    .click();
             });
 
             getBreadcrumbs().contains('app-env [Environments]');
@@ -484,9 +492,24 @@ describe('Deployments View widget', () => {
                 cy.contains('db-env').should('not.exist');
             });
 
+            const expectOnlySubdeploymentTypeIcon = () => {
+                // NOTE: expect only the deployment type icon. There should not be any deployment state icon
+                cy.get('i').should('have.length', 1);
+            };
+
             getDeploymentsViewDetailsPane().within(() => {
-                getSubenvironmentsButton().contains('0').should('be.disabled');
-                getSubservicesButton().contains('0').should('be.disabled');
+                getSubenvironmentsButton()
+                    .should('be.disabled')
+                    .within(() => {
+                        cy.contains('0');
+                        expectOnlySubdeploymentTypeIcon();
+                    });
+                getSubservicesButton()
+                    .should('be.disabled')
+                    .within(() => {
+                        cy.contains('0');
+                        expectOnlySubdeploymentTypeIcon();
+                    });
             });
 
             cy.log('Go back to the parent environment');

--- a/test/cypress/support/commands.ts
+++ b/test/cypress/support/commands.ts
@@ -53,6 +53,9 @@ declare global {
              * @see {@link https://www.npmjs.com/package/cypress-get-table}
              */
             getTable: () => Cypress.Chainable<Record<string, any>[]>;
+
+            /** Similar to `cy.contains(num)`, but makes sure the number is not a substring of some other number */
+            containsNumber: (num: number) => Cypress.Chainable;
         }
     }
 }
@@ -350,6 +353,12 @@ const commands = {
 };
 
 addCommands(commands);
+
+// See https://docs.cypress.io/api/cypress-api/custom-commands#Dual-Commands
+Cypress.Commands.add('containsNumber', { prevSubject: 'optional' }, (subject: unknown | undefined, num: number) =>
+    // eslint-disable-next-line security/detect-non-literal-regexp
+    (subject ? cy.wrap(subject) : cy).contains(new RegExp(`\\b${num}\\b`))
+);
 
 function toIdObj(id: string) {
     return { id };

--- a/widgets/common/src/deploymentsView/StatusIcon.tsx
+++ b/widgets/common/src/deploymentsView/StatusIcon.tsx
@@ -1,4 +1,4 @@
-import type { FunctionComponent } from 'react';
+import type { CSSProperties, FunctionComponent } from 'react';
 import type { IconProps } from 'semantic-ui-react';
 
 import { i18nPrefix } from './common';
@@ -16,7 +16,10 @@ const statusIconPropsMapping = createIconDescriptions({
 });
 type StatusIconName = keyof typeof statusIconPropsMapping;
 
-const BaseDeploymentStatusIcon: FunctionComponent<{ iconName?: StatusIconName }> = ({ iconName }) => {
+const BaseDeploymentStatusIcon: FunctionComponent<{ iconName?: StatusIconName; iconStyle?: CSSProperties }> = ({
+    iconName,
+    iconStyle
+}) => {
     if (!iconName) {
         return null;
     }
@@ -27,7 +30,7 @@ const BaseDeploymentStatusIcon: FunctionComponent<{ iconName?: StatusIconName }>
 
     return (
         // eslint-disable-next-line react/jsx-props-no-spreading
-        <Popup trigger={<Icon aria-label={label} {...iconProps} />} position="top center">
+        <Popup trigger={<Icon aria-label={label} {...iconProps} style={iconStyle} />} position="top center">
             {label}
         </Popup>
     );
@@ -42,6 +45,12 @@ export const DeploymentStatusIcon: FunctionComponent<{ status: DeploymentStatus 
     <BaseDeploymentStatusIcon iconName={deploymentStatusIconNameMapping[status]} />
 );
 
-export const SubdeploymentStatusIcon: FunctionComponent<{ status: DeploymentStatus | null }> = ({ status }) => (
-    <BaseDeploymentStatusIcon iconName={deploymentStatusIconNameMapping[status ?? DeploymentStatus.Good]} />
+export const SubdeploymentStatusIcon: FunctionComponent<{ status: DeploymentStatus | null; style?: CSSProperties }> = ({
+    status,
+    style
+}) => (
+    <BaseDeploymentStatusIcon
+        iconName={deploymentStatusIconNameMapping[status ?? DeploymentStatus.Good]}
+        iconStyle={style}
+    />
 );

--- a/widgets/common/src/deploymentsView/detailsPane/DrilldownButtons.tsx
+++ b/widgets/common/src/deploymentsView/detailsPane/DrilldownButtons.tsx
@@ -154,7 +154,8 @@ const DrilldownButton: FunctionComponent<DrilldownButtonProps> = ({
             {!result.loading && (
                 <>
                     {' '}
-                    ({result.count}) <SubdeploymentStatusIcon status={result.status} />
+                    ({result.count}){' '}
+                    <SubdeploymentStatusIcon status={result.status} style={{ marginRight: 0, marginLeft: 0 }} />
                 </>
             )}
         </Button>

--- a/widgets/common/src/deploymentsView/detailsPane/DrilldownButtons.tsx
+++ b/widgets/common/src/deploymentsView/detailsPane/DrilldownButtons.tsx
@@ -10,7 +10,8 @@ import {
     subenvironmentsIcon,
     subservicesIcon
 } from '../common';
-import type { Deployment } from '../types';
+import { SubdeploymentStatusIcon } from '../StatusIcon';
+import type { Deployment, DeploymentStatus } from '../types';
 
 export interface DrilldownButtonsProps {
     deployment: Deployment;
@@ -92,13 +93,22 @@ const getSubdeploymentResults = (
         };
     }
 
+    const {
+        /* eslint-disable camelcase */
+        sub_environments_count,
+        sub_environments_status,
+        sub_services_count,
+        sub_services_status
+        /* eslint-enable camelcase */
+    } = deploymentDetailsResult.data;
+
     return {
-        subservices: { loading: false, count: deploymentDetailsResult.data.sub_services_count },
-        subenvironments: { loading: false, count: deploymentDetailsResult.data.sub_environments_count }
+        subservices: { loading: false, count: sub_services_count, status: sub_services_status },
+        subenvironments: { loading: false, count: sub_environments_count, status: sub_environments_status }
     };
 };
 
-type SubdeploymentsResult = { loading: true } | { loading: false; count: number };
+type SubdeploymentsResult = { loading: true } | { loading: false; count: number; status: DeploymentStatus | null };
 
 interface DrilldownButtonProps {
     type: 'environments' | 'services';
@@ -141,8 +151,12 @@ const DrilldownButton: FunctionComponent<DrilldownButtonProps> = ({
         >
             <Icon name={icon} />
             {i18n.t(`${i18nDrillDownButtonsPrefix}.${type}.label`)}
-            {!result.loading && <> ({result.count})</>}
-            {/* TODO(RD-2005): add icons depending on children state */}
+            {!result.loading && (
+                <>
+                    {' '}
+                    ({result.count}) <SubdeploymentStatusIcon status={result.status} />
+                </>
+            )}
         </Button>
     );
 };

--- a/widgets/common/src/deploymentsView/detailsPane/DrilldownButtons.tsx
+++ b/widgets/common/src/deploymentsView/detailsPane/DrilldownButtons.tsx
@@ -154,8 +154,8 @@ const DrilldownButton: FunctionComponent<DrilldownButtonProps> = ({
             {!result.loading && (
                 <>
                     {' '}
-                    ({result.count}){' '}
-                    <SubdeploymentStatusIcon status={result.status} style={{ marginRight: 0, marginLeft: 0 }} />
+                    ({result.count})
+                    <SubdeploymentStatusIcon status={result.status} style={{ marginRight: 0, marginLeft: '0.2em' }} />
                 </>
             )}
         </Button>


### PR DESCRIPTION
This PR adds the subdeployment status icons to drill-down buttons in the Deployments View widget.

I have also added tests to verify the functionality.

## Screenshots

When subdeplloyments require attention:
![image](https://user-images.githubusercontent.com/889383/122393752-8128f380-cf75-11eb-8da8-de21e89d4f0c.png)

When subdeployments are good or there are no subdeployments, there is no icon:
![image](https://user-images.githubusercontent.com/889383/122393776-87b76b00-cf75-11eb-8586-6d94e06ee01b.png)

## System tests

https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/806/pipeline

Queued 2021-06-18 10:58 CEST