### PR TITLE
Revert "Remove jQuery-UI"

### DIFF
--- a/app/app.tsx
+++ b/app/app.tsx
@@ -1,4 +1,9 @@
 // @ts-nocheck File not migrated fully to TS
+import 'jquery-ui/ui/core';
+import 'jquery-ui/ui/widget';
+import 'jquery-ui/ui/widgets/mouse';
+import 'jquery-ui/ui/widgets/draggable';
+import 'jquery-ui/ui/widgets/droppable';
 
 import './styles/style.scss';
 import 'cloudify-ui-common/styles/font-cloudify.css';

--- a/package-lock.json
+++ b/package-lock.json
@@ -21891,6 +21891,11 @@
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.0.tgz",
       "integrity": "sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ=="
     },
+    "jquery-ui": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/jquery-ui/-/jquery-ui-1.12.1.tgz",
+      "integrity": "sha1-vLQEXI3QU5wTS8FIjN0+dop6nlE="
+    },
     "js-base64": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.2.tgz",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "i18next": "^19.8.3",
     "isomorphic-fetch": "^3.0.0",
     "jquery": "^3.5.0",
+    "jquery-ui": "^1.12.1",
     "js-cookie": "^2.1.4",
     "jszip": "^3.6.0",
     "leaflet": "^1.7.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -160,6 +160,7 @@ module.exports = (env, argv) => {
             resolve: {
                 extensions: resolveExtensions,
                 alias: {
+                    'jquery-ui': 'jquery-ui/ui',
                     jquery: `${__dirname}/node_modules/jquery`, // Always make sure we take jquery from the same place
                     // Necessary to use the same version of React when developing components locally
                     // @see https://github.com/facebook/react/issues/13991#issuecomment-435587809


### PR DESCRIPTION
Reverts cloudify-cosmo/cloudify-stage#1473

Adding this revert because `cloudify-blueprint-topology` is not fully support jquery ui itself. 