### PR TITLE
RD-2654 Remove Composer Link widget from Blueprints page

### DIFF
--- a/templates/pages/blueprints.json
+++ b/templates/pages/blueprints.json
@@ -1,22 +1,18 @@
 {
-  "name": "Blueprints",
-  "layout": [{
-    "type": "widgets",
-    "content": [
-      {
-        "name": "Blueprints",
-        "definition": "blueprints",
-        "width": 12,
-        "height": 24,
-        "x": 0,
-        "y": 0
-      },
-      {
-        "name": "Composer link",
-        "definition": "composerLink",
-        "x": 0,
-        "y": 25
-      }
+    "name": "Blueprints",
+    "layout": [
+        {
+            "type": "widgets",
+            "content": [
+                {
+                    "name": "Blueprints",
+                    "definition": "blueprints",
+                    "width": 12,
+                    "height": 24,
+                    "x": 0,
+                    "y": 0
+                }
+            ]
+        }
     ]
-  }]
 }


### PR DESCRIPTION
Just as it says in the title. I have also formatted the page template with prettier.

## Screenshot

After resetting the templates:

![image](https://user-images.githubusercontent.com/889383/124135820-777ab200-da84-11eb-8cba-95ae2ffcafb6.png)

## System tests

https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/879/pipeline

Queued 2021-07-01 15:53 CEST