### PR TITLE
RD-2769 Fix unbounded resizing of Deployments View panes

### DIFF
--- a/test/cypress/integration/widgets/deployments_view_spec.ts
+++ b/test/cypress/integration/widgets/deployments_view_spec.ts
@@ -213,20 +213,15 @@ describe('Deployments View widget', () => {
                 });
             }
 
-            {
-                cy.log('Try to maximize the left pane');
-                const pxDefinitelyLargerThanScreenWidth = 1e5;
-                resizePanes(pxDefinitelyLargerThanScreenWidth);
-                getDeploymentsViewDetailsPane().should('be.visible');
-            }
+            cy.log('Try to maximize the left pane');
+            const pxDefinitelyLargerThanScreenWidth = 1e5;
+            resizePanes(pxDefinitelyLargerThanScreenWidth);
+            getDeploymentsViewDetailsPane().should('be.visible');
 
-            {
-                cy.log('Try to maximize the right pane');
-                const pxDefinitelyLargerThanScreenWidth = -1e5;
-                resizePanes(pxDefinitelyLargerThanScreenWidth);
-                getDeploymentsViewTable().should('be.visible');
-                expect(table.width()).to.be.greaterThan(0);
-            }
+            cy.log('Try to maximize the right pane');
+            resizePanes(-pxDefinitelyLargerThanScreenWidth);
+            getDeploymentsViewTable().should('be.visible');
+            expect(table.width()).to.be.greaterThan(0);
         });
     });
 

--- a/widgets/common/src/deploymentsView/DeploymentsView.tsx
+++ b/widgets/common/src/deploymentsView/DeploymentsView.tsx
@@ -39,6 +39,8 @@ export interface DeploymentsViewProps {
     additionalFilterRules?: Stage.Common.Filters.Rule[];
 }
 
+const MIN_PANE_WIDTH = 100;
+
 export const DeploymentsView: FunctionComponent<DeploymentsViewProps> = ({
     toolbox,
     widget,
@@ -166,7 +168,13 @@ export const DeploymentsView: FunctionComponent<DeploymentsViewProps> = ({
             )}
 
             <DeploymentsMasterDetailViewContainer>
-                <SplitPane defaultSize="50%" split="vertical" resizerClassName="master-details-view-resizer">
+                <SplitPane
+                    minSize={MIN_PANE_WIDTH}
+                    maxSize={-MIN_PANE_WIDTH}
+                    defaultSize="50%"
+                    split="vertical"
+                    resizerClassName="master-details-view-resizer"
+                >
                     <DeploymentsTableContainer>
                         <DeploymentsTable
                             setGridParams={setGridParams}

--- a/widgets/common/src/deploymentsView/DeploymentsView.tsx
+++ b/widgets/common/src/deploymentsView/DeploymentsView.tsx
@@ -39,7 +39,7 @@ export interface DeploymentsViewProps {
     additionalFilterRules?: Stage.Common.Filters.Rule[];
 }
 
-const MIN_PANE_WIDTH = 100;
+const minPaneWidth = 100;
 
 export const DeploymentsView: FunctionComponent<DeploymentsViewProps> = ({
     toolbox,
@@ -169,8 +169,8 @@ export const DeploymentsView: FunctionComponent<DeploymentsViewProps> = ({
 
             <DeploymentsMasterDetailViewContainer>
                 <SplitPane
-                    minSize={MIN_PANE_WIDTH}
-                    maxSize={-MIN_PANE_WIDTH}
+                    minSize={minPaneWidth}
+                    maxSize={-minPaneWidth}
                     defaultSize="50%"
                     split="vertical"
                     resizerClassName="master-details-view-resizer"

--- a/widgets/common/src/deploymentsView/styles.scss
+++ b/widgets/common/src/deploymentsView/styles.scss
@@ -72,11 +72,14 @@ $deploymentProgressBarColors: (
 
         cursor: col-resize;
         width: $initialWidth;
+        // NOTE: min-width fixes the bar disappearing when there is little room for it
+        min-width: $initialWidth;
         margin: 0 $horizontalMargin;
         background-color: $grey-normal;
 
         &:hover {
             width: $widthOnHover;
+            min-width: $widthOnHover;
             background-color: $grey-dark;
             margin: 0 ($horizontalMargin - ($widthOnHover - $initialWidth) / 2);
         }


### PR DESCRIPTION
1. Add bounds on the minimum widths of panes in the Deployments View widget
when resizing them.
2. Make sure the draggable handle is always visible.
3. Modify system tests to verify that resizing is bounded.

## Video 

https://user-images.githubusercontent.com/889383/126150371-7be2fae6-0617-4730-b652-0132b4352938.mp4

## System tests

https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/933/pipeline

Queued 2021-07-19 13:02 CEST