### PR TITLE
RD-1851 Migrate DynamicDropdown to TS and do some minor enhancements

### DIFF
--- a/app/.eslintrc.json
+++ b/app/.eslintrc.json
@@ -10,5 +10,14 @@
     },
     "env": {
         "jquery": true
-    }
+    },
+    "overrides": [
+        {
+            "files": ["*.ts"],
+            "rules": {
+                // NOTE: results in false-positives in regular classes for `context` properties
+                "react/static-property-placement": "off"
+            }
+        }
+    ]
 }

--- a/app/components/EditWidgetModal.tsx
+++ b/app/components/EditWidgetModal.tsx
@@ -6,6 +6,7 @@ import i18n from 'i18next';
 import _ from 'lodash';
 import PropTypes from 'prop-types';
 import React, { useEffect, useState } from 'react';
+import { getToolbox } from '../utils/Toolbox';
 
 import { ApproveButton, CancelButton, Form, GenericField, Message, Modal } from './basic';
 
@@ -75,6 +76,7 @@ export default function EditWidgetModal({ configDef, configuration, show, onHide
                                 label={config.name}
                                 value={fields[config.id]}
                                 onChange={handleInputChange}
+                                widgetlessToolbox={getToolbox(undefined, undefined, undefined)}
                             />
                         ))}
 

--- a/app/components/shared/PageFilter.tsx
+++ b/app/components/shared/PageFilter.tsx
@@ -1,14 +1,16 @@
-// @ts-nocheck File not migrated fully to TS
-/**
- * Created by jakubniezgoda on 21/05/2018.
- */
-
-import _ from 'lodash';
+import _, { noop } from 'lodash';
 import PropTypes from 'prop-types';
-import React, { useState } from 'react';
-import { connect } from 'react-redux';
+import React, { FunctionComponent, useState } from 'react';
+import { useSelector } from 'react-redux';
+import { DropdownProps } from 'semantic-ui-react';
+import type { PageDefinition } from '../../actions/page';
+import type { ReduxState } from '../../reducers';
 
 import { Form } from '../basic';
+
+type PageFilterProps = Pick<Stage.Types.CustomConfigurationComponentProps<string>, 'name' | 'onChange' | 'value'> & {
+    allowDrillDownPages?: boolean;
+};
 
 /**
  * PageFilter  - a component showing dropdown with list of currently available pages.
@@ -23,24 +25,33 @@ import { Form } from '../basic';
  * let value = 'dashboard';
  * <PageFilter name='pageId' value={value} />
  * ```
- *
- * @param props
  */
