### PR TITLE
RD-2633 Allow setting up intercepts right before login

### DIFF
--- a/test/cypress/integration/change_password_spec.ts
+++ b/test/cypress/integration/change_password_spec.ts
@@ -80,9 +80,9 @@ describe('Change Password modal', () => {
     });
 
     it('should not be available when LDAP is enabled', () => {
-        cy.interceptSp('GET', `/ldap`, 'enabled').as('ldap');
-
-        cy.usePageMock().mockLogin();
+        cy.usePageMock().mockLogin(undefined, undefined, undefined, () => {
+            cy.interceptSp('GET', `/ldap`, 'enabled').as('ldap');
+        });
 
         cy.get('.usersMenu').click();
         cy.get('#changePasswordMenuItem').should('have.class', 'disabled');

--- a/test/cypress/integration/change_password_spec.ts
+++ b/test/cypress/integration/change_password_spec.ts
@@ -80,9 +80,9 @@ describe('Change Password modal', () => {
     });
 
     it('should not be available when LDAP is enabled', () => {
-        cy.usePageMock().mockLogin(undefined, undefined, undefined, () => {
-            cy.interceptSp('GET', `/ldap`, 'enabled').as('ldap');
-        });
+        cy.interceptSp('GET', `/ldap`, 'enabled').as('ldap');
+
+        cy.usePageMock().mockLogin();
 
         cy.get('.usersMenu').click();
         cy.get('#changePasswordMenuItem').should('have.class', 'disabled');

--- a/test/cypress/integration/widgets/deployments_view_spec.ts
+++ b/test/cypress/integration/widgets/deployments_view_spec.ts
@@ -67,12 +67,13 @@ describe('Deployments View widget', () => {
         routeHandler,
         configurationOverrides = {}
     }: { routeHandler?: RouteHandler; configurationOverrides?: Partial<typeof widgetConfiguration> } = {}) => {
-        cy.interceptSp('POST', /^\/searches\/deployments/, routeHandler).as('deployments');
         cy.usePageMock(
             [widgetId],
             { ...widgetConfiguration, ...configurationOverrides },
             { additionalWidgetIdsToLoad, widgetsWidth: 12, additionalPageTemplates: ['drilldownDeployments'] }
-        ).mockLogin();
+        ).mockLogin(undefined, undefined, undefined, () => {
+            cy.interceptSp('POST', /^\/searches\/deployments/, routeHandler).as('deployments');
+        });
         cy.wait('@deployments');
     };
 

--- a/test/cypress/integration/widgets/deployments_view_spec.ts
+++ b/test/cypress/integration/widgets/deployments_view_spec.ts
@@ -71,9 +71,8 @@ describe('Deployments View widget', () => {
             [widgetId],
             { ...widgetConfiguration, ...configurationOverrides },
             { additionalWidgetIdsToLoad, widgetsWidth: 12, additionalPageTemplates: ['drilldownDeployments'] }
-        ).mockLogin(undefined, undefined, undefined, () => {
-            cy.interceptSp('POST', /^\/searches\/deployments/, routeHandler).as('deployments');
-        });
+        ).mockLoginWithoutWaiting();
+        cy.interceptSp('POST', /^\/searches\/deployments/, routeHandler).as('deployments');
         cy.wait('@deployments');
     };
 

--- a/test/cypress/support/commands.ts
+++ b/test/cypress/support/commands.ts
@@ -183,18 +183,20 @@ const commands = {
             cy.waitUntilLoaded().then(() => cy.saveLocalStorage());
         }
     },
-    /**
-     * @param setupIntercepts Allows setting up network intercepts at a moment that ensures that the page from
-     * the previous test is already unloaded. Prevents race conditions (e.g. the intercept catching a polling request
-     * from the previous test)
-     */
     // TODO(RD-2314): object instead of multiple optional parameters
-    mockLogin: (
+    mockLogin: (username?: string, password?: string, disableGettingStarted?: boolean) => {
+        cy.mockLoginWithoutWaiting({ username, password, disableGettingStarted });
+        cy.waitUntilLoaded();
+    },
+    mockLoginWithoutWaiting: ({
         username = 'admin',
         password = 'admin',
-        disableGettingStarted = true,
-        setupIntercepts: () => void = _.noop
-    ) => {
+        disableGettingStarted = true
+    }: {
+        username?: string;
+        password?: string;
+        disableGettingStarted?: boolean;
+    } = {}) => {
         cy.stageRequest('/console/auth/login', 'POST', undefined, {
             Authorization: `Basic ${btoa(`${username}:${password}`)}`
         }).then(response => {
@@ -209,8 +211,6 @@ const commands = {
             if (disableGettingStarted) mockGettingStarted(false);
         });
         cy.visit('/console');
-        setupIntercepts();
-        cy.waitUntilLoaded();
     },
     visitPage: (name: string, id: string | null = null) => {
         cy.log(`Switching to '${name}' page`);

--- a/test/cypress/support/commands.ts
+++ b/test/cypress/support/commands.ts
@@ -189,7 +189,12 @@ const commands = {
      * from the previous test)
      */
     // TODO(RD-2314): object instead of multiple optional parameters
-    mockLogin: (username = 'admin', password = 'admin', disableGettingStarted = true, setupIntercepts?: () => void) => {
+    mockLogin: (
+        username = 'admin',
+        password = 'admin',
+        disableGettingStarted = true,
+        setupIntercepts: () => void = _.noop
+    ) => {
         cy.stageRequest('/console/auth/login', 'POST', undefined, {
             Authorization: `Basic ${btoa(`${username}:${password}`)}`
         }).then(response => {
@@ -204,8 +209,7 @@ const commands = {
             if (disableGettingStarted) mockGettingStarted(false);
         });
         cy.visit('/console');
-        // eslint-disable-next-line chai-friendly/no-unused-expressions
-        setupIntercepts?.();
+        setupIntercepts();
         cy.waitUntilLoaded();
     },
     visitPage: (name: string, id: string | null = null) => {

--- a/test/cypress/support/commands.ts
+++ b/test/cypress/support/commands.ts
@@ -183,8 +183,13 @@ const commands = {
             cy.waitUntilLoaded().then(() => cy.saveLocalStorage());
         }
     },
+    /**
+     * @param setupIntercepts Allows setting up network intercepts at a moment that ensures that the page from
+     * the previous test is already unloaded. Prevents race conditions (e.g. the intercept catching a polling request
+     * from the previous test)
+     */
     // TODO(RD-2314): object instead of multiple optional parameters
-    mockLogin: (username = 'admin', password = 'admin', disableGettingStarted = true) => {
+    mockLogin: (username = 'admin', password = 'admin', disableGettingStarted = true, setupIntercepts?: () => void) => {
         cy.stageRequest('/console/auth/login', 'POST', undefined, {
             Authorization: `Basic ${btoa(`${username}:${password}`)}`
         }).then(response => {
@@ -198,7 +203,10 @@ const commands = {
             );
             if (disableGettingStarted) mockGettingStarted(false);
         });
-        cy.visit('/console').waitUntilLoaded();
+        cy.visit('/console');
+        // eslint-disable-next-line chai-friendly/no-unused-expressions
+        setupIntercepts?.();
+        cy.waitUntilLoaded();
     },
     visitPage: (name: string, id: string | null = null) => {
         cy.log(`Switching to '${name}' page`);


### PR DESCRIPTION
See https://cloudifysource.atlassian.net/browse/RD-2633?focusedCommentId=72312 for more information about the problem.

Long story short, when the `useDeploymentsView` function was executing for some test, the UI from the previous test is still displayed in the browser. When cypress sets up an intercept for the `/searches/deployments` before the page is refreshed (via `cy.visit`) in the new test, it may happen that due to polling, the UI from the previous test sends a request that is matched by Cypress. Because the browser unloads the UI and aborts the requests, the request never gets any response, which is what I believe caused the problems mentioned in RD-2633.

Now if there is a `/searches/deployments` request that happens before `/visit`, it will not be intercepted. I could not reproduce this exact situation locally, but a "close enough" case is below:
![image](https://user-images.githubusercontent.com/889383/123059349-f9763580-d409-11eb-8f83-f4256bc8dfbe.png)

I inspected all uses of `mockLogin` to see if there are `intercept(...).as(...)` before `mockLogin` calls. I only found one aside from `deployments_view_spec`. Other `intercept`s before `mockLogin` did not have `as`, meaning they only mocked the response, which is irrelevant to this problem. I left those as they are, as IMO those are harmless

I will cherry-pick the PR to `master` after it's merged.

## System tests

https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/828/pipeline

Queued 2021-06-23 15:02 CEST