### PR TITLE
RD-2654 Remove Composer Link widget from Blueprints page (#1487)

### DIFF
--- a/templates/pages/blueprints.json
+++ b/templates/pages/blueprints.json
@@ -1,22 +1,18 @@
 {
-  "name": "Blueprints",
-  "layout": [{
-    "type": "widgets",
-    "content": [
-      {
-        "name": "Blueprints",
-        "definition": "blueprints",
-        "width": 12,
-        "height": 24,
-        "x": 0,
-        "y": 0
-      },
-      {
-        "name": "Composer link",
-        "definition": "composerLink",
-        "x": 0,
-        "y": 25
-      }
+    "name": "Blueprints",
+    "layout": [
+        {
+            "type": "widgets",
+            "content": [
+                {
+                    "name": "Blueprints",
+                    "definition": "blueprints",
+                    "width": 12,
+                    "height": 24,
+                    "x": 0,
+                    "y": 0
+                }
+            ]
+        }
     ]
-  }]
 }


### PR DESCRIPTION
Cherry-pick of #1487 to master

In case this PR does not get merged today (Thursday), could either of you (@kubama, @stepek ) merge it yourself tomorrow and move RD-2654 to "done"? I will be absent tomorrow and this way we can conclude the required 6.1  tasks before you go on PTO :slightly_smiling_face: 