### PR TITLE
RD-2128 Fix margin for widgets maximized on small screens

### DIFF
--- a/app/components/Page.tsx
+++ b/app/components/Page.tsx
@@ -29,6 +29,7 @@ import { setEditMode } from '../actions/config';
 import type { ReduxState } from '../reducers';
 import type { WidgetDefinition } from '../utils/StageAPI';
 import type { DrilldownContext } from '../reducers/drilldownContextReducer';
+import StageUtils from '../utils/stageUtils';
 
 export interface PageOwnProps {
     pageId: string;
@@ -62,15 +63,15 @@ class Page extends Component<PageProps, never> {
             page,
             pagesList
         } = this.props;
-        const maximizeWidget =
+        const hasMaximizedWidget =
             _(page.layout).flatMap('content').find({ maximized: true }) ||
             _(page.layout).flatMap('content').flatMap('widgets').find({ maximized: true });
 
-        document.body.style.overflow = maximizeWidget ? 'hidden' : 'inherit';
+        document.body.style.overflow = hasMaximizedWidget ? 'hidden' : 'inherit';
         window.scroll(0, 0);
 
         return (
-            <div className={`fullHeight ${maximizeWidget ? 'maximizeWidget' : ''}`}>
+            <div className={StageUtils.combineClassNames('fullHeight', hasMaximizedWidget && 'maximizeWidget')}>
                 <Breadcrumbs
                     pagesList={pagesList}
                     onPageNameChange={onPageNameChange}

--- a/app/styles/style.scss
+++ b/app/styles/style.scss
@@ -1,7 +1,5 @@
 @import '~cloudify-ui-common/styles/colors';
 
-body {
-}
 
 a:hover {
   text-decoration: underline !important;

--- a/app/styles/style.scss
+++ b/app/styles/style.scss
@@ -168,9 +168,6 @@ a:hover {
   }
 }
 
-.pageMenuItem {
-}
-
 .pageRemoveButton {
     position: absolute;
     right : 5px;

--- a/app/styles/style.scss
+++ b/app/styles/style.scss
@@ -151,15 +151,17 @@ a:hover {
   display: none;
 
   &.maximize {
+    $maximizedWidgetGap: 1rem;
+
     display: block;
     width: auto !important;
     height: auto !important;
     transform: translate(0px, 0px) !important;
     position: fixed !important;
     top: 8rem !important;
-    bottom: 1rem !important;
-    left: 14rem !important;
-    right: 1rem !important;
+    bottom: $maximizedWidgetGap !important;
+    left: ($sidebarWidth + $maximizedWidgetGap) !important;
+    right: $maximizedWidgetGap !important;
     outline: 0;
 
     .widget{

--- a/app/styles/style.scss
+++ b/app/styles/style.scss
@@ -1,6 +1,7 @@
 @import '~cloudify-ui-common/styles/colors';
 
 $sidebarAlwaysVisibleBreakpoint: 992px;
+$sidebarWidth: 13rem; // NOTE: defined in Semantic UI
 
 a:hover {
   text-decoration: underline !important;
@@ -64,7 +65,7 @@ a:hover {
 
   .page {
     @media (min-width: $sidebarAlwaysVisibleBreakpoint) {
-      margin-left: 13rem;
+      margin-left: $sidebarWidth;
     }
     $input-padding: 4.85px 9px !important;
     $input-left: -10px;
@@ -121,7 +122,7 @@ a:hover {
 .ui.segment.addPageContainer {
   position:fixed;
   bottom: 0;
-  width: 13rem;
+  width: $sidebarWidth;
   z-index:1;
   transition: all 500ms cubic-bezier(.55, 0, .1, 1);
   left: -200px;
@@ -666,7 +667,7 @@ a.underline {
   margin: 0 calc(50% - 250px) !important;
   display: block;
   @media (min-width: $sidebarAlwaysVisibleBreakpoint) {
-    left: 6.5rem !important;
+    left: ($sidebarWidth / 2) !important;
   }
 
   .content {

--- a/app/styles/style.scss
+++ b/app/styles/style.scss
@@ -1,5 +1,6 @@
 @import '~cloudify-ui-common/styles/colors';
 
+$sidebarAlwaysVisibleBreakpoint: 992px;
 
 a:hover {
   text-decoration: underline !important;
@@ -22,7 +23,7 @@ a:hover {
 }
 
 .show-on-small-screen {
-  @media (min-width: 992px) {
+  @media (min-width: $sidebarAlwaysVisibleBreakpoint) {
     display: none !important;
   }
 }
@@ -42,7 +43,7 @@ a:hover {
       height: calc(100% - 55px) !important;
       transition: all 500ms cubic-bezier(.55, 0, .1, 1);
       left: -200px;
-      @media (min-width: 992px) {
+      @media (min-width: $sidebarAlwaysVisibleBreakpoint) {
         left: 0;
       }
       &.open{
@@ -62,7 +63,7 @@ a:hover {
   }
 
   .page {
-    @media (min-width: 992px) {
+    @media (min-width: $sidebarAlwaysVisibleBreakpoint) {
       margin-left: 13rem;
     }
     $input-padding: 4.85px 9px !important;
@@ -124,7 +125,7 @@ a:hover {
   z-index:1;
   transition: all 500ms cubic-bezier(.55, 0, .1, 1);
   left: -200px;
-  @media (min-width: 992px) {
+  @media (min-width: $sidebarAlwaysVisibleBreakpoint) {
     left: 0;
   }
   &.open{
@@ -664,7 +665,7 @@ a.underline {
   max-width: 500px !important;
   margin: 0 calc(50% - 250px) !important;
   display: block;
-  @media (min-width: 992px) {
+  @media (min-width: $sidebarAlwaysVisibleBreakpoint) {
     left: 6.5rem !important;
   }
 

--- a/app/styles/style.scss
+++ b/app/styles/style.scss
@@ -160,7 +160,10 @@ a:hover {
     position: fixed !important;
     top: 8rem !important;
     bottom: $maximizedWidgetGap !important;
-    left: ($sidebarWidth + $maximizedWidgetGap) !important;
+    left: $maximizedWidgetGap !important;
+    @media (min-width: $sidebarAlwaysVisibleBreakpoint) {
+      left: ($sidebarWidth + $maximizedWidgetGap) !important;
+    }
     right: $maximizedWidgetGap !important;
     outline: 0;
 

--- a/app/utils/shared/combineClassNames.ts
+++ b/app/utils/shared/combineClassNames.ts
@@ -1,6 +1,5 @@
-// @ts-nocheck File not migrated fully to TS
-/**
- * @param {(string | null | undefined | boolean)[]} classNames
- */
-const combineClassNames = classNames => classNames.filter(Boolean).join(' ');
+type PossibleClassNameEntry = string | number | null | undefined | boolean;
+
+const combineClassNames = (...classNames: (PossibleClassNameEntry | PossibleClassNameEntry[])[]) =>
+    classNames.flat().filter(Boolean).join(' ');
 export default combineClassNames;

--- a/test/jest/utils/shared/combineClassNames.test.ts
+++ b/test/jest/utils/shared/combineClassNames.test.ts
@@ -1,7 +1,13 @@
 import combineClassNames from 'utils/shared/combineClassNames';
 
 describe('(Utils) combineClassNames', () => {
-    const cases = [
+    interface TestCase {
+        description: string;
+        classNames: Parameters<typeof combineClassNames>;
+        expectedResult: string;
+    }
+
+    const cases: TestCase[] = [
         {
             description: 'a single string',
             classNames: ['a'],
@@ -21,12 +27,17 @@ describe('(Utils) combineClassNames', () => {
             description: 'all falsy values',
             classNames: [false, 0, ''],
             expectedResult: ''
+        },
+        {
+            description: 'nested arrays',
+            classNames: [['a', 'b'], 'c', ['d'], false && 'e', false],
+            expectedResult: 'a b c d'
         }
     ];
 
     cases.forEach(c => {
         it(`should work for ${c.description}`, () => {
-            const result = combineClassNames(c.classNames);
+            const result = combineClassNames(...c.classNames);
             expect(result).toEqual(c.expectedResult);
         });
     });


### PR DESCRIPTION
This PR fixes the left margin for maximized widgets on smaller screens - it did not respect the fact that the sidebar is collapsed in such conditions and always assumed it is there. The actual fix is in 361212e54422e1b87ec96e9889bf485586b99b22.

Other commits are refactors/improvements that I made along the way as I was investigating the problem. They should not have any user-facing result or functional changes.

## Video


https://user-images.githubusercontent.com/889383/125455533-db20432b-24ba-42e6-9b9c-85616f935de2.mp4

## System tests

https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/913/pipeline

Queued 2021-07-13 14:59 CEST