### PR TITLE
RD-2593 Hide "Edit a copy in Composer" button

### DIFF
--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -656,6 +656,11 @@
                 }
             }
         },
+        "blueprintActionButtons": {
+            "configuration": {
+                "showEditACopyInComposerButton": "Show the 'Edit a copy in Composer' button"
+            }
+        },
         "executions": {
             "noExecutionFound": "There are no executions that could be shown."
         },

--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -658,7 +658,7 @@
         },
         "blueprintActionButtons": {
             "configuration": {
-                "showEditACopyInComposerButton": "Show the 'Edit a copy in Composer' button"
+                "showEditCopyInComposerButton": "Show the 'Edit a copy in Composer' button"
             }
         },
         "executions": {

--- a/test/cypress/integration/widgets/blueprint_actions_spec.ts
+++ b/test/cypress/integration/widgets/blueprint_actions_spec.ts
@@ -1,19 +1,31 @@
+import type { BlueprintActionButtonsConfiguration } from '../../../../widgets/blueprintActionButtons/src/widget';
+
 describe('Blueprint Action Buttons widget', () => {
     const blueprintName = 'blueprints_actions_test';
 
     before(() =>
         cy
-            .usePageMock('blueprintActionButtons')
             .activate('valid_trial_license')
-            .mockLogin()
             .deleteBlueprints(blueprintName, true)
             .uploadBlueprint('blueprints/empty.zip', blueprintName)
     );
 
-    it('should open Composer with imported blueprint on "Edit a copy in Composer" button click', () => {
-        cy.setBlueprintContext(blueprintName);
+    const useBlueprintActionButtonsWidget = (widgetConfig: Partial<BlueprintActionButtonsConfiguration> = {}) => {
+        cy.usePageMock('blueprintActionButtons', widgetConfig).mockLogin().setBlueprintContext(blueprintName);
+    };
 
-        cy.contains('Edit a copy in Composer').click();
+    const getEditACopyInComposerButton = () => cy.contains('Edit a copy in Composer');
+
+    it('should not show the "Edit a copy in Composer" button by default', () => {
+        useBlueprintActionButtonsWidget();
+
+        getEditACopyInComposerButton().should('not.exist');
+    });
+
+    it('should open Composer with imported blueprint on "Edit a copy in Composer" button click', () => {
+        useBlueprintActionButtonsWidget({ showEditACopyInComposerButton: true });
+
+        getEditACopyInComposerButton().click();
 
         cy.window()
             .its('open')
@@ -21,6 +33,7 @@ describe('Blueprint Action Buttons widget', () => {
     });
 
     it('should open deployment modal', () => {
+        useBlueprintActionButtonsWidget();
         cy.get('button#createDeploymentButton').click();
 
         cy.get('div.deployBlueprintModal').should('be.visible');

--- a/test/cypress/integration/widgets/blueprint_actions_spec.ts
+++ b/test/cypress/integration/widgets/blueprint_actions_spec.ts
@@ -23,7 +23,7 @@ describe('Blueprint Action Buttons widget', () => {
     });
 
     it('should open Composer with imported blueprint on "Edit a copy in Composer" button click', () => {
-        useBlueprintActionButtonsWidget({ showEditACopyInComposerButton: true });
+        useBlueprintActionButtonsWidget({ showEditCopyInComposerButton: true });
 
         getEditACopyInComposerButton().click();
 

--- a/widgets/blueprintActionButtons/src/BlueprintActionButtons.tsx
+++ b/widgets/blueprintActionButtons/src/BlueprintActionButtons.tsx
@@ -3,7 +3,7 @@ import type { ComponentProps } from 'react';
 interface BlueprintActionButtonsProps {
     blueprintId?: string;
     toolbox: Stage.Types.Toolbox;
-    showEditACopyInComposerButton: boolean;
+    showEditCopyInComposerButton: boolean;
 }
 
 interface BlueprintActionButtonsState {
@@ -86,7 +86,7 @@ export default class BlueprintActionButtons extends React.Component<
     }
 
     render() {
-        const { blueprintId, toolbox, showEditACopyInComposerButton } = this.props;
+        const { blueprintId, toolbox, showEditCopyInComposerButton } = this.props;
         const { error, force, loading } = this.state;
         const { ErrorMessage, Button } = Stage.Basic;
         const { DeleteConfirm, DeployBlueprintModal } = Stage.Common;
@@ -116,7 +116,7 @@ export default class BlueprintActionButtons extends React.Component<
                     id="deleteBlueprintButton"
                 />
 
-                {!manager.isCommunityEdition() && showEditACopyInComposerButton && (
+                {!manager.isCommunityEdition() && showEditCopyInComposerButton && (
                     <Button
                         className="labeled icon"
                         color="teal"

--- a/widgets/blueprintActionButtons/src/BlueprintActionButtons.tsx
+++ b/widgets/blueprintActionButtons/src/BlueprintActionButtons.tsx
@@ -3,6 +3,7 @@ import type { ComponentProps } from 'react';
 interface BlueprintActionButtonsProps {
     blueprintId?: string;
     toolbox: Stage.Types.Toolbox;
+    showEditACopyInComposerButton: boolean;
 }
 
 interface BlueprintActionButtonsState {
@@ -85,7 +86,7 @@ export default class BlueprintActionButtons extends React.Component<
     }
 
     render() {
-        const { blueprintId, toolbox } = this.props;
+        const { blueprintId, toolbox, showEditACopyInComposerButton } = this.props;
         const { error, force, loading } = this.state;
         const { ErrorMessage, Button } = Stage.Basic;
         const { DeleteConfirm, DeployBlueprintModal } = Stage.Common;
@@ -115,7 +116,7 @@ export default class BlueprintActionButtons extends React.Component<
                     id="deleteBlueprintButton"
                 />
 
-                {!manager.isCommunityEdition() && (
+                {!manager.isCommunityEdition() && showEditACopyInComposerButton && (
                     <Button
                         className="labeled icon"
                         color="teal"

--- a/widgets/blueprintActionButtons/src/widget.tsx
+++ b/widgets/blueprintActionButtons/src/widget.tsx
@@ -1,7 +1,7 @@
 import BlueprintActionButtons from './BlueprintActionButtons';
 
 export interface BlueprintActionButtonsConfiguration {
-    showEditACopyInComposerButton: boolean;
+    showEditCopyInComposerButton: boolean;
 }
 
 Stage.defineWidget<unknown, unknown, BlueprintActionButtonsConfiguration>({
@@ -14,9 +14,9 @@ Stage.defineWidget<unknown, unknown, BlueprintActionButtonsConfiguration>({
     showBorder: false,
     initialConfiguration: [
         {
-            id: 'showEditACopyInComposerButton',
+            id: 'showEditCopyInComposerButton',
             type: Stage.Basic.GenericField.BOOLEAN_TYPE,
-            name: Stage.i18n.t('widgets.blueprintActionButtons.configuration.showEditACopyInComposerButton'),
+            name: Stage.i18n.t('widgets.blueprintActionButtons.configuration.showEditCopyInComposerButton'),
             default: false
         }
     ],
@@ -32,7 +32,7 @@ Stage.defineWidget<unknown, unknown, BlueprintActionButtonsConfiguration>({
             <BlueprintActionButtons
                 blueprintId={blueprintId}
                 toolbox={toolbox}
-                showEditACopyInComposerButton={widget.configuration.showEditACopyInComposerButton}
+                showEditCopyInComposerButton={widget.configuration.showEditCopyInComposerButton}
             />
         );
     }

--- a/widgets/blueprintActionButtons/src/widget.tsx
+++ b/widgets/blueprintActionButtons/src/widget.tsx
@@ -1,6 +1,10 @@
 import BlueprintActionButtons from './BlueprintActionButtons';
 
-Stage.defineWidget({
+export interface BlueprintActionButtonsConfiguration {
+    showEditACopyInComposerButton: boolean;
+}
+
+Stage.defineWidget<unknown, unknown, BlueprintActionButtonsConfiguration>({
     id: 'blueprintActionButtons',
     name: 'Blueprint action buttons',
     description: 'Provides set of action buttons for blueprint',
@@ -8,15 +12,28 @@ Stage.defineWidget({
     initialHeight: 5,
     showHeader: false,
     showBorder: false,
-    initialConfiguration: [],
+    initialConfiguration: [
+        {
+            id: 'showEditACopyInComposerButton',
+            type: Stage.Basic.GenericField.BOOLEAN_TYPE,
+            name: Stage.i18n.t('widgets.blueprintActionButtons.configuration.showEditACopyInComposerButton'),
+            default: false
+        }
+    ],
     isReact: true,
     hasReadme: true,
     permission: Stage.GenericConfig.WIDGET_PERMISSION('blueprintActionButtons'),
     categories: [Stage.GenericConfig.CATEGORY.BLUEPRINTS, Stage.GenericConfig.CATEGORY.BUTTONS_AND_FILTERS],
 
-    render(_widget, _data, _error, toolbox) {
+    render(widget, _data, _error, toolbox) {
         const blueprintId = toolbox.getContext().getValue('blueprintId');
 
-        return <BlueprintActionButtons blueprintId={blueprintId} toolbox={toolbox} />;
+        return (
+            <BlueprintActionButtons
+                blueprintId={blueprintId}
+                toolbox={toolbox}
+                showEditACopyInComposerButton={widget.configuration.showEditACopyInComposerButton}
+            />
+        );
     }
 });


### PR DESCRIPTION
This PR hides the "Edit a copy in Composer" button by default in the Blueprint Action Buttons widget. It can be brought back by changing the configuration.

## Video


https://user-images.githubusercontent.com/889383/123640312-536b6680-d821-11eb-970f-c10363564dce.mp4



## System tests

https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/857/pipeline

Queued 2021-06-28 14:59 CEST