-function PageFilter({ allowDrillDownPages, name, onChange, pages, value }) {
+const PageFilter: FunctionComponent<PageFilterProps> = ({
+    allowDrillDownPages = false,
+    name,
+    onChange = noop,
+    value
+}) => {
+    const pages = useSelector((state: ReduxState) => state.pages);
     const [pageId, setPageId] = useState(value);
 
-    function getPageName(allPages, id) {
-        const page = _.find(allPages, { id });
+    function getPageName(allPages: PageDefinition[], id: PageDefinition['id']): string {
+        // NOTE: assumes the page is always found
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const page = _.find(allPages, { id })!;
         if (page.isDrillDown) {
-            return `${getPageName(allPages, page.parent)} > ${page.name}`;
+            // NOTE: assumes the drilldown page always have a parent set
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            return `${getPageName(allPages, page.parent!)} > ${page.name}`;
         }
         return page.name;
     }
 
-    function handleInputChange(event, field) {
-        setPageId(field.value);
-        onChange(event, { name, value: field.value });
-    }
+    const handleInputChange: DropdownProps['onChange'] = (event, field) => {
+        const fieldValue = field.value as string;
+        setPageId(fieldValue);
+        onChange(event, { name, value: fieldValue });
+    };
 
     const filteredPages = allowDrillDownPages ? pages : _.filter(pages, page => !page.isDrillDown);
     const pagesOptions = _.map(filteredPages, page => ({
@@ -61,7 +72,7 @@ function PageFilter({ allowDrillDownPages, name, onChange, pages, value }) {
             onChange={handleInputChange}
         />
     );
-}
+};
 
 PageFilter.propTypes = {
     /**
@@ -72,41 +83,14 @@ PageFilter.propTypes = {
     /**
      * value of the field
      */
-    // eslint-disable-next-line react/no-unused-prop-types
     value: PropTypes.string.isRequired,
 
-    /**
-     * array containing page objects
-     */
-    pages: PropTypes.arrayOf(
-        PropTypes.shape({
-            id: PropTypes.string,
-            isDrilldown: PropTypes.bool,
-            name: PropTypes.string,
-            parent: PropTypes.string
-        })
-    ).isRequired,
-
-    /**
-     *
-     */
     allowDrillDownPages: PropTypes.bool,
 
     /**
      * function called on input value change
      */
-    onChange: PropTypes.func
+    onChange: PropTypes.func as any
 };
 
-PageFilter.defaultProps = {
-    allowDrillDownPages: false,
-    onChange: _.noop
-};
-
-const mapStateToProps = state => {
-    return {
-        pages: state.pages
-    };
-};
-
-export default connect(mapStateToProps)(PageFilter);
+export default PageFilter;

--- a/app/components/shared/PageFilter.tsx
+++ b/app/components/shared/PageFilter.tsx
@@ -1,4 +1,4 @@
-import _, { noop } from 'lodash';
+import { filter, find, map, noop } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { FunctionComponent, useState } from 'react';
 import { useSelector } from 'react-redux';
@@ -38,7 +38,7 @@ const PageFilter: FunctionComponent<PageFilterProps> = ({
     function getPageName(allPages: PageDefinition[], id: PageDefinition['id']): string {
         // NOTE: assumes the page is always found
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        const page = _.find(allPages, { id })!;
+        const page = find(allPages, { id })!;
         if (page.isDrillDown) {
             // NOTE: assumes the drilldown page always have a parent set
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -53,8 +53,8 @@ const PageFilter: FunctionComponent<PageFilterProps> = ({
         onChange(event, { name, value: fieldValue });
     };
 
-    const filteredPages = allowDrillDownPages ? pages : _.filter(pages, page => !page.isDrillDown);
-    const pagesOptions = _.map(filteredPages, page => ({
+    const filteredPages = allowDrillDownPages ? pages : filter(pages, page => !page.isDrillDown);
+    const pagesOptions = map(filteredPages, page => ({
         text: getPageName(filteredPages, page.id),
         value: page.id,
         key: page.id

--- a/app/utils/StageAPI.ts
+++ b/app/utils/StageAPI.ts
@@ -20,8 +20,8 @@ import './types';
 type StagePropTypes = typeof StagePropTypes;
 type StageHooks = typeof StageHooks;
 
-/** @see https://docs.cloudify.co/developer/writing_widgets/widget-apis/#toolbox-object */
-interface StageToolbox {
+/** Toolbox without widget-related methods. Can be created before widgets are rendered */
+interface StageWidgetlessToolbox {
     drillDown(
         widget: StageWidget<unknown>,
         defaultTemplate: string,
@@ -35,15 +35,19 @@ interface StageToolbox {
     getManager(): Manager;
     getManagerState(): any;
     getNewManager(ip: unknown): any;
-    getWidget(): StageWidget;
-    getWidgetBackend(): any;
     goToHomePage(): void;
     goToPage(pageName: string, context: any): void;
     goToParentPage(): void;
+}
+
+/** @see https://docs.cloudify.co/developer/writing_widgets/widget-apis/#toolbox-object */
+interface StageToolbox extends StageWidgetlessToolbox {
+    getWidget(): StageWidget;
+    getWidgetBackend(): any;
     loading(isLoading: boolean): void;
     refresh(params?: any): void;
 }
-export type { StageToolbox as Toolbox };
+export type { StageToolbox as Toolbox, StageWidgetlessToolbox as WidgetlessToolbox };
 
 interface StageWidget<Configuration = Record<string, unknown>> {
     id: string;
@@ -84,6 +88,7 @@ interface StageCustomConfigurationComponentProps<T> {
     name: string;
     value: T;
     onChange: (event: unknown, field: { name: string; value: T }) => void;
+    widgetlessToolbox: StageWidgetlessToolbox;
 }
 export type { StageCustomConfigurationComponentProps as CustomConfigurationComponentProps };
 
@@ -263,6 +268,7 @@ declare global {
          */
         namespace Types {
             type Toolbox = StageToolbox;
+            type WidgetlessToolbox = StageWidgetlessToolbox;
             // TODO(RD-1645): rename Widget to ResolvedWidget
             type Widget<Configuration = Record<string, unknown>> = StageWidget<Configuration>;
             type WidgetDefinition<

--- a/app/utils/StageAPI.ts
+++ b/app/utils/StageAPI.ts
@@ -80,20 +80,25 @@ type StageWidgetDefinition<Params = any, Data = any, Configuration = Record<stri
     (ReactWidgetDefinitionPart<Data, Configuration> | HTMLWidgetDefinitionPart<Data, Configuration>);
 export type { StageWidgetDefinition as WidgetDefinition };
 
+interface StageCustomConfigurationComponentProps<T> {
+    name: string;
+    value: T;
+    onChange: (event: unknown, field: { name: string; value: T }) => void;
+}
+export type { StageCustomConfigurationComponentProps as CustomConfigurationComponentProps };
+
+// TODO(RD-2792): use a discriminated union for different types of configuration
 interface StageWidgetConfigurationDefinition {
     id: string;
     name?: string;
     description?: string;
-    // TODO(RD-1296): add individual interfaces for different types. Use TypeScript discriminated unions
     type: string;
     default?: any;
     placeHolder?: string;
     hidden?: boolean;
-    component?: ComponentType<any>;
+    component?: ComponentType<StageCustomConfigurationComponentProps<any>>;
     /** Used for lists */
     items?: (string | { name: string; value: string })[];
-
-    // TODO(RD-1296): add concrete types for each possible key and remove the line below
     [key: string]: any;
 }
 export type { StageWidgetConfigurationDefinition as WidgetConfigurationDefinition };
@@ -266,6 +271,7 @@ declare global {
                 Configuration = Record<string, unknown>
             > = StageWidgetDefinition<Params, Data, Configuration>;
             type WidgetConfigurationDefinition = StageWidgetConfigurationDefinition;
+            type CustomConfigurationComponentProps<T> = StageCustomConfigurationComponentProps<T>;
             type WidgetData<D> = StageWidgetData<D>;
             type InitialWidgetDefinition<Params, Data, Configuration> = StageInitialWidgetDefinition<
                 Params,

--- a/app/utils/Toolbox.ts
+++ b/app/utils/Toolbox.ts
@@ -26,8 +26,6 @@ class Toolbox implements Stage.Types.Toolbox {
 
     private internal!: Internal;
 
-    // NOTE: this is not React component's `context`
-    // eslint-disable-next-line react/static-property-placement
     private context!: Context;
 
     constructor(store: Store<ReduxState>) {

--- a/app/utils/Toolbox.ts
+++ b/app/utils/Toolbox.ts
@@ -1,11 +1,8 @@
-// @ts-nocheck File not migrated fully to TS
 /* eslint-disable class-methods-use-this */
-/**
- * Created by kinneretzin on 14/11/2016.
- */
 
 import _ from 'lodash';
 import 'proxy-polyfill';
+import type { AnyAction, Store, Unsubscribe } from 'redux';
 
 import { drillDownToPage } from '../actions/drilldownPage';
 import { selectPageByName, selectHomePage, selectParentPage } from '../actions/page';
@@ -16,9 +13,24 @@ import Manager from './Manager';
 import External from './External';
 import Internal from './Internal';
 import WidgetBackend from './WidgetBackend';
+import type { ReduxState } from '../reducers';
 
-class Toolbox {
-    constructor(store) {
+class Toolbox implements Stage.Types.Toolbox {
+    private readonly store: Store<ReduxState>;
+
+    public readonly unsubscribe: Unsubscribe;
+
+    private templates!: ReduxState['templates'];
+
+    private manager!: Manager;
+
+    private internal!: Internal;
+
+    // NOTE: this is not React component's `context`
+    // eslint-disable-next-line react/static-property-placement
+    private context!: Context;
+
+    constructor(store: Store<ReduxState>) {
         // Save the link to the store on the context (so we can dispatch to it later)
         this.store = store;
         this.initFromStore();
@@ -37,23 +49,31 @@ class Toolbox {
         this.context = new Context(this.store);
     }
 
-    drillDown(widget, defaultTemplate, drilldownContext, drilldownPageName) {
+    drillDown: Stage.Types.Toolbox['drillDown'] = (widget, defaultTemplate, drilldownContext, drilldownPageName) => {
         this.store.dispatch(
-            drillDownToPage(widget, this.templates.pagesDef[defaultTemplate], drilldownContext, drilldownPageName)
+            (drillDownToPage(
+                widget,
+                this.templates.pagesDef[defaultTemplate],
+                drilldownContext,
+                drilldownPageName
+                // NOTE: redux's type do not handle thunks well
+            ) as unknown) as AnyAction
         );
-    }
+    };
 
     goToHomePage() {
-        this.store.dispatch(selectHomePage());
+        // NOTE: redux's type do not handle thunks well
+        this.store.dispatch((selectHomePage() as unknown) as AnyAction);
     }
 
     goToParentPage() {
-        this.store.dispatch(selectParentPage());
+        // NOTE: redux's type do not handle thunks well
+        this.store.dispatch((selectParentPage() as unknown) as AnyAction);
     }
 
-    goToPage(pageName, context) {
-        this.store.dispatch(selectPageByName(pageName, context));
-    }
+    goToPage: Stage.Types.Toolbox['goToPage'] = (pageName, context) => {
+        this.store.dispatch((selectPageByName(pageName, context) as unknown) as AnyAction);
+    };
 
     getEventBus() {
         return EventBus;
@@ -77,34 +97,45 @@ class Toolbox {
         return new WidgetBackend(_.get(widget, 'definition.id', ''), state.manager || {});
     }
 
-    getExternal(basicAuth) {
+    getExternal: Stage.Types.Toolbox['getExternal'] = basicAuth => {
         return new External(basicAuth);
-    }
+    };
 
     // This is sometimes needed inorder to join a different manager (for cluster joining for example)
     getNewManager() {
-        return new Manager();
+        return new Manager(undefined);
     }
 
     getContext() {
         return this.context;
     }
 
+    // NOTE: placeholder methods. Real ones are proxied and provided when
+    // the Toolbox instance is created
     refresh() {}
 
     loading() {}
 
-    getWidget() {}
+    getWidget() {
+        // NOTE: `getWidget` is dynamically substituted via Proxy
+        return undefined as any;
+    }
 }
 
-let toolbox = null;
+let toolbox: Toolbox | null = null;
 
-const createToolbox = store => {
+const createToolbox = (store: Store<ReduxState>) => {
     toolbox = new Toolbox(store);
 };
 
-const getToolbox = (onRefresh, onLoading, widget) => {
-    return new Proxy(toolbox, {
+const getToolbox = (
+    onRefresh: Stage.Types.Toolbox['refresh'],
+    onLoading: Stage.Types.Toolbox['loading'],
+    widget: ReturnType<Stage.Types.Toolbox['getWidget']>
+) => {
+    // NOTE: assumes the toolbox is already created
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    return new Proxy(toolbox!, {
         get: (target, name) => {
             if (name === 'refresh') {
                 return onRefresh;
@@ -115,7 +146,7 @@ const getToolbox = (onRefresh, onLoading, widget) => {
             if (name === 'getWidget') {
                 return () => widget;
             }
-            return target[name];
+            return (target as any)[name];
         }
     });
 };

--- a/widgets/buttonLink/src/widget.tsx
+++ b/widgets/buttonLink/src/widget.tsx
@@ -1,8 +1,4 @@
-/**
- * Created by pawelposel on 13/02/2017.
- */
-
-import type { CSSProperties } from 'react';
+import type { ComponentType, CSSProperties } from 'react';
 
 interface ButtonLinkWidgetConfiguration {
     color: string;
@@ -30,7 +26,9 @@ Stage.defineWidget<unknown, unknown, ButtonLinkWidgetConfiguration>({
             name: 'Color',
             default: '#21ba45',
             type: Stage.Basic.GenericField.CUSTOM_TYPE,
-            component: Stage.Basic.Form.ColorPicker
+            component: Stage.Basic.Form.ColorPicker as ComponentType<
+                Stage.Types.CustomConfigurationComponentProps<string>
+            >
         }
     ],
     isReact: true,

--- a/widgets/common/src/DynamicDropdown.tsx
+++ b/widgets/common/src/DynamicDropdown.tsx
@@ -1,10 +1,8 @@
-// @ts-nocheck File not migrated fully to TS
-// NOTE: Disabling react/require-default-props as default values are provided in component's definition
-/* eslint-disable react/require-default-props */
 import { useCallback, useReducer } from 'react';
 import { debounce, isFunction } from 'lodash';
 import VisibilitySensor from 'react-visibility-sensor';
 import './DynamicDropdown.css';
+import type { DropdownItemProps, DropdownOnSearchChangeData, DropdownProps } from 'semantic-ui-react';
 
 let instanceCount = 0;
 
@@ -29,9 +27,15 @@ const fetchActionType = {
     PREPARE_FOR_NEXT_PAGE_FETCH: 'prepareForNextPageFetch',
     TRIGGER_FETCH: 'triggerFetch',
     END_FETCH: 'endFetch'
-};
+} as const;
 const defaultFetchState = { hasMore: true, currentPage: -1, shouldLoadMore: false };
-function fetchReducer(state, action) {
+type FetchReducerAction =
+    | { type: typeof fetchActionType['PREPARE_FOR_FIRST_PAGE_FETCH'] }
+    | { type: typeof fetchActionType['PREPARE_FOR_NEXT_PAGE_FETCH']; currentPage: number; hasMore: boolean }
+    | { type: typeof fetchActionType['TRIGGER_FETCH'] }
+    | { type: typeof fetchActionType['END_FETCH'] };
+
+function fetchReducer(state: typeof defaultFetchState, action: FetchReducerAction) {
     switch (action.type) {
         case fetchActionType.PREPARE_FOR_FIRST_PAGE_FETCH:
             return { ...defaultFetchState };
@@ -46,8 +50,34 @@ function fetchReducer(state, action) {
         case fetchActionType.END_FETCH:
             return { ...defaultFetchState, hasMore: false };
         default:
-            throw new Error(`Unknown action type: ${action.type}.`);
+            throw new Error(`Unknown action type: ${(action as any).type}.`);
     }
+}
+
+/** May also contain an `implicit` property, but it's hard to model in TypeScript */
+type Option = { [valueProp: string]: string };
+
+type DropdownValue = string | string[] | null;
+interface DynamicDropdownProps extends Omit<DropdownProps, 'onChange'> {
+    allowAdditions?: boolean;
+    innerRef?: React.Ref<HTMLElement>;
+    disabled?: boolean;
+    multiple?: boolean;
+    placeholder?: string;
+    fetchUrl: string;
+    fetchAll?: boolean;
+    value: DropdownValue;
+    onChange: (value: DropdownValue) => void;
+    onSearchChange?: (event: React.SyntheticEvent<HTMLElement, Event>, data: DropdownOnSearchChangeData) => void;
+    toolbox: Stage.Types.WidgetlessToolbox;
+    filter?: Record<string, string>;
+    valueProp?: string;
+    textFormatter?: (item: any) => string;
+    pageSize?: number;
+    name?: string;
+    prefetch?: boolean;
+    refreshEvent?: string;
+    itemsFormatter?: (items: any[]) => Option[];
 }
 
 export default function DynamicDropdown({
@@ -62,25 +92,25 @@ export default function DynamicDropdown({
     innerRef = null,
     itemsFormatter = _.identity,
     multiple = false,
-    name = null,
+    name,
     onSearchChange = undefined,
     pageSize = 10,
-    placeholder = null,
+    placeholder,
     prefetch = false,
-    refreshEvent = null,
-    textFormatter = null,
-    value = null,
+    refreshEvent,
+    textFormatter,
+    value,
     valueProp = 'id',
     ...rest
-}) {
+}: DynamicDropdownProps) {
     const { useState, useEffect } = React;
-    const { useBoolean, useEventListener } = Stage.Hooks;
+    const { useEventListener } = Stage.Hooks;
 
     const [id] = useState(() => {
         instanceCount += 1;
         return `dynamicDropdown${instanceCount}`;
     });
-    const [options, setOptions] = useState([]);
+    const [options, setOptions] = useState<Option[]>([]);
     const [fetchState, dispatchFetchAction] = useReducer(fetchReducer, {
         ...defaultFetchState,
         shouldLoadMore: prefetch
@@ -94,12 +124,13 @@ export default function DynamicDropdown({
      *
      * @param newOptions list of options used for comparison
      */
-    function getImplicitOptions(newOptions: { [valueProp: string]: string }[]) {
-        const implicitOptions = [];
+    function getImplicitOptions(newOptions: Option[]) {
+        const implicitOptions: Option[] = [];
         if (!_.isEmpty(value)) {
             _.castArray(value).forEach(singleValue => {
                 if (!_.find(newOptions, { [valueProp]: singleValue })) {
-                    implicitOptions.push({ [valueProp]: singleValue, implicit: true });
+                    // NOTE: no elegant way was found to have `implicit` prop in TS
+                    implicitOptions.push({ [valueProp]: singleValue, implicit: true as any });
                 }
             });
         }
@@ -113,7 +144,7 @@ export default function DynamicDropdown({
             dispatchFetchAction({ type: fetchActionType.END_FETCH });
         }
 
-        function onFetchFailed(error) {
+        function onFetchFailed(error: unknown) {
             dispatchEndFetchAction();
             log.error(error);
         }
@@ -125,8 +156,8 @@ export default function DynamicDropdown({
         if (fetchAll) {
             toolbox
                 .getManager()
-                .doGetFull(fetchUrl)
-                .then(data => {
+                .doGetFull(fetchUrl, undefined)
+                .then((data: { items: unknown[] }) => {
                     dispatchEndFetchAction();
                     setOptions(itemsFormatter(data.items));
                 })
@@ -202,7 +233,7 @@ export default function DynamicDropdown({
         .uniqBy(valueProp)
         .value();
 
-    function getDropdownValue() {
+    function getDropdownValue(): DropdownProps['value'] {
         if (!value) {
             return multiple ? [] : '';
         }
@@ -228,21 +259,23 @@ export default function DynamicDropdown({
                 id={id}
                 name={name}
                 allowAdditions={allowAdditions}
-                onAddItem={(event, data) =>
-                    setOptions(latestOptions => [{ [valueProp]: data.value }, ...latestOptions])
+                onAddItem={(_event, data) =>
+                    setOptions(latestOptions => [{ [valueProp]: data.value as string }, ...latestOptions])
                 }
-                onChange={(event, data) => onChange(!_.isEmpty(data.value) ? data.value : null)}
+                onChange={(_event, data) => onChange(!_.isEmpty(data.value) ? (data.value as string | string[]) : null)}
                 onSearchChange={(event, data) => {
                     setSearchQuery(data.searchQuery);
                     if (isFunction(onSearchChange)) onSearchChange(event, data);
                 }}
                 multiple={multiple}
                 loading={isLoading}
-                options={(() => {
-                    const preparedOptions = filteredOptions.map(item => ({
-                        text: (textFormatter || (i => i[valueProp]))(item),
-                        value: item[valueProp]
-                    }));
+                options={((): DropdownItemProps[] => {
+                    const preparedOptions = filteredOptions.map(
+                        (item): DropdownItemProps => ({
+                            text: (textFormatter ?? ((i: Record<string, string>) => i[valueProp]))(item),
+                            value: item[valueProp]
+                        })
+                    );
                     if (fetchState.hasMore) {
                         preparedOptions.push({
                             disabled: true,

--- a/widgets/common/src/DynamicDropdown.tsx
+++ b/widgets/common/src/DynamicDropdown.tsx
@@ -157,7 +157,7 @@ export default function DynamicDropdown({
             toolbox
                 .getManager()
                 .doGetFull(fetchUrl, undefined)
-                .then((data: { items: unknown[] }) => {
+                .then((data: Stage.Types.PaginatedResponse<unknown>) => {
                     dispatchEndFetchAction();
                     setOptions(itemsFormatter(data.items));
                 })

--- a/widgets/common/src/DynamicDropdown.tsx
+++ b/widgets/common/src/DynamicDropdown.tsx
@@ -66,6 +66,7 @@ interface DynamicDropdownProps extends Omit<DropdownProps, 'onChange'> {
     placeholder?: string;
     fetchUrl: string;
     fetchAll?: boolean;
+    searchParams?: string[];
     value: DropdownValue;
     onChange: (value: DropdownValue) => void;
     onSearchChange?: (event: React.SyntheticEvent<HTMLElement, Event>, data: DropdownOnSearchChangeData) => void;
@@ -170,8 +171,8 @@ export default function DynamicDropdown({
             toolbox
                 .getManager()
                 .doGet(fetchUrl, {
-                    params: searchParams.reduce(
-                        (result: Record<string, string>, param) => {
+                    params: searchParams.reduce<Record<string, unknown>>(
+                        (result, param) => {
                             result[param] = searchQuery;
 
                             return result;

--- a/widgets/common/src/DynamicDropdown.tsx
+++ b/widgets/common/src/DynamicDropdown.tsx
@@ -294,6 +294,12 @@ DynamicDropdown.propTypes = {
     itemsFormatter: PropTypes.func
 };
 
+declare global {
+    namespace Stage.Common {
+        export { DynamicDropdown };
+    }
+}
+
 Stage.defineCommon({
     name: 'DynamicDropdown',
     common: DynamicDropdown

--- a/widgets/common/src/deploymentsView/header/filter/FilterModal.tsx
+++ b/widgets/common/src/deploymentsView/header/filter/FilterModal.tsx
@@ -53,7 +53,6 @@ const FilterModal: FunctionComponent<FilterModalProps> = ({
 }) => {
     const { i18n } = Stage;
     const { ApproveButton, CancelButton, Dimmer, Icon, Modal, UnsafelyTypedForm, UnsafelyTypedFormField } = Stage.Basic;
-    // @ts-expect-error DynamicDropdown is not converted to TS yet
     const { DynamicDropdown } = Stage.Common;
     const { useBoolean, useErrors } = Stage.Hooks;
 
@@ -106,8 +105,10 @@ const FilterModal: FunctionComponent<FilterModalProps> = ({
         clearErrors();
     }
 
-    function handleFilterIdChange(value: string) {
-        filterId.set(value);
+    function handleFilterIdChange(value: string | string[] | null) {
+        // NOTE: CommonDropdown does not know whether `multiple` is set,
+        // so need to manually assert it's a single string
+        filterId.set((value as string | null) ?? undefined);
         filterDirty.set(false);
         clearErrors();
     }
@@ -196,7 +197,7 @@ const FilterModal: FunctionComponent<FilterModalProps> = ({
                             onChange={handleFilterIdChange}
                             fetchUrl="/filters/deployments?_include=id"
                             prefetch
-                            value={filterId.value}
+                            value={filterId.value ?? null}
                         />
                     </UnsafelyTypedFormField>
                     <UnsafelyTypedFormField label={tModal('filterRules')}>

--- a/widgets/common/src/deploymentsView/header/filter/FilterModal.tsx
+++ b/widgets/common/src/deploymentsView/header/filter/FilterModal.tsx
@@ -106,7 +106,7 @@ const FilterModal: FunctionComponent<FilterModalProps> = ({
     }
 
     function handleFilterIdChange(value: string | string[] | null) {
-        // NOTE: CommonDropdown does not know whether `multiple` is set,
+        // NOTE: DynamicDropdown does not know whether `multiple` is set,
         // so need to manually assert it's a single string
         filterId.set((value as string | null) ?? undefined);
         filterDirty.set(false);

--- a/widgets/common/src/filters/inputs/LabelValueInput.tsx
+++ b/widgets/common/src/filters/inputs/LabelValueInput.tsx
@@ -26,7 +26,7 @@ const LabelValueInput: FunctionComponent<LabelValueInputProps> = ({
     labelKey,
     labelValue
 }) => {
-    const keyDropdownRef = useRef<HTMLElement>();
+    const keyDropdownRef = useRef<HTMLElement>(null);
 
     return (
         <>

--- a/widgets/common/src/hooks/useEventListener.ts
+++ b/widgets/common/src/hooks/useEventListener.ts
@@ -1,6 +1,10 @@
 import { useEffect } from 'react';
 
-function useEventListener(toolbox: Stage.Types.Toolbox, event: string, handler: (...args: any[]) => void) {
+function useEventListener(
+    toolbox: Stage.Types.WidgetlessToolbox,
+    event: string | undefined,
+    handler: (...args: any[]) => void
+) {
     useEffect(() => {
         if (event) {
             toolbox.getEventBus().on(event, handler);

--- a/widgets/common/src/labels/LabelsInput.tsx
+++ b/widgets/common/src/labels/LabelsInput.tsx
@@ -68,7 +68,7 @@ const LabelsInput: FunctionComponent<LabelsInputProps> = ({
     const [open, toggleOpen] = useToggle();
     const [newLabelKey, setNewLabelKey, resetNewLabelKey] = useResettableState('');
     const [newLabelValue, setNewLabelValue, resetNewLabelValue] = useResettableState('');
-    const keyDropdownRef = useRef<HTMLElement>();
+    const keyDropdownRef = useRef<HTMLElement>(null);
 
     const newLabelIsProvided = !!newLabelKey && !!newLabelValue;
     const newLabelIsAlreadyPresent = (() => {

--- a/widgets/deploymentsView/src/widget.tsx
+++ b/widgets/deploymentsView/src/widget.tsx
@@ -74,7 +74,8 @@ const TopLevelDeploymentsView: FunctionComponent<TopLevelDeploymentsViewProps> =
             toolbox={toolbox}
             widget={widget}
             filterByParentDeployment={filterByParentDeployment}
-            defaultFilterId={filterId}
+            // NOTE: converts null to undefined
+            defaultFilterId={filterId ?? undefined}
         />
     );
 };


### PR DESCRIPTION
This PR:
1. Migrates `DynamicDropdown` to TypeScript and fixes resulting TS errors.
2. Adds a type for `CustomConfigurationComponentProps` (used when the widget's configuration uses a custom component).
3. Migrates `Toolbox` to TypeScript
4. Migrates `PageFilter` component to TS (there were some errors with using it as a `component` in custom configuration, so I decided to migrate it entirely rather than just fix that one small problem with `connect`)

My intention for this PR is to have no user-facing changes.

This PR is a base for the functionality for RD-1851.

I doubt we will complete RD-1851 this week to merge it into 6.1. Unless some miracle happens and I complete it early tomorrow, I will keep the PRs pointed at 6.1. If that does not happen, I will rebase them and point them to `master`.

## System tests

https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/958/pipeline

Queued 2021-07-23 14:25 CEST (after changing the base branch to `master`)