### PR TITLE
RD-2897 Upgrade ui-components to 2.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11267,9 +11267,9 @@
       }
     },
     "cloudify-ui-components": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/cloudify-ui-components/-/cloudify-ui-components-2.5.0.tgz",
-      "integrity": "sha512-oHcSkKvLgTzCKsuM7C6gAJxCQCfeRce0AMVC5VPFyjVQFRoaNq7DvF0IezNMpuJc1p0DwcLZ8zjTCZogHnb3jA==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/cloudify-ui-components/-/cloudify-ui-components-2.6.0.tgz",
+      "integrity": "sha512-AbTeqsPMMJ/24FTXo93YK6yWCerM8MrzslMfQ5TpYA6aMiVLzCcUVepjaPKFmwR8urEp+CLsE6befQ1eQ4/jrg==",
       "requires": {
         "cloudify-ui-common": "^4.0.0",
         "rc-tree": "^2.1.3",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "blueimp-md5": "^2.7.0",
     "cloudify-blueprint-topology": "^2.4.5",
     "cloudify-ui-common": "^4.0.0",
-    "cloudify-ui-components": "^2.5.0",
+    "cloudify-ui-components": "^2.6.0",
     "connected-react-router": "^6.5.2",
     "d3": "^3.5.17",
     "d3-format": "^1.3.2",

--- a/widgets/common/src/DeploymentActionsMenu.tsx
+++ b/widgets/common/src/DeploymentActionsMenu.tsx
@@ -53,8 +53,6 @@ export default function DeploymentActionsMenu({ onActionClick, toolbox, trigger 
     return (
         // eslint-disable-next-line react/jsx-props-no-spreading
         <PopupMenu className="deploymentActionsMenu" {...popupMenuProps}>
-            {/* TODO(RD-2760): remove the warning after Popup.Trigger can accept `children` */}
-            {/* @ts-expect-error Popup.Trigger does not accept `children` prop */}
             {trigger && <Popup.Trigger>{trigger}</Popup.Trigger>}
             <Menu pointing vertical onItemClick={onItemClick} items={items} />
         </PopupMenu>


### PR DESCRIPTION
Upgrade the package and remove an unnecessary `ts-expect-error` comment.
This is because `Popup.Trigger` can now accept children.

## System tests

https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/1000/pipeline

Queued 2021-07-29 8:53 CEST