### PR TITLE
RD-2898 Loosen assertions in topology spec

### DIFF
--- a/test/cypress/integration/widgets/topology_spec.ts
+++ b/test/cypress/integration/widgets/topology_spec.ts
@@ -1,5 +1,16 @@
-import { omit, size } from 'lodash';
+import { pick, size } from 'lodash';
 import { secondsToMs, waitUntilEmpty, waitUntilNotEmpty } from '../../support/resource_commons';
+
+/**
+ * Performs a deep equality check assuming the `assertedValue` can
+ * contain extra properties not present in `expectedValue`
+ */
+// NOTE: TS does not allow using `Record<string, object>` for the `assertedValue`
+// eslint-disable-next-line @typescript-eslint/ban-types
+const expectToContainSubset = (assertedValue: object, expectedValue: Record<string, unknown>) => {
+    const partialValueToCompare = pick(assertedValue, Object.keys(expectedValue));
+    expect(partialValueToCompare).to.deep.equal(expectedValue);
+};
 
 describe('Topology', () => {
     const pollingTimeSeconds = 5;
@@ -88,7 +99,7 @@ describe('Topology', () => {
                 .invoke('text')
                 .then(rawData => {
                     const parsedData: RowData = JSON.parse(rawData);
-                    expect(omit(parsedData, 'instances')).to.deep.equal({
+                    expectToContainSubset(parsedData, {
                         provider: 'provider["registry.terraform.io/hashicorp/null"]',
                         type: 'null_resource',
                         mode: 'managed',
@@ -96,7 +107,7 @@ describe('Topology', () => {
                     });
                     expect(parsedData.instances.length).to.equal(2);
                     parsedData.instances.forEach((instance, i) => {
-                        expect(omit(instance, 'attributes')).to.deep.equal({
+                        expectToContainSubset(instance, {
                             schema_version: 0,
                             dependencies: ['null_resource.foo2'],
                             index_key: i
@@ -110,14 +121,14 @@ describe('Topology', () => {
                 .invoke('text')
                 .then(rawData => {
                     const parsedData: RowData = JSON.parse(rawData);
-                    expect(omit(parsedData, 'instances')).to.deep.equal({
+                    expectToContainSubset(parsedData, {
                         provider: 'provider["registry.terraform.io/hashicorp/null"]',
                         type: 'null_resource',
                         mode: 'managed',
                         name: 'foo2'
                     });
                     expect(parsedData.instances.length).to.equal(1);
-                    expect(omit(parsedData.instances[0], 'attributes')).to.deep.equal({
+                    expectToContainSubset(parsedData.instances[0], {
                         schema_version: 0
                     });
                     expect(size(parsedData.instances[0].attributes)).to.equal(2);

--- a/test/cypress/integration/widgets/topology_spec.ts
+++ b/test/cypress/integration/widgets/topology_spec.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import { omit, size } from 'lodash';
 import { secondsToMs, waitUntilEmpty, waitUntilNotEmpty } from '../../support/resource_commons';
 
 describe('Topology', () => {
@@ -88,7 +88,7 @@ describe('Topology', () => {
                 .invoke('text')
                 .then(rawData => {
                     const parsedData: RowData = JSON.parse(rawData);
-                    expect(_.omit(parsedData, 'instances')).to.deep.equal({
+                    expect(omit(parsedData, 'instances')).to.deep.equal({
                         provider: 'provider["registry.terraform.io/hashicorp/null"]',
                         type: 'null_resource',
                         mode: 'managed',
@@ -96,12 +96,12 @@ describe('Topology', () => {
                     });
                     expect(parsedData.instances.length).to.equal(2);
                     parsedData.instances.forEach((instance, i) => {
-                        expect(_.omit(instance, 'attributes')).to.deep.equal({
+                        expect(omit(instance, 'attributes')).to.deep.equal({
                             schema_version: 0,
                             dependencies: ['null_resource.foo2'],
                             index_key: i
                         });
-                        expect(_.size(instance.attributes)).to.equal(2);
+                        expect(size(instance.attributes)).to.equal(2);
                         expect(instance.attributes.id).to.match(/^\d+$/);
                         expect(instance.attributes.triggers).to.deep.equal({ cluster_instance_ids: 'dummy_id' });
                     });
@@ -110,17 +110,17 @@ describe('Topology', () => {
                 .invoke('text')
                 .then(rawData => {
                     const parsedData: RowData = JSON.parse(rawData);
-                    expect(_.omit(parsedData, 'instances')).to.deep.equal({
+                    expect(omit(parsedData, 'instances')).to.deep.equal({
                         provider: 'provider["registry.terraform.io/hashicorp/null"]',
                         type: 'null_resource',
                         mode: 'managed',
                         name: 'foo2'
                     });
                     expect(parsedData.instances.length).to.equal(1);
-                    expect(_.omit(parsedData.instances[0], 'attributes')).to.deep.equal({
+                    expect(omit(parsedData.instances[0], 'attributes')).to.deep.equal({
                         schema_version: 0
                     });
-                    expect(_.size(parsedData.instances[0].attributes)).to.equal(2);
+                    expect(size(parsedData.instances[0].attributes)).to.equal(2);
                     expect(parsedData.instances[0].attributes.id).to.match(/^\d+$/);
                     expect(parsedData.instances[0].attributes.triggers).to.be.null;
                 });


### PR DESCRIPTION
Refactor the assertions in `topology_spec` to allow extra properties in the asserted objects. Changes the existing logic of using `omit` to skip some fields and now asserts that only the fields from the expected objects match.

## System tests

https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/1002/pipeline

Queued 2021-07-29 9:56 CEST