### PR TITLE
RD-1827 Remove double loader in DeploymentActionButtons widget

### DIFF
--- a/app/components/PagesList.tsx
+++ b/app/components/PagesList.tsx
@@ -30,7 +30,7 @@ export interface PagesListState {
 }
 export default class PagesList extends Component<PagesListProps, PagesListState> {
     // eslint-disable-next-line react/static-property-placement
-    propTypes = {
+    static propTypes = {
         onPageSelected: PropTypes.func.isRequired,
         onPageRemoved: PropTypes.func.isRequired,
         onPageReorder: PropTypes.func.isRequired,
@@ -49,7 +49,7 @@ export default class PagesList extends Component<PagesListProps, PagesListState>
 
     // NOTE: TypeScript need static defaultProps to mark those props as non-optional in `this.props`
     // eslint-disable-next-line react/static-property-placement
-    defaultProps = {
+    static defaultProps = {
         selected: ''
     };
 

--- a/app/utils/StageAPI.ts
+++ b/app/utils/StageAPI.ts
@@ -139,7 +139,11 @@ export type { StageWidgetData as WidgetData };
 export function isEmptyWidgetData(data: unknown): data is Record<string, never> | undefined {
     return (
         data === undefined ||
-        (typeof data === 'object' && data !== null && !Array.isArray(data) && Object.keys(data).length === 0)
+        (typeof data === 'object' &&
+            data !== null &&
+            !Array.isArray(data) &&
+            Object.keys(data).length === 0 &&
+            !(data instanceof Error))
     );
 }
 

--- a/test/cypress/integration/widgets/deployment_actions_spec.ts
+++ b/test/cypress/integration/widgets/deployment_actions_spec.ts
@@ -16,7 +16,7 @@ describe('Deployment Action Buttons widget', () => {
             .deployBlueprint(blueprintName, deploymentId, { server_ip: '127.0.0.1' }, { display_name: deploymentName })
     );
 
-    it('when deploymentId is not set in the context it should be disabled', () => {
+    it('should be disabled when deploymentId is not set in the context', () => {
         cy.contains('button', 'Execute workflow').should('have.attr', 'disabled');
         cy.contains('button', 'Deployment actions').should('have.attr', 'disabled');
     });

--- a/widgets/common/src/DeploymentActions.ts
+++ b/widgets/common/src/DeploymentActions.ts
@@ -157,7 +157,8 @@ export default class DeploymentActions {
             .then(({ items }) => items);
     }
 
-    doGetWorkflows(deploymentId: string) {
+    // eslint-disable-next-line camelcase
+    doGetWorkflows(deploymentId: string): Promise<{ id: string; display_name: string; workflows: unknown[] }> {
         return this.toolbox.getManager().doGet(`/deployments/${deploymentId}?_include=id,display_name,workflows`);
     }
 

--- a/widgets/common/src/DeploymentActionsMenu.tsx
+++ b/widgets/common/src/DeploymentActionsMenu.tsx
@@ -1,4 +1,5 @@
-// @ts-nocheck File not migrated fully to TS
+import type { ReactNode, ComponentProps } from 'react';
+
 export const actions = Object.freeze({
     delete: 'delete',
     forceDelete: 'forceDelete',
@@ -9,7 +10,7 @@ export const actions = Object.freeze({
     update: 'update'
 });
 
-const translate = (key, params) => Stage.i18n.t(`widgets.common.deployments.actionsMenu.${key}`, params);
+const translate = Stage.Utils.getT('widgets.common.deployments.actionsMenu');
 const menuItems = [
     { name: actions.install, icon: 'play', permission: 'execution_start' },
     { name: actions.update, icon: 'edit', permission: 'deployment_update_create' },
@@ -20,7 +21,13 @@ const menuItems = [
     { name: actions.forceDelete, icon: 'trash', permission: 'deployment_delete' }
 ];
 
-export default function DeploymentActionsMenu({ onActionClick, toolbox, trigger }) {
+interface DeploymentActionsMenuProps {
+    onActionClick: (actionName: string) => void;
+    toolbox: Stage.Types.Toolbox;
+    trigger: ReactNode;
+}
+
+export default function DeploymentActionsMenu({ onActionClick, toolbox, trigger }: DeploymentActionsMenuProps) {
     const {
         Basic: { Menu, Popup, PopupMenu },
         Utils: { isUserAuthorized },
@@ -38,13 +45,16 @@ export default function DeploymentActionsMenu({ onActionClick, toolbox, trigger 
         ? { bordered: true, help: i18n.t('widgets.common.deployments.actionsMenu.tooltip'), offset: [0, 5] }
         : {};
 
-    function onItemClick(event, { name }) {
-        onActionClick(name);
-    }
+    const onItemClick: ComponentProps<typeof Menu>['onItemClick'] = (_event, { name }) => {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        onActionClick(name!);
+    };
 
     return (
         // eslint-disable-next-line react/jsx-props-no-spreading
         <PopupMenu className="deploymentActionsMenu" {...popupMenuProps}>
+            {/* TODO(RD-2760): remove the warning after Popup.Trigger can accept `children` */}
+            {/* @ts-expect-error Popup.Trigger does not accept `children` prop */}
             {trigger && <Popup.Trigger>{trigger}</Popup.Trigger>}
             <Menu pointing vertical onItemClick={onItemClick} items={items} />
         </PopupMenu>
@@ -60,6 +70,12 @@ DeploymentActionsMenu.propTypes = {
 DeploymentActionsMenu.defaultProps = {
     trigger: null
 };
+
+declare global {
+    namespace Stage.Common {
+        export { DeploymentActionsMenu };
+    }
+}
 
 Stage.defineCommon({
     name: 'DeploymentActionsMenu',

--- a/widgets/deploymentActionButtons/src/DeploymentActionButtons.tsx
+++ b/widgets/deploymentActionButtons/src/DeploymentActionButtons.tsx
@@ -58,7 +58,6 @@ const DeploymentActionButtons: FunctionComponent<DeploymentActionButtonsProps> =
             />
 
             <DeploymentActionsMenu
-                deploymentId={deploymentId}
                 onActionClick={setActiveAction}
                 toolbox={toolbox}
                 trigger={


### PR DESCRIPTION
This PR removes the extra loading spinner that was shown inside of the `DeploymentActionButtons` widget. Now there will only be a single loader when the deployment data is being fetched from the Manager (the loader comes from our widget framework).

Additionally, this PR:
1. Migrates some code to TypeScript
2. Makes the data fetching states more explicit (explicit error, loading, success states)
3. Fixes some minor problems that I encountered along the way (static properties missing the `static` keyword, `Error` not being handled as widget's `data`)

I tried to add a test to verify that there is only a single loading spinner active, but Cypress was too slow (or the data fetching was too fast) and did not catch the moment that there was a spinner. It always saw 0 spinners when deployment was being picked. I could add some throttling logic and create a test for that, but IMO that's worth more than the 3 SP for this ticket and I believe there can be more value created by me focusing on other tickets :smile: 

## Media

I had network throttling enabled (Slow 3G) to see the loading states. The layout no longer shifts when picking a new deployment


https://user-images.githubusercontent.com/889383/125618644-2e632ecf-6092-4e8e-8856-3aba0de2d51c.mp4

When there is no deployment picked, the buttons are disabled and there is an error logged in the console:
![image](https://user-images.githubusercontent.com/889383/125618911-f457edcc-f489-4fea-991c-d87bcbac6961.png)
![image](https://user-images.githubusercontent.com/889383/125618929-eff5d98f-4f81-4aca-8590-251e6e919aa5.png)


## System tests

https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/919/pipeline

Queued 2021-07-14 14:52 CEST
