### PR TITLE
RD-2483 Migrate Plugins Catalog widget to TypeScript

### DIFF
--- a/test/cypress/integration/widgets/plugins_catalog_spec.ts
+++ b/test/cypress/integration/widgets/plugins_catalog_spec.ts
@@ -1,0 +1,34 @@
+import type { PluginsCatalogWidgetConfiguration } from '../../../../widgets/pluginsCatalog/src/types';
+
+describe('Plugins Catalog widget', () => {
+    const widgetConfiguration: PluginsCatalogWidgetConfiguration = {
+        jsonPath: 'http://repository.cloudifysource.org/cloudify/wagons/plugins.json',
+        sortByName: true
+    };
+
+    before(() => cy.activate());
+    beforeEach(() => cy.deletePlugins().usePageMock(['pluginsCatalog', 'plugins'], widgetConfiguration).mockLogin());
+
+    it('should allow uploading the latest version of a plugin', () => {
+        const pluginToUpload = 'Utilities';
+        cy.uploadPluginFromCatalog(pluginToUpload);
+
+        cy.get('.pluginsCatalogWidget table')
+            .getTable()
+            .then(pluginsCatalogTable => {
+                const pluginCatalogRow = pluginsCatalogTable.find(row => row.Name === pluginToUpload);
+                expect(pluginCatalogRow).not.to.be.undefined;
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                const latestPluginVersion: string = pluginCatalogRow!.Version;
+
+                cy.log('Verify if plugin is visible in the Plugins widget');
+                cy.get('.pluginsWidget table')
+                    .getTable()
+                    .then(pluginsTable => {
+                        const uploadedPluginRow = pluginsTable.find(row => row.Plugin === pluginToUpload);
+                        expect(uploadedPluginRow).not.to.be.undefined;
+                        expect(uploadedPluginRow?.['Package version']).to.equal(latestPluginVersion);
+                    });
+            });
+    });
+});

