### PR TITLE
RD-2647 Switch UI development to 6.1.0 build

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -26,7 +26,7 @@ pipeline {
     stage_dir = "cloudify-stage"
     cfy_manager_url = 'https://raw.githubusercontent.com/cloudify-cosmo/cloudify-manager'
     cfy_node_rpm = 'http://repository.cloudifysource.org/cloudify/components/nodejs-12.22.1-1nodesource.x86_64.rpm'
-    MAIN_BRANCH = "master"
+    MAIN_BRANCH = "6.1.0-build"
   }
 
   stages {

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -26,6 +26,7 @@ pipeline {
     stage_dir = "cloudify-stage"
     cfy_manager_url = 'https://raw.githubusercontent.com/cloudify-cosmo/cloudify-manager'
     cfy_node_rpm = 'http://repository.cloudifysource.org/cloudify/components/nodejs-12.22.1-1nodesource.x86_64.rpm'
+    MAIN_BRANCH = "master"
   }
 
   stages {
@@ -161,7 +162,7 @@ pipeline {
     }
     stage('Audit'){
       when {
-        branch "master"
+        branch "${MAIN_BRANCH}"
       }
       steps {
         catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE'){
@@ -176,13 +177,13 @@ pipeline {
     }
     stage('Run Stage-UI System-tests') {
       when {
-        branch "master"
+        branch "${MAIN_BRANCH}"
       }
       steps {
         echo 'Trigger Stage-UI System-tests'
         build(job: 'Stage-UI-System-Test', parameters: [
-          string(name: 'BRANCH', value: 'master'),
-          string(name: 'STAGE_BRANCH', value: 'master')
+          string(name: 'BRANCH', value: '${MAIN_BRANCH}'),
+          string(name: 'STAGE_BRANCH', value: '${MAIN_BRANCH}')
         ])
       }
     }


### PR DESCRIPTION
This branch switches the main branch for the UI CI to `6.1.0-build`. I have also refactored slightly the Jenkinsfile to avoid having to change the name in multiple places in the future :slightly_smiling_face: 

I will raise a cherry-pick for the `6.1.0-build` branch after this PR is merged.

## System tests

https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/819/pipeline

Queued 2021-06-21 20:02 CEST