### PR TITLE
RD-2483 Display uploaded plugin version in Plugins Catalog widget

### DIFF
--- a/.size-limit
+++ b/.size-limit
@@ -13,7 +13,7 @@
     },
     {
         "name": "Widgets",
-        "limit": "2.97 MB",
+        "limit": "3.00 MB",
         "gzip": false,
         "running": false,
         "path": ["dist/appData/widgets", "!dist/appData/widgets/**/*.gz"]

--- a/test/cypress/integration/widgets/plugins_catalog_spec.ts
+++ b/test/cypress/integration/widgets/plugins_catalog_spec.ts
@@ -72,5 +72,18 @@ describe('Plugins Catalog widget', () => {
                 .should('exist')
                 .and('not.be.disabled');
         });
+
+        it('should refresh the uploaded version when the plugin is removed', () => {
+            cy.contains('.pluginsTable tbody tr', pluginToUpload).find('i[title="Delete"]').click();
+            cy.get('.modal').contains('button', 'Yes').click().should('not.exist');
+
+            const uploadedVersionColumnNumber = 5;
+            // NOTE: manually query for the specific column to use Cypress' retries.
+            // Using `getTable` did not retry
+            cy.contains('.pluginsCatalogWidget tr', pluginToUpload).contains(
+                `td:nth-of-type(${uploadedVersionColumnNumber})`,
+                '-'
+            );
+        });
     });
 });

