### PR TITLE
RD-2593 Hide "Edit in Composer" in Blueprints widget

### DIFF
--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -662,6 +662,11 @@
                 "showEditCopyInComposerButton": "Show the 'Edit a copy in Composer' button"
             }
         },
+        "blueprints": {
+            "configuration": {
+                "showEditCopyInComposerButton": "Show the 'Edit a copy in Composer' button"
+            }
+        },
         "executions": {
             "noExecutionFound": "There are no executions that could be shown."
         },

--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -659,12 +659,12 @@
         },
         "blueprintActionButtons": {
             "configuration": {
-                "showEditCopyInComposerButton": "Show the 'Edit a copy in Composer' button"
+                "showEditCopyInComposerButton": "Show the \"Edit a copy in Composer\" button"
             }
         },
         "blueprints": {
             "configuration": {
-                "showEditCopyInComposerButton": "Show the 'Edit a copy in Composer' button"
+                "showEditCopyInComposerButton": "Show the \"Edit a copy in Composer\" button"
             }
         },
         "executions": {

--- a/test/cypress/integration/widgets/blueprints_spec.ts
+++ b/test/cypress/integration/widgets/blueprints_spec.ts
@@ -42,8 +42,7 @@ describe('Blueprints widget', () => {
 
         it('should not show the "Edit a copy in Composer" button if it is turned off in the configuration', () => {
             cy.editWidgetConfiguration('blueprints', () => {
-                cy.contains('Show the "Edit a copy in Composer" button')
-                    .parent('.field')
+                cy.contains('.field', 'Show the "Edit a copy in Composer" button')
                     .find('input')
                     // NOTE: force, as the checkbox from Semantic UI is
                     // class=hidden which prevents Cypress from clicking it

--- a/test/cypress/integration/widgets/blueprints_spec.ts
+++ b/test/cypress/integration/widgets/blueprints_spec.ts
@@ -1,7 +1,14 @@
+import type { BlueprintsWidgetConfiguration } from '../../../../widgets/blueprints/src/types';
+
 describe('Blueprints widget', () => {
     const blueprintNamePrefix = 'blueprints_test';
     const emptyBlueprintName = `${blueprintNamePrefix}_empty`;
-    const blueprintsWidgetConfiguration = { displayStyle: 'table', clickToDrillDown: true, pollingTime: 5 };
+    const blueprintsWidgetConfiguration: Partial<BlueprintsWidgetConfiguration> = {
+        displayStyle: 'table',
+        clickToDrillDown: true,
+        pollingTime: 5,
+        showEditCopyInComposerButton: true
+    };
 
     before(() =>
         cy
@@ -23,13 +30,27 @@ describe('Blueprints widget', () => {
     describe('for specific blueprint', () => {
         before(() => cy.uploadBlueprint('blueprints/simple.zip', emptyBlueprintName).refreshPage());
 
+        const editCopyInComposerButtonSelector = '[title="Edit a copy in Composer"]';
+
         it('should open Composer with the blueprint imported on "Edit a copy in Composer" icon click', () => {
-            // Click the action icon
-            getBlueprintRow(emptyBlueprintName).find('.external.share').click();
+            getBlueprintRow(emptyBlueprintName).find(editCopyInComposerButtonSelector).click();
 
             cy.window()
                 .its('open')
                 .should('be.calledWith', `/composer/import/default_tenant/${emptyBlueprintName}/blueprint.yaml`);
+        });
+
+        it('should not show the "Edit a copy in Composer" button if it is turned off in the configuration', () => {
+            cy.editWidgetConfiguration('blueprints', () => {
+                cy.contains('Show the "Edit a copy in Composer" button')
+                    .parent('.field')
+                    .find('input')
+                    // NOTE: force, as the checkbox from Semantic UI is
+                    // class=hidden which prevents Cypress from clicking it
+                    .click({ force: true });
+            });
+
+            getBlueprintRow(emptyBlueprintName).find(editCopyInComposerButtonSelector).should('not.exist');
         });
 
         it('should allow to deploy the blueprint', () => {

--- a/widgets/blueprints/src/BlueprintsCatalog.tsx
+++ b/widgets/blueprints/src/BlueprintsCatalog.tsx
@@ -139,7 +139,7 @@ export default function BlueprintsCatalog({
                                     }}
                                 />
 
-                                {!manager.isCommunityEdition() && (
+                                {!manager.isCommunityEdition() && widget.configuration.showEditCopyInComposerButton && (
                                     <Button
                                         icon="external share"
                                         content="Edit a copy in Composer"

--- a/widgets/blueprints/src/BlueprintsTable.tsx
+++ b/widgets/blueprints/src/BlueprintsTable.tsx
@@ -72,20 +72,21 @@ export default function BlueprintsTable({
                             <>
                                 {BlueprintActions.isUploaded(item) && (
                                     <>
-                                        {!toolbox.getManager().isCommunityEdition() && (
-                                            <Icon
-                                                name="external share"
-                                                bordered
-                                                title="Edit a copy in Composer"
-                                                onClick={(event: Event) => {
-                                                    event.stopPropagation();
-                                                    new Stage.Common.BlueprintActions(toolbox).doEditInComposer(
-                                                        item.id,
-                                                        item.main_file_name
-                                                    );
-                                                }}
-                                            />
-                                        )}
+                                        {!toolbox.getManager().isCommunityEdition() &&
+                                            widget.configuration.showEditCopyInComposerButton && (
+                                                <Icon
+                                                    name="external share"
+                                                    bordered
+                                                    title="Edit a copy in Composer"
+                                                    onClick={(event: Event) => {
+                                                        event.stopPropagation();
+                                                        new Stage.Common.BlueprintActions(toolbox).doEditInComposer(
+                                                            item.id,
+                                                            item.main_file_name
+                                                        );
+                                                    }}
+                                                />
+                                            )}
                                         <Icon
                                             name="rocket"
                                             link

--- a/widgets/blueprints/src/types.ts
+++ b/widgets/blueprints/src/types.ts
@@ -6,6 +6,7 @@ export interface BlueprintsWidgetConfiguration {
     clickToDrillDown: boolean;
     displayStyle: 'table' | 'catalog';
     hideFailedBlueprints: boolean;
+    showEditCopyInComposerButton: boolean;
 }
 
 interface Blueprint {

--- a/widgets/blueprints/src/widget.tsx
+++ b/widgets/blueprints/src/widget.tsx
@@ -41,6 +41,12 @@ Stage.defineWidget<unknown, unknown, BlueprintsWidgetConfiguration>({
             name: 'Hide failed blueprints',
             default: false,
             type: Stage.Basic.GenericField.BOOLEAN_TYPE
+        },
+        {
+            id: 'showEditCopyInComposerButton',
+            type: Stage.Basic.GenericField.BOOLEAN_TYPE,
+            name: Stage.i18n.t('widgets.blueprints.configuration.showEditCopyInComposerButton'),
+            default: false
         }
     ],
 


### PR DESCRIPTION
This PR adds a configuration flag to the Blueprints widget to hide the "Edit a copy in Composer" link.

## Video


https://user-images.githubusercontent.com/889383/123964809-20a5a780-d9b4-11eb-9dba-7e3ed2386b0f.mp4



## System tests

https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/870/pipeline

Queued 2021-06-30 15:01 CEST