### PR TITLE
RD-1851 Add autocomplete for default filter in Deployments View widget

### DIFF
--- a/test/cypress/integration/widgets/deployments_view_spec.ts
+++ b/test/cypress/integration/widgets/deployments_view_spec.ts
@@ -397,6 +397,14 @@ describe('Deployments View widget', () => {
             });
         });
 
+        it('should return an error when the filter ID saved in the configuration is invalid', () => {
+            // NOTE: verifies a case when the filter was removed and the Deployments View is still
+            // using the removed filter's ID in the configuration.
+            useDeploymentsViewWidget({ configurationOverrides: { filterId: 'some-removed-filter-id' } });
+
+            cy.contains(/with ID .* was not found/);
+        });
+
         it('should take the selected existing filter into account when displaying deployments', () => {
             useDeploymentsViewWidget();
 

--- a/test/cypress/integration/widgets/deployments_view_spec.ts
+++ b/test/cypress/integration/widgets/deployments_view_spec.ts
@@ -365,18 +365,21 @@ describe('Deployments View widget', () => {
         });
 
         it('should take the configured filter into account when displaying deployments', () => {
-            const getFilterIdInput = () =>
-                cy.contains('Name of the saved filter to apply').parent().get('input[type="text"]');
+            useDeploymentsViewWidget();
 
-            useDeploymentsViewWidget({ configurationOverrides: { filterId } });
+            const filterFieldLabel = 'Name of the saved filter to apply';
 
             cy.log('Show only precious deployments');
+            cy.editWidgetConfiguration(widgetId, () => {
+                cy.setSearchableDropdownValue(filterFieldLabel, filterId);
+            });
+
             cy.contains(deploymentNameThatMatchesFilter);
             cy.contains(deploymentName).should('not.exist');
 
             cy.log('Show all deployments');
             cy.editWidgetConfiguration(widgetId, () => {
-                getFilterIdInput().clear();
+                cy.clearSearchableDropdown(filterFieldLabel);
             });
 
             cy.contains(deploymentNameThatMatchesFilter);
@@ -384,10 +387,14 @@ describe('Deployments View widget', () => {
 
             cy.log('Invalid filter id');
             cy.editWidgetConfiguration(widgetId, () => {
-                getFilterIdInput().type('some-very-gibberish-filter-id');
+                cy.contains('.field', filterFieldLabel)
+                    .click()
+                    .within(() => {
+                        cy.get('input').type('some-very-gibberish-filter-id');
+                        // NOTE: there should not be such a filter
+                        cy.contains('No results found');
+                    });
             });
-
-            cy.contains(/with ID .* was not found/);
         });
 
         it('should take the selected existing filter into account when displaying deployments', () => {

--- a/test/cypress/support/commands.ts
+++ b/test/cypress/support/commands.ts
@@ -357,7 +357,8 @@ const commands = {
             });
     },
 
-    clearSearchableDropdown: (fieldName: string) => cy.contains('.field', fieldName).find('.dropdown.icon').click(),
+    clearSearchableDropdown: (fieldName: string) =>
+        cy.contains('.field', fieldName).find('.dropdown.clear.icon').click(),
 
     setDropdownValues: (fieldName: string, values: string[]) => {
         cy.contains('.field', fieldName)

--- a/test/cypress/support/commands.ts
+++ b/test/cypress/support/commands.ts
@@ -357,6 +357,8 @@ const commands = {
             });
     },
 
+    clearSearchableDropdown: (fieldName: string) => cy.contains('.field', fieldName).find('.dropdown.icon').click(),
+
     setDropdownValues: (fieldName: string, values: string[]) => {
         cy.contains('.field', fieldName)
             .click()

--- a/widgets/deploymentsView/src/FilterIdDropdown.tsx
+++ b/widgets/deploymentsView/src/FilterIdDropdown.tsx
@@ -1,0 +1,17 @@
+import { FunctionComponent } from 'react';
+
+const FilterIdDropdown: FunctionComponent<Stage.Types.CustomConfigurationComponentProps<string | null>> = ({
+    name,
+    value,
+    onChange,
+    widgetlessToolbox
+}) => (
+    <Stage.Common.DynamicDropdown
+        toolbox={widgetlessToolbox}
+        onChange={newValue => onChange(null, { name, value: newValue as string })}
+        fetchUrl="/filters/deployments?_include=id"
+        prefetch
+        value={value}
+    />
+);
+export default FilterIdDropdown;

--- a/widgets/deploymentsView/src/widget.tsx
+++ b/widgets/deploymentsView/src/widget.tsx
@@ -1,8 +1,9 @@
 import { FunctionComponent, useEffect } from 'react';
+import FilterIdDropdown from './FilterIdDropdown';
 
 export interface DeploymentsViewWidgetConfiguration
     extends Stage.Common.DeploymentsView.Configuration.SharedDeploymentsViewWidgetConfiguration {
-    filterId?: string;
+    filterId?: string | null;
     filterByParentDeployment: boolean;
     mapOpenByDefault?: boolean;
 }
@@ -30,9 +31,9 @@ Stage.defineWidget<never, never, DeploymentsViewWidgetConfiguration>({
         },
         {
             id: 'filterId',
-            // TODO(RD-1851): add autocomplete instead of plain text input
-            type: Stage.Basic.GenericField.STRING_TYPE,
-            name: Stage.i18n.t(`${i18nPrefix}.configuration.filterId.name`)
+            type: Stage.Basic.GenericField.CUSTOM_TYPE,
+            name: Stage.i18n.t(`${i18nPrefix}.configuration.filterId.name`),
+            component: FilterIdDropdown
         },
         {
             id: 'filterByParentDeployment',


### PR DESCRIPTION
This PR leverages the work done in #1518 to add an autocomplete component (`DynamicDropdown`) as the custom component for the default filter to use in the Deployments View widget.

There are also changes in the system tests to make sure it all works according to our expectations.

Depends on #1518 

## Video


https://user-images.githubusercontent.com/889383/126783299-7edc92e3-c6f6-4c2a-bdfe-7ff447fcab35.mp4



## System tests

https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/974/pipeline

Queued 2021-07-26 14:13 CEST