### PR TITLE
RD-2335 Added deployment name column to nodes list widget

### DIFF
--- a/test/cypress/integration/widgets/nodes_spec.ts
+++ b/test/cypress/integration/widgets/nodes_spec.ts
@@ -1,0 +1,45 @@
+describe('Nodes list widget', () => {
+    const blueprintName = 'nodes_list_test';
+    const deployment1Id = `${blueprintName}_dep1_id`;
+    const deployment1Name = `${blueprintName}_dep1_name`;
+    const deployment2Id = `${blueprintName}_dep2_id`;
+    const deployment2Name = `${blueprintName}_dep2_name`;
+
+    before(() =>
+        cy
+            .activate('valid_trial_license')
+            .usePageMock('nodes', { fieldsToShow: ['Deployment', 'Deployment ID'] })
+            .mockLogin()
+            .deleteDeployments(blueprintName, true)
+            .deleteBlueprints(blueprintName, true)
+            .uploadBlueprint('blueprints/simple.zip', blueprintName)
+            .deployBlueprint(
+                blueprintName,
+                deployment1Id,
+                { server_ip: '127.0.0.1' },
+                { display_name: deployment1Name }
+            )
+            .deployBlueprint(
+                blueprintName,
+                deployment2Id,
+                { server_ip: '127.0.0.1' },
+                { display_name: deployment2Name }
+            )
+    );
+
+    it('should display nodes list', () => {
+        cy.setBlueprintContext(blueprintName);
+        cy.get('tbody tr').should('have.length', 2);
+        cy.get('table')
+            .getTable()
+            .should(tableData => {
+                expect(tableData[0].Deployment).to.eq(deployment1Name);
+                expect(tableData[0]['Deployment ID']).to.eq(deployment1Id);
+                expect(tableData[1].Deployment).to.eq(deployment2Name);
+                expect(tableData[1]['Deployment ID']).to.eq(deployment2Id);
+            });
+
+        cy.setDeploymentContext(deployment1Id);
+        cy.contains('th', 'Deployment').should('not.exist');
+    });
+});

--- a/widgets/nodes/src/NodesTable.tsx
+++ b/widgets/nodes/src/NodesTable.tsx
@@ -90,9 +90,15 @@ export default class NodesTable extends React.Component {
                     />
                     <DataTable.Column
                         label="Deployment"
-                        name="deployment_id"
+                        name="deployment_display_name"
                         width="10%"
                         show={fieldsToShow.indexOf('Deployment') >= 0 && !data.deploymentSelected}
+                    />
+                    <DataTable.Column
+                        label="Deployment ID"
+                        name="deployment_id"
+                        width="10%"
+                        show={fieldsToShow.indexOf('Deployment ID') >= 0 && !data.deploymentSelected}
                     />
                     <DataTable.Column
                         label="Contained in"
@@ -169,6 +175,7 @@ export default class NodesTable extends React.Component {
                                         </div>
                                     </DataTable.Data>
                                     <DataTable.Data>{node.blueprint_id}</DataTable.Data>
+                                    <DataTable.Data>{node.deployment_display_name}</DataTable.Data>
                                     <DataTable.Data>{node.deployment_id}</DataTable.Data>
                                     <DataTable.Data>{node.containedIn}</DataTable.Data>
                                     <DataTable.Data>{node.connectedTo}</DataTable.Data>

--- a/widgets/nodes/src/widget.tsx
+++ b/widgets/nodes/src/widget.tsx
@@ -29,6 +29,7 @@ Stage.defineWidget({
                 'Type',
                 'Blueprint',
                 'Deployment',
+                'Deployment ID',
                 'Contained in',
                 'Connected to',
                 'Host',
@@ -42,7 +43,7 @@ Stage.defineWidget({
     ],
     fetchUrl: {
         nodes:
-            '[manager]/nodes?_include=id,deployment_id,blueprint_id,type,type_hierarchy,actual_number_of_instances,host_id,relationships,created_by[params:blueprint_id,deployment_id,gridParams]',
+            '[manager]/nodes?_include=id,deployment_id,deployment_display_name,blueprint_id,type,type_hierarchy,actual_number_of_instances,host_id,relationships,created_by[params:blueprint_id,deployment_id,gridParams]',
         nodeInstances:
             '[manager]/node-instances?_include=id,node_id,deployment_id,state,relationships,runtime_properties[params:deployment_id]',
         deployments: '[manager]/deployments?_include=id,groups[params:blueprint_id,id]'


### PR DESCRIPTION
The pre-existing Deployment column was renamed to Deployment ID and is hidden by default. As a result nothing has changed in widget appearance except that the Deployment column now shows deployment name instead of deployment ID.

System tests: https://jenkins.cloudify.co/view/UI/job/Stage-UI-System-Test/871