### PR TITLE
RD-1829 Update Resource Filter's README

### DIFF
--- a/widgets/filter/README.md
+++ b/widgets/filter/README.md
@@ -5,6 +5,14 @@ By default, the widget allows filtering by blueprint, deployment and execution, 
 
 ![resource-filter]( /images/ui/widgets/resource_filter.png )
 
+<div class="ui message info">
+It is discouraged to place the Resource Filter widget alongside
+[the Deployments View widget](/working_with/console/widgets/deploymentsView)
+on the same page.
+The Resource Filter widget does not influence the filtering performed in the Deployments View widget.
+Moreover, the deployment selection in the Resource Filter widget will most likely be overridden
+by the Deployments View widget.
+</div>
 
 ## Settings
 


### PR DESCRIPTION
Add a note about incompatibility with the Deployments View widget.
The change to the docs is made in https://github.com/cloudify-cosmo/docs.getcloudify.org/pull/1880. I will wait for that PR to be merged before trying to merge this one (the CI won't let me do otherwise :smile: ).

## Screenshots

![image](https://user-images.githubusercontent.com/889383/122546232-08866d80-d02f-11eb-8812-000fc75889af.png)

Unfortunately, the link to the Deployments View widget is broken due to RD-2455 (already happens in the Deployments View widget).

## System tests

I do not plan on running system tests, as it's an automated readme change that is validated in the multibranch pipeline :slightly_smiling_face: 