--- a/test/cypress/integration/widgets/plugins_catalog_spec.ts
+++ b/test/cypress/integration/widgets/plugins_catalog_spec.ts
@@ -75,7 +75,12 @@ describe('Plugins Catalog widget', () => {
 
         it('should refresh the uploaded version when the plugin is removed', () => {
             cy.contains('.pluginsTable tbody tr', pluginToUpload).find('i[title="Delete"]').click();
-            cy.get('.modal').contains('button', 'Yes').click().should('not.exist');
+            cy.get('.modal').within(() => {
+                // NOTE: force removal, as there is some dependency between test suites that prevents regular removal
+                cy.contains('.checkbox', 'Force').find('input[type="checkbox"]').click({ force: true });
+                cy.contains('button', 'Yes').click();
+            });
+            cy.get('.modal').should('not.exist');
 
             const uploadedVersionColumnNumber = 5;
             // NOTE: manually query for the specific column to use Cypress' retries.

--- a/test/cypress/integration/widgets/plugins_catalog_spec.ts
+++ b/test/cypress/integration/widgets/plugins_catalog_spec.ts
@@ -6,29 +6,71 @@ describe('Plugins Catalog widget', () => {
         sortByName: true
     };
 
-    before(() => cy.activate());
-    beforeEach(() => cy.deletePlugins().usePageMock(['pluginsCatalog', 'plugins'], widgetConfiguration).mockLogin());
+    before(() => cy.activate().deletePlugins());
 
-    it('should allow uploading the latest version of a plugin', () => {
+    describe('after uploading the "Utilities" plugin', () => {
         const pluginToUpload = 'Utilities';
-        cy.uploadPluginFromCatalog(pluginToUpload);
+        before(() =>
+            cy
+                .usePageMock(['pluginsCatalog', 'plugins'], widgetConfiguration)
+                .mockLogin()
+                .uploadPluginFromCatalog(pluginToUpload)
+        );
 
-        cy.get('.pluginsCatalogWidget table')
-            .getTable()
-            .then(pluginsCatalogTable => {
-                const pluginCatalogRow = pluginsCatalogTable.find(row => row.Name === pluginToUpload);
-                expect(pluginCatalogRow).not.to.be.undefined;
-                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                const latestPluginVersion: string = pluginCatalogRow!.Version;
+        it('should allow uploading the latest version of a plugin', () => {
+            cy.get('.pluginsCatalogWidget table')
+                .getTable()
+                .then(pluginsCatalogTableRows => {
+                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                    const pluginCatalogRow = pluginsCatalogTableRows.find(row => row.Name === pluginToUpload)!;
+                    expect(pluginCatalogRow).not.to.be.undefined;
+                    const latestPluginVersion: string = pluginCatalogRow.Version;
 
-                cy.log('Verify if plugin is visible in the Plugins widget');
-                cy.get('.pluginsWidget table')
-                    .getTable()
-                    .then(pluginsTable => {
-                        const uploadedPluginRow = pluginsTable.find(row => row.Plugin === pluginToUpload);
-                        expect(uploadedPluginRow).not.to.be.undefined;
-                        expect(uploadedPluginRow?.['Package version']).to.equal(latestPluginVersion);
-                    });
-            });
+                    cy.log('Verify if plugin is visible in the Plugins widget');
+                    cy.get('.pluginsWidget table')
+                        .getTable()
+                        .then(pluginsTable => {
+                            const uploadedPluginRow = pluginsTable.find(row => row.Plugin === pluginToUpload);
+                            expect(uploadedPluginRow).not.to.be.undefined;
+                            expect(uploadedPluginRow?.['Package version']).to.equal(latestPluginVersion);
+                        });
+
+                    expect(pluginCatalogRow['Uploaded version']).to.equal(latestPluginVersion);
+                });
+
+            cy.contains('.pluginsCatalogWidget tbody tr', pluginToUpload)
+                .find('button[title="Latest version is already uploaded"]')
+                .should('exist')
+                .and('be.disabled');
+        });
+
+        it('should allow uploading the plugin when the uploaded version is different than the latest one', () => {
+            const mockPluginVersion = '0.1.0';
+
+            cy.interceptSp('GET', '/plugins?_include=package_name,package_version&package_name=', {
+                metadata: { pagination: { total: 1, size: 1000, offset: 0 }, filtered: null },
+                items: [
+                    {
+                        package_name: 'cloudify-utilities-plugin',
+                        package_version: mockPluginVersion
+                    }
+                ]
+            }).refreshPage();
+
+            cy.get('.pluginsCatalogWidget table')
+                .getTable()
+                .then(pluginsCatalogTableRows => {
+                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                    const pluginCatalogRow = pluginsCatalogTableRows.find(row => row.Name === pluginToUpload)!;
+                    expect(pluginCatalogRow).not.to.be.undefined;
+                    expect(pluginCatalogRow['Uploaded version']).to.equal(mockPluginVersion);
+                    expect(pluginCatalogRow.Version).not.to.equal(pluginCatalogRow['Uploaded version']);
+                });
+
+            cy.contains('.pluginsCatalogWidget tbody tr', pluginToUpload)
+                .find('button[title="Upload plugin"]')
+                .should('exist')
+                .and('not.be.disabled');
+        });
     });
 });

--- a/widgets/pluginsCatalog/src/Actions.ts
+++ b/widgets/pluginsCatalog/src/Actions.ts
@@ -1,7 +1,44 @@
+import type { PluginDescription, PluginDescriptionWithVersion } from './types';
+
+interface UploadedPlugin {
+    // NOTE: property names match from the backend ones
+    /* eslint-disable camelcase */
+    package_name: string;
+    package_version: string;
+    /* eslint-disable camelcase */
+}
+
 export default class Actions {
     constructor(private readonly toolbox: Stage.Types.Toolbox, private readonly jsonPath: string) {}
 
-    doGetPluginsList() {
+    async doGetPluginsList(): Promise<PluginDescriptionWithVersion[]> {
+        const pluginDescriptions = await this.doGetPluginsCatalogList();
+
+        const uploadedPlugins: Stage.Types.PaginatedResponse<UploadedPlugin> = await this.toolbox
+            .getManager()
+            .doGet('/plugins?_include=package_name,package_version', {
+                params: {
+                    package_name: pluginDescriptions.map(({ name }) => name),
+                    ...(this.toolbox.getContext().getValue('onlyMyResources')
+                        ? { created_by: this.toolbox.getManager().getCurrentUsername() }
+                        : {})
+                }
+            });
+
+        const uploadedPluginsVersions = new Map(
+            // eslint-disable-next-line camelcase
+            uploadedPlugins.items.map(({ package_name, package_version }) => [package_name, package_version])
+        );
+
+        return pluginDescriptions.map(
+            (pluginDescription): PluginDescriptionWithVersion => ({
+                pluginDescription,
+                uploadedVersion: uploadedPluginsVersions.get(pluginDescription.name)
+            })
+        );
+    }
+
+    private doGetPluginsCatalogList(): Promise<PluginDescription[]> {
         return this.toolbox
             .getInternal()
             .doGet('/external/content', { params: { url: this.jsonPath }, parseResponse: false })

--- a/widgets/pluginsCatalog/src/PluginsCatalogList.tsx
+++ b/widgets/pluginsCatalog/src/PluginsCatalogList.tsx
@@ -1,3 +1,6 @@
+import type { ComponentProps, ComponentType } from 'react';
+import styled from 'styled-components';
+
 import PluginsCatalogModal, { PluginsCatalogModalProps } from './PluginsCatalogModal';
 import Actions from './Actions';
 import type { PluginDescriptionWithVersion, PluginsCatalogWidgetConfiguration } from './types';
@@ -14,6 +17,19 @@ interface PluginsCatalogListState {
     /** Potentially holds a message after a successful upload */
     success: string | null;
 }
+
+const UploadPluginButton: ComponentType<ComponentProps<typeof Stage.Basic.Button>> = styled(Stage.Basic.Button)`
+    // NOTE: increase specificity to override semantic-ui's style
+    &&& {
+        ${props =>
+            props.disabled &&
+            // NOTE: enables showing the title on a disabled button
+            // Uses `!important` to override semantic-ui's `!important`
+            // Count not be applied via inline `style` prop due to
+            // https://github.com/facebook/react/issues/1881
+            'pointer-events: auto !important;'}
+    }
+`;
 
 export default class PluginsCatalogList extends React.Component<PluginsCatalogListProps, PluginsCatalogListState> {
     constructor(props: PluginsCatalogListProps) {
@@ -55,7 +71,7 @@ export default class PluginsCatalogList extends React.Component<PluginsCatalogLi
         const { plugin, showModal, success } = this.state;
         const { items: itemsProp, toolbox, widget } = this.props;
         const NO_DATA_MESSAGE = "There are no Plugins available in catalog. Check widget's configuration.";
-        const { DataTable, Message, Button } = Stage.Basic;
+        const { DataTable, Message } = Stage.Basic;
         const { PluginIcon } = Stage.Common;
 
         const distro = `${toolbox
@@ -99,7 +115,7 @@ export default class PluginsCatalogList extends React.Component<PluginsCatalogLi
                                 <DataTable.Data>{item.version}</DataTable.Data>
                                 <DataTable.Data>{item.uploadedVersion ?? '-'}</DataTable.Data>
                                 <DataTable.Data className="center aligned">
-                                    <Button
+                                    <UploadPluginButton
                                         icon="upload"
                                         onClick={event => {
                                             event.preventDefault();
@@ -110,6 +126,10 @@ export default class PluginsCatalogList extends React.Component<PluginsCatalogLi
                                                 yamlUrl: item.link
                                             });
                                         }}
+                                        // eslint-disable-next-line react/jsx-props-no-spreading
+                                        {...(item.version === item.uploadedVersion
+                                            ? { disabled: true, title: 'Latest version is already uploaded' }
+                                            : { disabled: false, title: 'Upload plugin' })}
                                     />
                                 </DataTable.Data>
                             </DataTable.Row>

--- a/widgets/pluginsCatalog/src/PluginsCatalogList.tsx
+++ b/widgets/pluginsCatalog/src/PluginsCatalogList.tsx
@@ -85,6 +85,7 @@ export default class PluginsCatalogList extends React.Component<PluginsCatalogLi
                     <DataTable.Column label="Name" width="20%" />
                     <DataTable.Column label="Description" width="60%" />
                     <DataTable.Column label="Version" width="10%" />
+                    <DataTable.Column label="Uploaded version" width="10%" />
                     <DataTable.Column width="5%" />
 
                     {plugins.map(item => {
@@ -96,6 +97,7 @@ export default class PluginsCatalogList extends React.Component<PluginsCatalogLi
                                 <DataTable.Data>{item.title}</DataTable.Data>
                                 <DataTable.Data>{item.description}</DataTable.Data>
                                 <DataTable.Data>{item.version}</DataTable.Data>
+                                <DataTable.Data>{item.uploadedVersion ?? '-'}</DataTable.Data>
                                 <DataTable.Data className="center aligned">
                                     <Button
                                         icon="upload"

--- a/widgets/pluginsCatalog/src/PluginsCatalogList.tsx
+++ b/widgets/pluginsCatalog/src/PluginsCatalogList.tsx
@@ -41,6 +41,11 @@ export default class PluginsCatalogList extends React.Component<PluginsCatalogLi
         };
     }
 
+    componentDidMount() {
+        const { toolbox } = this.props;
+        toolbox.getEventBus().on('plugins:refresh', this.refreshData, this);
+    }
+
     shouldComponentUpdate(nextProps: PluginsCatalogListProps, nextState: PluginsCatalogListState) {
         const { items, widget } = this.props;
         return (
@@ -50,20 +55,30 @@ export default class PluginsCatalogList extends React.Component<PluginsCatalogLi
         );
     }
 
-    onSuccess: PluginsCatalogModalProps['onSuccess'] = msg => {
+    componentWillUnmount() {
+        const { toolbox } = this.props;
+        toolbox.getEventBus().off('plugins:refresh', this.refreshData);
+    }
+
+    private onSuccess: PluginsCatalogModalProps['onSuccess'] = msg => {
         this.setState({ success: msg });
     };
 
-    onUpload(plugin: PluginsCatalogModalProps['plugin']) {
+    private onUpload(plugin: PluginsCatalogModalProps['plugin']) {
         this.setState({ plugin });
         this.showModal();
     }
 
-    hideModal = () => {
+    private hideModal = () => {
         this.setState({ showModal: false });
     };
 
-    showModal() {
+    private refreshData = () => {
+        const { toolbox } = this.props;
+        toolbox.refresh();
+    };
+
+    private showModal() {
         this.setState({ showModal: true });
     }
 

--- a/widgets/pluginsCatalog/src/PluginsCatalogList.tsx
+++ b/widgets/pluginsCatalog/src/PluginsCatalogList.tsx
@@ -1,9 +1,9 @@
 import PluginsCatalogModal, { PluginsCatalogModalProps } from './PluginsCatalogModal';
 import Actions from './Actions';
-import type { PluginDescription, PluginsCatalogWidgetConfiguration } from './types';
+import type { PluginDescriptionWithVersion, PluginsCatalogWidgetConfiguration } from './types';
 
 interface PluginsCatalogListProps {
-    items: PluginDescription[];
+    items: PluginDescriptionWithVersion[];
     widget: Stage.Types.Widget<PluginsCatalogWidgetConfiguration>;
     toolbox: Stage.Types.Toolbox;
 }
@@ -62,13 +62,13 @@ export default class PluginsCatalogList extends React.Component<PluginsCatalogLi
             .getManager()
             .getDistributionName()
             .toLowerCase()} ${toolbox.getManager().getDistributionRelease().toLowerCase()}`;
-        const items = _.compact(
+        const plugins = _.compact(
             _.map(itemsProp, item => {
                 const wagon = _.find(
-                    item.wagons,
+                    item.pluginDescription.wagons,
                     w => w.name.toLowerCase() === distro || w.name.toLowerCase() === 'any'
                 );
-                return wagon ? { ...item, wagon } : undefined;
+                return wagon ? { ...item.pluginDescription, wagon, uploadedVersion: item.uploadedVersion } : undefined;
             })
         );
 
@@ -80,14 +80,14 @@ export default class PluginsCatalogList extends React.Component<PluginsCatalogLi
                     </Message>
                 )}
 
-                <DataTable noDataAvailable={items.length === 0} selectable noDataMessage={NO_DATA_MESSAGE}>
+                <DataTable noDataAvailable={plugins.length === 0} selectable noDataMessage={NO_DATA_MESSAGE}>
                     <DataTable.Column width="2%" />
                     <DataTable.Column label="Name" width="20%" />
                     <DataTable.Column label="Description" width="60%" />
                     <DataTable.Column label="Version" width="10%" />
                     <DataTable.Column width="5%" />
 
-                    {items.map(item => {
+                    {plugins.map(item => {
                         return (
                             <DataTable.Row key={item.title}>
                                 <DataTable.Data>

--- a/widgets/pluginsCatalog/src/types.ts
+++ b/widgets/pluginsCatalog/src/types.ts
@@ -15,6 +15,11 @@ export interface PluginDescription {
     wagons: PluginWagon[];
 }
 
+export interface PluginDescriptionWithVersion {
+    pluginDescription: PluginDescription;
+    uploadedVersion: string | undefined;
+}
+
 export interface PluginsCatalogWidgetConfiguration {
     jsonPath: string;
     sortByName: boolean;

--- a/widgets/pluginsCatalog/src/widget.tsx
+++ b/widgets/pluginsCatalog/src/widget.tsx
@@ -1,8 +1,8 @@
 import Actions from './Actions';
 import PluginsCatalogList from './PluginsCatalogList';
-import type { PluginDescription, PluginsCatalogWidgetConfiguration } from './types';
+import type { PluginDescriptionWithVersion, PluginsCatalogWidgetConfiguration } from './types';
 
-type PluginsCatalogResponse = PluginDescription[];
+type PluginsCatalogResponse = PluginDescriptionWithVersion[];
 
 Stage.defineWidget<unknown, PluginsCatalogResponse | Error, PluginsCatalogWidgetConfiguration>({
     id: 'pluginsCatalog',
@@ -53,7 +53,7 @@ Stage.defineWidget<unknown, PluginsCatalogResponse | Error, PluginsCatalogWidget
 
         let formattedData = data;
         if (_.get(widget.configuration, 'sortByName', false)) {
-            formattedData = _.sortBy(data, 'title');
+            formattedData = _.sortBy(data, item => item.pluginDescription.title);
         }
 
         return <PluginsCatalogList widget={widget} items={formattedData} toolbox={toolbox} />;


### PR DESCRIPTION
This PR adds the "Uploaded version" column to the Plugins Catalog widget. If the uploaded plugin version is the same as the latest version, the upload button is disabled with an appropriate tooltip.

I have also added a system test that verifies the code added/modified in this PR matches expectations.

This PR relies on #1495 being merged first. The changes from both PRs will have to be cherry-picked to `master` as well.

## Screenshots/video

A new column:
![image](https://user-images.githubusercontent.com/889383/124584007-08baa180-de54-11eb-9858-3da0831fa8ff.png)

Versions shown for installed plugins:
![image](https://user-images.githubusercontent.com/889383/124583982-ffc9d000-de53-11eb-9a11-d73433057c02.png)

Tooltip when the Upload button is disabled:
![image](https://user-images.githubusercontent.com/889383/124584079-1ec86200-de54-11eb-99dd-0ff20b7e2cde.png)

Whole workflow:

https://user-images.githubusercontent.com/889383/124586698-09086c00-de57-11eb-88c0-a60e5a1b5091.mp4

## System tests

https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/895/pipeline

Queued 2021-07-06 13:39 CEST