### PR TITLE
RD-2664 Fix selecting label key from dropdown list in filters_spec

### DIFF
--- a/test/cypress/integration/widgets/filters_spec.ts
+++ b/test/cypress/integration/widgets/filters_spec.ts
@@ -451,15 +451,17 @@ describe('Filters widget', () => {
         function selectRuleLabelKey(key: string, isNew = false) {
             withinLastRuleRow(() => {
                 cy.interceptSp('GET', `/labels/deployments?_search=${key}`).as(`keySearch_${key}`);
-                cy.get('div[name="labelKey"]').within(() => {
-                    cy.get('input').type(key);
-                    cy.wait(`@keySearch_${key}`);
+                cy.get('div[name="labelKey"]')
+                    .click()
+                    .within(() => {
+                        cy.get('input').type(key);
+                        cy.wait(`@keySearch_${key}`);
 
-                    if (isNew) cy.contains('[role="option"]', `New key ${key}`).click();
-                    else cy.get(`div[option-value="${key}"]`).click();
+                        if (isNew) cy.contains('[role="option"]', `New key ${key}`).click();
+                        else cy.get(`div[option-value="${key}"]`).click();
 
-                    cy.get(`input.search`).should('not.have.value');
-                });
+                        cy.get(`input.search`).should('not.have.value');
+                    });
             });
         }
 

--- a/test/cypress/integration/widgets/filters_spec.ts
+++ b/test/cypress/integration/widgets/filters_spec.ts
@@ -51,8 +51,13 @@ describe('Filters widget', () => {
         cy.contains('Add new rule').click();
     }
 
+    type FilterRuleDropdownNames = 'ruleRowType' | 'ruleOperator' | 'ruleValue' | 'labelKey' | 'labelValue';
+    function openDropdown(divName: FilterRuleDropdownNames) {
+        return cy.get(`div[name="${divName}"]`).click();
+    }
+
     function typeAttributeRuleValue(value: string) {
-        cy.get('[name=ruleValue]').click().find('input').type(`${value}{enter}`).blur();
+        openDropdown('ruleValue').find('input').type(`${value}{enter}`).blur();
     }
 
     function getFilterIdInput() {
@@ -168,13 +173,12 @@ describe('Filters widget', () => {
                 withinLastRuleRow(() => typeAttributeRuleValue(blueprintId));
                 addNewRule();
                 withinLastRuleRow(() => {
-                    cy.get('[name=ruleRowType]').click();
-                    cy.contains('Label').click();
-                    cy.get('[name=ruleOperator]').click();
-                    cy.contains('key is not').click();
-                    cy.get('[name=labelKey]').click();
-                    cy.get('[name=labelKey] input').type(labelKey);
-                    cy.get(`[option-value=${labelKey}]`).click();
+                    openDropdown('ruleRowType').contains('Label').click();
+                    openDropdown('ruleOperator').contains('key is not').click();
+                    openDropdown('labelKey').within(() => {
+                        cy.get('input').type(labelKey);
+                        cy.get(`[option-value=${labelKey}]`).click();
+                    });
                 });
 
                 cy.interceptSp('PUT', `/filters/deployments/${newFilterName}`).as('createRequest');
@@ -399,21 +403,36 @@ describe('Filters widget', () => {
         beforeEach(openAddFilterModal);
         afterEach(closeFilterModal);
 
-        function selectRuleRowType(ruleRowType: FilterRuleRowType) {
-            withinLastRuleRow(() => {
-                cy.get('div[name="ruleRowType"]').click();
-                cy.get(`div[option-value="${ruleRowType}"]`).click();
-            });
-        }
-
-        function selectRuleOperator(operator: FilterRuleOperator) {
-            withinLastRuleRow(() => {
-                cy.get('div[name="ruleOperator"]').click();
-                cy.get(`div[option-value="${operator}"]`).click();
-            });
+        function openDropdownAndSetValue(divName: FilterRuleDropdownNames, optionValue: string) {
+            openDropdown(divName).find(`div[option-value="${optionValue}"]`).click();
         }
 
         type RuleValueObject = { value: string; isNew: boolean };
+        function searchAndSetDropdownValue(
+            { value, isNew }: RuleValueObject,
+            searchEndpoint: string | RegExp,
+            additionLabel: string,
+            isMultiple: boolean
+        ) {
+            if (searchEndpoint) cy.interceptSp('GET', searchEndpoint).as(`search_${value}`);
+            cy.get('input.search').type(value);
+            if (searchEndpoint) cy.wait(`@search_${value}`);
+
+            if (isNew) cy.contains('[role="option"]', `${additionLabel} ${value}`).click();
+            else cy.get(`div[option-value="${value}"]`).click();
+
+            if (isMultiple) cy.get(`.label[value="${value}"]`).should('exist');
+            cy.get('input.search').should('not.have.value');
+        }
+
+        function selectRuleRowType(ruleRowType: FilterRuleRowType) {
+            withinLastRuleRow(() => openDropdownAndSetValue('ruleRowType', ruleRowType));
+        }
+
+        function selectRuleOperator(operator: FilterRuleOperator) {
+            withinLastRuleRow(() => openDropdownAndSetValue('ruleOperator', operator));
+        }
+
         function selectRuleAttributeValues(
             ruleRowType: FilterRuleRowType,
             values: RuleValueObject[],
@@ -427,41 +446,32 @@ describe('Filters widget', () => {
                     created_by: 'users',
                     label: '' // NOTE: Only endpoints for attribute rules are necessary
                 };
-                cy.get('div[name="ruleValue"]')
-                    .click()
-                    .within(() => {
-                        values.forEach(({ value, isNew }) => {
-                            if (withAutocomplete) {
-                                const searchEndpointRegExp = RegExp(`${searchEndpoint[ruleRowType]}.*_search=${value}`);
-                                cy.interceptSp('GET', searchEndpointRegExp).as(`valueSearch_${value}`);
-                            }
 
-                            cy.get('input').type(`${value}`);
-                            if (withAutocomplete) cy.wait(`@valueSearch_${value}`);
-
-                            if (isNew) cy.contains('[role="option"]', `Add ${value}`).click();
-                            else cy.get(`div[option-value="${value}"]`).click();
-
-                            cy.get(`.label[value="${value}"]`).should('exist');
-                        });
-                    });
+                openDropdown('ruleValue').within(() =>
+                    values.forEach(ruleValue => {
+                        searchAndSetDropdownValue(
+                            ruleValue,
+                            withAutocomplete
+                                ? RegExp(`${searchEndpoint[ruleRowType]}.*_search=${ruleValue.value}`)
+                                : '',
+                            'Add',
+                            true
+                        );
+                    })
+                );
             });
         }
 
         function selectRuleLabelKey(key: string, isNew = false) {
             withinLastRuleRow(() => {
-                cy.interceptSp('GET', `/labels/deployments?_search=${key}`).as(`keySearch_${key}`);
-                cy.get('div[name="labelKey"]')
-                    .click()
-                    .within(() => {
-                        cy.get('input').type(key);
-                        cy.wait(`@keySearch_${key}`);
-
-                        if (isNew) cy.contains('[role="option"]', `New key ${key}`).click();
-                        else cy.get(`div[option-value="${key}"]`).click();
-
-                        cy.get(`input.search`).should('not.have.value');
-                    });
+                openDropdown('labelKey').within(() => {
+                    searchAndSetDropdownValue(
+                        { value: key, isNew },
+                        RegExp(`/labels/deployments?.*_search=${key}`),
+                        'New key',
+                        false
+                    );
+                });
             });
         }
 
@@ -469,23 +479,16 @@ describe('Filters widget', () => {
             if (values.length === 0) return;
 
             withinLastRuleRow(() => {
-                cy.get('div[name="labelValue"]')
-                    .click()
-                    .within(() => {
-                        values.forEach(({ value, isNew }) => {
-                            cy.interceptSp('GET', RegExp(`/labels/deployments/.*?_search=${value}`)).as(
-                                `valueSearch_${value}`
-                            );
-
-                            cy.get('input').type(value);
-                            cy.wait(`@valueSearch_${value}`);
-
-                            if (isNew) cy.contains('[role="option"]', `New value ${value}`).click();
-                            else cy.get(`div[option-value="${value}"]`).click();
-
-                            cy.get(`.label[value="${value}"]`).should('exist');
-                        });
+                openDropdown('labelValue').within(() => {
+                    values.forEach(ruleValue => {
+                        searchAndSetDropdownValue(
+                            ruleValue,
+                            RegExp(`/labels/deployments/.*_search=${ruleValue.value}`),
+                            'New value',
+                            true
+                        );
                     });
+                });
             });
         }
 

--- a/test/cypress/integration/widgets/filters_spec.ts
+++ b/test/cypress/integration/widgets/filters_spec.ts
@@ -51,8 +51,8 @@ describe('Filters widget', () => {
         cy.contains('Add new rule').click();
     }
 
-    type FilterRuleDropdownNames = 'ruleRowType' | 'ruleOperator' | 'ruleValue' | 'labelKey' | 'labelValue';
-    function openDropdown(divName: FilterRuleDropdownNames) {
+    type FilterRuleDropdownName = 'ruleRowType' | 'ruleOperator' | 'ruleValue' | 'labelKey' | 'labelValue';
+    function openDropdown(divName: FilterRuleDropdownName) {
         return cy.get(`div[name="${divName}"]`).click();
     }
 
@@ -403,7 +403,7 @@ describe('Filters widget', () => {
         beforeEach(openAddFilterModal);
         afterEach(closeFilterModal);
 
-        function openDropdownAndSetValue(divName: FilterRuleDropdownNames, optionValue: string) {
+        function openDropdownAndSetValue(divName: FilterRuleDropdownName, optionValue: string) {
             openDropdown(divName).find(`div[option-value="${optionValue}"]`).click();
         }
 

--- a/test/cypress/integration/widgets/filters_spec.ts
+++ b/test/cypress/integration/widgets/filters_spec.ts
@@ -410,9 +410,9 @@ describe('Filters widget', () => {
         type RuleValueObject = { value: string; isNew: boolean };
         function searchAndSetDropdownValue(
             { value, isNew }: RuleValueObject,
-            searchEndpoint: string | RegExp,
             additionLabel: string,
-            isMultiple: boolean
+            isMultiple: boolean,
+            searchEndpoint?: string | RegExp
         ) {
             if (searchEndpoint) cy.interceptSp('GET', searchEndpoint).as(`search_${value}`);
             cy.get('input.search').type(value);
@@ -451,11 +451,11 @@ describe('Filters widget', () => {
                     values.forEach(ruleValue => {
                         searchAndSetDropdownValue(
                             ruleValue,
+                            'Add',
+                            true,
                             withAutocomplete
                                 ? RegExp(`${searchEndpoint[ruleRowType]}.*_search=${ruleValue.value}`)
-                                : '',
-                            'Add',
-                            true
+                                : undefined
                         );
                     })
                 );
@@ -467,9 +467,9 @@ describe('Filters widget', () => {
                 openDropdown('labelKey').within(() => {
                     searchAndSetDropdownValue(
                         { value: key, isNew },
-                        RegExp(`/labels/deployments?.*_search=${key}`),
                         'New key',
-                        false
+                        false,
+                        RegExp(`/labels/deployments?.*_search=${key}`)
                     );
                 });
             });
@@ -483,9 +483,9 @@ describe('Filters widget', () => {
                     values.forEach(ruleValue => {
                         searchAndSetDropdownValue(
                             ruleValue,
-                            RegExp(`/labels/deployments/.*_search=${ruleValue.value}`),
                             'New value',
-                            true
+                            true,
+                            RegExp(`/labels/deployments/.*_search=${ruleValue.value}`)
                         );
                     });
                 });


### PR DESCRIPTION
I found out that the only difference between label key selecting function (`selectRuleLabelKey`) and other functions setting values in dropdowns in `filters_spec` (`selectRuleRowType`, `selectRuleOperator`, `selectRuleAttributeValues`, `selectRuleLabelValues`) was that in `selectRuleLabelKey` there was no `click` issued on the dropdown's div element. I suspect that might be an issue.

This PR contains two changes:
1. https://github.com/cloudify-cosmo/cloudify-stage/pull/1519/commits/741bbec6435cbe1442e6e6ca57beb3bd426ade98 - small change, just `click` addition in `selectRuleLabelKey` (that should fix the problem)
2. https://github.com/cloudify-cosmo/cloudify-stage/pull/1519/commits/8ecc3ae844fc454b09ec87fe6f195d806b0f61d8 - refactoring in dropdowns usage inside `filters_spec`. The goal was to reuse as much dropdown interaction code as possible. There is much more to do within that area IMHO (many other tests use their own logic to interact with dropdowns), so I have created RD-2829 to create generic Cypress custom commands for interaction with dropdowns.

### System Tests

1. [Stage-UI-System-Test #971](https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/971/pipeline) - only `filters_spec` - PASSED
2. [Stage-UI-System-Test #972](https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/972/pipeline) - only `filters_spec` - PASSED
3. [Stage-UI-System-Test #973](https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/973/pipeline) - only `filters_spec` - PASSED
4. [Stage-UI-System-Test #976](https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/976/pipeline) - full run - FAILED (Internal Server Error 500 during EC2 instance creation)
5. [Stage-UI-System-Test #977](https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/977/pipeline) - full run - FAILED (Internal Server Error 500 during EC2 instance creation)
6. [Stage-UI-System-Test #978](https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/978/pipeline) - full run - FAILED (Internal Server Error 500 during some test execution, but `filters_spec` test passed)
7. [Stage-UI-System-Test #980](https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/980/pipeline) - full run - FAILED (Internal Server Error 500 during EC2 instance creation)
8. [Stage-UI-System-Test #981](https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/981/pipeline) - full run - FAILED (Internal Server Error 500 during EC2 instance creation)
9. [Stage-UI-System-Test #982](https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/982/pipeline) - full run - FAILED (Internal Server Error 500 during some test execution, but `filters_spec` test passed)