### PR TITLE
RD-2789 Change default split-pane behavior in Deployments View

### DIFF
--- a/widgets/common/src/deploymentsView/DeploymentsView.tsx
+++ b/widgets/common/src/deploymentsView/DeploymentsView.tsx
@@ -39,7 +39,10 @@ export interface DeploymentsViewProps {
     additionalFilterRules?: Stage.Common.Filters.Rule[];
 }
 
-const minPaneWidth = 100;
+// NOTE: added to the actual min pane width by `react-split-pane` for an unknown reason
+const reactSplitPaneOffset = 30;
+// NOTE: keeps the UI looking nice at all times
+const minPaneWidth = 440 + reactSplitPaneOffset;
 
 export const DeploymentsView: FunctionComponent<DeploymentsViewProps> = ({
     toolbox,

--- a/widgets/common/src/deploymentsView/DeploymentsView.tsx
+++ b/widgets/common/src/deploymentsView/DeploymentsView.tsx
@@ -171,7 +171,7 @@ export const DeploymentsView: FunctionComponent<DeploymentsViewProps> = ({
                 <SplitPane
                     minSize={minPaneWidth}
                     maxSize={-minPaneWidth}
-                    defaultSize="50%"
+                    defaultSize="40%"
                     split="vertical"
                     resizerClassName="master-details-view-resizer"
                 >


### PR DESCRIPTION
This PR changes the default behavior of react-split-pane to improve the usability of the Deployments View widget.

The changes are quite simple:
1. Increase the minimum width of the panes so that the UI keeps looking good, even at minimum width.
2. Change the default width ratio to 40/60

The page size part of RD-2789 will come in a separate PR after https://github.com/cloudify-cosmo/cloudify-ui-components/pull/76 is merged. I have decided to split it into 2 PRs for stage so I can deliver a part of the functionalities earlier.

## Video


https://user-images.githubusercontent.com/889383/127164700-f57c89ff-bec9-413a-b57f-bf483486628c.mp4



## System tests

https://jenkins.cloudify.co/job/Stage-UI-System-Test/987/

Queued 2021-07-27 15:53 CEST