--- a/widgets/common/src/PluginActions.ts
+++ b/widgets/common/src/PluginActions.ts
@@ -1,18 +1,15 @@
-// @ts-nocheck File not migrated fully to TS
 export {};
 
 class PluginActions {
-    constructor(toolbox) {
-        this.toolbox = toolbox;
-    }
+    constructor(private readonly toolbox: Stage.Types.Toolbox) {}
 
-    doDelete(plugin, force = true) {
+    doDelete(plugin: { id: string }, force = true) {
         return this.toolbox.getManager().doDelete(`/plugins/${plugin.id}`, { body: { force } });
     }
 
-    doUpload(visibility, title, resources) {
-        const params = { visibility, title };
-        const files = {};
+    doUpload(visibility: string, title: string, resources: Record<string, { url: string; file: unknown }>) {
+        const params: Record<string, unknown> = { visibility, title };
+        const files: Record<string, unknown> = {};
 
         _.each(resources, ({ url, file }, name) => {
             if (file) {
@@ -25,18 +22,26 @@ class PluginActions {
 
         return this.toolbox
             .getInternal()
-            .doUpload('/plugins/upload', { params, files: !_.isEmpty(files) ? files : null, method: 'post' });
+            .doUpload('/plugins/upload', { params, files: !_.isEmpty(files) ? files : undefined, method: 'post' });
     }
 
-    doDownload(plugin) {
+    // eslint-disable-next-line camelcase
+    doDownload(plugin: { id: string; package_name: string; package_version: string }) {
         const pluginDownloadUrl = `/plugins/${plugin.id}/archive`;
         const pluginFileName = `${plugin.package_name}_${plugin.package_version}.zip`;
 
         return this.toolbox.getManager().doDownload(pluginDownloadUrl, pluginFileName);
     }
 
-    doSetVisibility(pluginId, visibility) {
+    doSetVisibility(pluginId: string, visibility: string) {
         return this.toolbox.getManager().doPatch(`/plugins/${pluginId}/set-visibility`, { body: { visibility } });
+    }
+}
+
+declare global {
+    namespace Stage.Common {
+        // eslint-disable-next-line import/prefer-default-export
+        export { PluginActions };
     }
 }
 

--- a/widgets/common/src/PluginIcon.tsx
+++ b/widgets/common/src/PluginIcon.tsx
@@ -1,5 +1,10 @@
-// @ts-nocheck File not migrated fully to TS
-export default function PluginIcon({ src }) {
+export {};
+
+interface PluginIconProps {
+    src?: string;
+}
+
+export default function PluginIcon({ src }: PluginIconProps) {
     const { Image, Icon } = Stage.Basic;
     return src ? <Image src={src} width="25" /> : <Icon name="plug" size="large" />;
 }
@@ -11,6 +16,12 @@ PluginIcon.propTypes = {
 PluginIcon.defaultProps = {
     src: null
 };
+
+declare global {
+    namespace Stage.Common {
+        export { PluginIcon };
+    }
+}
 
 Stage.defineCommon({
     name: 'PluginIcon',

--- a/widgets/pluginsCatalog/src/Actions.ts
+++ b/widgets/pluginsCatalog/src/Actions.ts
@@ -1,30 +1,6 @@
-// @ts-nocheck File not migrated fully to TS
-/**
- * Created by Tamer on 30/07/2017.
- */
-
-/**
- * @class Actions
- */
 export default class Actions {
-    /**
-     * Creates an instance of Actions.
-     *
-     * @param {object} o
-     * @memberof Actions
-     * @access public
-     */
-    constructor(o) {
-        this.toolbox = o.toolbox;
-        this.jsonPath = o.jsonPath;
-    }
+    constructor(private readonly toolbox: Stage.Types.Toolbox, private readonly jsonPath: string) {}
 
-    /**
-     * get plugins list
-     *
-     * @returns Promise(json)
-     * @access public
-     */
     doGetPluginsList() {
         return this.toolbox
             .getInternal()
@@ -32,15 +8,10 @@ export default class Actions {
             .then(response => response.json());
     }
 
-    /**
-     * upload plugins to api
-     *
-     * @param wagonUrl
-     * @param yamlUrl
-     * @param visibility
-     * @access public
-     */
-    doUpload({ url: wagonUrl, yamlUrl, icon: iconUrl, title }, visibility) {
+    doUpload(
+        { url: wagonUrl, yamlUrl, icon: iconUrl, title }: { url: string; yamlUrl: string; icon: string; title: string },
+        visibility: string
+    ) {
         const params = {
             visibility,
             wagonUrl,

--- a/widgets/pluginsCatalog/src/PluginsCatalogModal.tsx
+++ b/widgets/pluginsCatalog/src/PluginsCatalogModal.tsx
@@ -1,10 +1,27 @@
-// @ts-nocheck File not migrated fully to TS
-export default function PluginsCatalogModal({ actions, onSuccess, onHide, open, plugin, toolbox }) {
+import Actions from './Actions';
+
+export interface PluginsCatalogModalProps {
+    actions: Actions;
+    onSuccess: (message: string) => void;
+    onHide: () => void;
+    open: boolean;
+    plugin: { title: string; url: string; yamlUrl: string; icon: string };
+    toolbox: Stage.Types.Toolbox;
+}
+
+export default function PluginsCatalogModal({
+    actions,
+    onSuccess,
+    onHide,
+    open,
+    plugin,
+    toolbox
+}: PluginsCatalogModalProps) {
     const { useBoolean, useOpenProp, useInput } = Stage.Hooks;
     const { useState } = React;
 
     const [isLoading, setLoading, unsetLoading] = useBoolean();
-    const [error, setError] = useState();
+    const [error, setError] = useState<string | null>(null);
     const [visibility, setVisibility, clearVisibility] = useInput(Stage.Common.Consts.defaultVisibility);
     useOpenProp(open, () => {
         unsetLoading();
@@ -61,18 +78,3 @@ export default function PluginsCatalogModal({ actions, onSuccess, onHide, open, 
         </div>
     );
 }
-
-PluginsCatalogModal.propTypes = {
-    actions: PropTypes.shape({
-        doUpload: PropTypes.func
-    }).isRequired,
-    onHide: PropTypes.func.isRequired,
-    onSuccess: PropTypes.func.isRequired,
-    open: PropTypes.bool.isRequired,
-    plugin: PropTypes.shape({ title: PropTypes.string }),
-    toolbox: Stage.PropTypes.Toolbox.isRequired
-};
-
-PluginsCatalogModal.defaultProps = {
-    plugin: null
-};

--- a/widgets/pluginsCatalog/src/types.ts
+++ b/widgets/pluginsCatalog/src/types.ts
@@ -1,0 +1,21 @@
+export interface PluginWagon {
+    name: string;
+    url: string;
+    md5url: string;
+}
+
+export interface PluginDescription {
+    name: string;
+    title: string;
+    version: string;
+    link: string;
+    icon: string;
+    description: string;
+    releases: string;
+    wagons: PluginWagon[];
+}
+
+export interface PluginsCatalogWidgetConfiguration {
+    jsonPath: string;
+    sortByName: boolean;
+}

--- a/widgets/pluginsCatalog/src/widget.tsx
+++ b/widgets/pluginsCatalog/src/widget.tsx
@@ -1,12 +1,10 @@
-// @ts-nocheck File not migrated fully to TS
-/**
- * Created by Tamer on 30/07/2017.
- */
-
 import Actions from './Actions';
 import PluginsCatalogList from './PluginsCatalogList';
+import type { PluginDescription, PluginsCatalogWidgetConfiguration } from './types';
 
-Stage.defineWidget({
+type PluginsCatalogResponse = PluginDescription[];
+
+Stage.defineWidget<unknown, PluginsCatalogResponse | Error, PluginsCatalogWidgetConfiguration>({
     id: 'pluginsCatalog',
     name: 'Plugins Catalog',
     description: 'Shows plugins catalog',
@@ -33,41 +31,24 @@ Stage.defineWidget({
         }
     ],
 
-    /**
-     * fetch data from source
-     *
-     * @param {any} widget
-     * @param {any} toolbox
-     * @param {any} params
-     * @returns
-     */
     fetchData(widget, toolbox) {
-        const actions = new Actions({
-            toolbox,
-            ...widget.configuration
-        });
+        const actions = new Actions(toolbox, widget.configuration.jsonPath);
 
         return actions.doGetPluginsList().catch(e => (e instanceof Error ? e : Error(e)));
     },
 
-    /**
-     * render widget
-     *
-     * @param {any} widget
-     * @param {any} data
-     * @param {any} error
-     * @param {any} toolbox
-     * @returns
-     */
-    render(widget, data, error, toolbox) {
-        const { Basic, Common } = Stage;
+    render(widget, data, _error, toolbox) {
+        const {
+            Basic: { Loading },
+            Common: { NoDataMessage }
+        } = Stage;
 
         if (data instanceof Error) {
-            return <Common.NoDataMessage error={data} repositoryName="plugins" />;
+            return <NoDataMessage error={data} repositoryName="plugins" />;
         }
 
-        if (_.isEmpty(data)) {
-            return <Basic.Loading />;
+        if (Stage.Utils.isEmptyWidgetData(data)) {
+            return <Loading />;
         }
 
         let formattedData = data;


### PR DESCRIPTION
This PR migrates the Plugins Catalog widget fully to TypeScript. My aim was only to make the code simpler to understand and keep functional changes to a minimum. I have also added system tests for the Plugins Catalog widget to make sure that the basic workflow (upload a plugin and check that it is visible in the Plugins widget) works.

There are no user-facing changes, only internal ones, so I'm not posting any screenshots.

I have verified that the error message is shown correctly after uploading a malformed plugin (some data was missing in the request body) and that the plugins are actually uploaded (which is also verified by the system test).

There will be a separate PR for RD-2483 that actually adds a new "Uploaded version" column to the Plugins Catalog widget. I am raising these changes as a separate PR to make it easier to review since those are 2 distinct changes.

I will cherry-pick this PR to `master` once it is merged.

## System tests

https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/892/pipeline

Queued 2021-07-06 9:48 CEST