### PR TITLE
RD-2647 Switch UI development to 6.1

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -26,7 +26,7 @@ pipeline {
     stage_dir = "cloudify-stage"
     cfy_manager_url = 'https://raw.githubusercontent.com/cloudify-cosmo/cloudify-manager'
     cfy_node_rpm = 'http://repository.cloudifysource.org/cloudify/components/nodejs-12.22.1-1nodesource.x86_64.rpm'
-    MAIN_BRANCH = "master"
+    MAIN_BRANCH = "6.1.0-build"
   }
 
   stages {

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -65,7 +65,7 @@ pipeline {
               sh """
                 cd && mkdir rpmbuild && cd rpmbuild
                 mkdir -p BUILD && cp -rf ${workspace}/${stage_dir}/. BUILD && cd BUILD
-                curl -fO "${cfy_manager_url}/${BRANCH}/packaging/version_info" || curl -fO "${cfy_manager_url}/master/packaging/version_info"
+                curl -fO "${cfy_manager_url}/${BRANCH}/packaging/version_info" || curl -fO "${cfy_manager_url}/${MAIN_BRANCH}/packaging/version_info" || curl -fO "${cfy_manager_url}/master/packaging/version_info"
               """
 
               echo 'Install NodeJS & RPM development tools'

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -182,8 +182,8 @@ pipeline {
       steps {
         echo 'Trigger Stage-UI System-tests'
         build(job: 'Stage-UI-System-Test', parameters: [
-          string(name: 'BRANCH', value: '${MAIN_BRANCH}'),
-          string(name: 'STAGE_BRANCH', value: '${MAIN_BRANCH}')
+          string(name: 'BRANCH', value: "${MAIN_BRANCH}"),
+          string(name: 'STAGE_BRANCH', value: "${MAIN_BRANCH}")
         ])
       }
     }

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -26,6 +26,7 @@ pipeline {
     stage_dir = "cloudify-stage"
     cfy_manager_url = 'https://raw.githubusercontent.com/cloudify-cosmo/cloudify-manager'
     cfy_node_rpm = 'http://repository.cloudifysource.org/cloudify/components/nodejs-12.22.1-1nodesource.x86_64.rpm'
+    MAIN_BRANCH = "master"
   }
 
   stages {
@@ -161,7 +162,7 @@ pipeline {
     }
     stage('Audit'){
       when {
-        branch "master"
+        branch "${MAIN_BRANCH}"
       }
       steps {
         catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE'){
@@ -176,13 +177,13 @@ pipeline {
     }
     stage('Run Stage-UI System-tests') {
       when {
-        branch "master"
+        branch "${MAIN_BRANCH}"
       }
       steps {
         echo 'Trigger Stage-UI System-tests'
         build(job: 'Stage-UI-System-Test', parameters: [
-          string(name: 'BRANCH', value: 'master'),
-          string(name: 'STAGE_BRANCH', value: 'master')
+          string(name: 'BRANCH', value: '${MAIN_BRANCH}'),
+          string(name: 'STAGE_BRANCH', value: '${MAIN_BRANCH}')
         ])
       }
     }


### PR DESCRIPTION
This is a copy of https://github.com/cloudify-cosmo/cloudify-stage/pull/1446 because I wanted to push more commits to it but I could not as the branch was already protected.

I will cherry-pick to 6.1.0 after this PR is merged

## System tests

https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/823/pipeline

Queued 2021-06-22 12:16 CEST

