### PR TITLE
RD-2639 Make system tests independent from running executions

### DIFF
--- a/test/cypress/integration/widgets/maintenance_mode_button_spec.ts
+++ b/test/cypress/integration/widgets/maintenance_mode_button_spec.ts
@@ -9,7 +9,7 @@ describe('Maintenance mode button widget', () => {
     const getDeactivateButton = () => cy.contains('Deactivate Maintenance Mode');
 
     it('should enter maintenance mode on click', () => {
-        cy.waitUntilNoExecutionIsActive();
+        cy.killRunningExecutions();
         getActivateButton().click();
         cy.contains('Yes').click();
         getDeactivateButton().click();

--- a/test/cypress/integration/widgets/servers_num_spec.ts
+++ b/test/cypress/integration/widgets/servers_num_spec.ts
@@ -4,6 +4,7 @@ describe('Number of nodes widget', () => {
             .activate('valid_trial_license')
             .usePageMock('serversNum', { pollingTime: 1 })
             .mockLogin()
+            .killRunningExecutions()
             .deleteDeployments('', true)
     );
 

--- a/test/cypress/integration/widgets/snapshots_spec.ts
+++ b/test/cypress/integration/widgets/snapshots_spec.ts
@@ -10,6 +10,7 @@ describe('Snapshots list widget', () => {
             .deletePlugins()
             .deleteSnapshot(createdSnapshotName)
             .deleteSnapshot(uploadedSnapshotName)
+            .killRunningExecutions()
             .mockLogin()
     );
 


### PR DESCRIPTION
### Changes 

In this PR I merged `waitUntilNoExecutionIsActive` and `killExecutions` Cypress commands into one `killRunningExecutions`. It should be executed before each test which needs no executions running in the Cloudify Manager.

I found 3 tests that are designed in such a way that no running executions is needed:
* Maintenance Mode Button widget test - `maintenance_mode_button_spec.ts`
* Number of Nodes widget test - `servers_num_spec.ts`
* Snapshots widget test - `snapshots_spec.ts`

and added a call to to `killRunningExecutions` command there.

Especially making the first one (Maintenance Mode Button widget test) more reliable can help us avoid problems stemming from turned on Maintenance Mode (failing Topology widget test, Nodes widget test, Nodes Statistics widget test, Outputs/Capabilities widget test). Of course we could also check if Maintenance Mode is activated before the tests and deactive it in case it is active, but IMHO at this point it is not necessary as the root cause for maintenance mode activated problems were due to running executions.

### Verification

I tested my solution the following way:
* Created simple blueprint with long running `install` workflow (thanks @tehasdf for providing it)
* Deployed and installed that blueprint
* Executed each test (mentioned above) and verified that it passes (and it kills that `install` workflow started in the previous step

### System tests

[Stage-UI-System-Test #942](https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/942/pipeline) - deadlock did not happen => cannot verify if the kill execution solution works fine
[Stage-UI-System-Test #943](https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/943/pipeline) - no deadlock => no real verification ;-)