### PR TITLE
RD-2999 Improve UserAppDataAutoSaver and fix Edit Mode test

### DIFF
--- a/app/reducers/widgetsReducer.ts
+++ b/app/reducers/widgetsReducer.ts
@@ -44,7 +44,8 @@ const widgets = (state = [], action) => {
                         ...StageUtils.buildConfig(action.widgetDefinition),
                         ...action.widget.configuration
                     },
-                    drillDownPages: {}
+                    drillDownPages: {},
+                    maximized: false
                 }
             ];
         case types.UPDATE_WIDGET:

--- a/test/cypress/integration/edit_mode_spec.ts
+++ b/test/cypress/integration/edit_mode_spec.ts
@@ -6,7 +6,7 @@ describe('Edit mode', () => {
         cy.usePageMock('blueprints');
         cy.refreshTemplate();
         cy.enterEditMode();
-        cy.intercept('POST', '/console/ua').as('uaPost');
+        cy.intercept('POST', '/console/ua').as('updateUserApps');
     });
 
     it('should allow to edit widget settings', () => {
@@ -15,14 +15,14 @@ describe('Edit mode', () => {
         cy.get('.pollingTime input').type(0);
 
         cy.contains('Save').click();
-        cy.wait('@uaPost')
+        cy.wait('@updateUserApps')
             .its('request.body')
             .should('have.nested.property', 'appData.pages[0].layout[0].content[1].configuration.pollingTime', 100);
     });
 
     it('should allow to remove widget', () => {
         cy.get('.blueprintsWidget .remove').click({ force: true });
-        cy.wait('@uaPost')
+        cy.wait('@updateUserApps')
             .its('request.body')
             .should('not.have.nested.property', 'appData.pages[0].layout[0].content[1]');
         cy.get('.blueprintsWidget').should('not.exist');
@@ -33,7 +33,7 @@ describe('Edit mode', () => {
         cy.get('.addWidgetBtn').click();
         cy.get(`*[data-id=${widget1Id}]`).click();
         cy.contains('Add selected widgets').click();
-        cy.wait('@uaPost').then(({ request }) => {
+        cy.wait('@updateUserApps').then(({ request }) => {
             expect(request.body).to.have.nested.property('appData.pages[0].layout[0].content[2].definition', widget1Id);
             expect(request.body).to.have.nested.property('appData.pages[0].layout[0].content[2].height');
             expect(request.body).to.have.nested.property('appData.pages[0].layout[0].content[2].x');
@@ -41,14 +41,14 @@ describe('Edit mode', () => {
         });
 
         cy.contains('Add Widgets Container').click();
-        cy.wait('@uaPost');
+        cy.wait('@updateUserApps');
         cy.get('.react-grid-layout').should('have.length', 2);
 
         const widget2Id = 'blueprints';
         cy.get('.addWidgetBtn:last()').click();
         cy.get(`*[data-id=${widget2Id}]`).click();
         cy.contains('Add selected widgets').click();
-        cy.wait('@uaPost').then(({ request }) => {
+        cy.wait('@updateUserApps').then(({ request }) => {
             expect(request.body).to.have.nested.property('appData.pages[0].layout[1].content[0].definition', widget2Id);
             expect(request.body).to.have.nested.property('appData.pages[0].layout[1].content[0].height');
             expect(request.body).to.have.nested.property('appData.pages[0].layout[1].content[0].x');
@@ -77,14 +77,14 @@ describe('Edit mode', () => {
 
     it('should allow to rename tab and set default tab', () => {
         cy.contains('Add Tabs').click();
-        cy.wait('@uaPost');
+        cy.wait('@updateUserApps');
 
         cy.get('.editModeButton .edit:eq(0)').click();
         cy.get('.modal input[type=text]').type(2);
         cy.get('.modal .toggle').click();
 
         cy.contains('Save').click();
-        cy.wait('@uaPost')
+        cy.wait('@updateUserApps')
             .its('request.body')
             .should('have.nested.property', 'appData.pages[0].layout[1].content[0].name', 'New Tab2');
 
@@ -98,7 +98,7 @@ describe('Edit mode', () => {
         cy.get('.modal .toggle').click();
 
         cy.contains('Save').click();
-        cy.wait('@uaPost').then(({ request }) => {
+        cy.wait('@updateUserApps').then(({ request }) => {
             expect(request.body).to.have.nested.property('appData.pages[0].layout[1].content[0].isDefault', false);
             expect(request.body).to.have.nested.property('appData.pages[0].layout[1].content[1].isDefault', true);
         });

--- a/test/cypress/integration/edit_mode_spec.ts
+++ b/test/cypress/integration/edit_mode_spec.ts
@@ -29,11 +29,12 @@ describe('Edit mode', () => {
     });
 
     it('should allow to add widget', () => {
+        const widget1Id = 'pluginsCatalog';
         cy.get('.addWidgetBtn').click();
-        cy.get('*[data-id=pluginsCatalog]').click();
+        cy.get(`*[data-id=${widget1Id}]`).click();
         cy.contains('Add selected widgets').click();
-        cy.wait('@uaPost').its('request.body').should('have.nested.property', 'appData.pages[0].layout[0].content[2]');
         cy.wait('@uaPost').then(({ request }) => {
+            expect(request.body).to.have.nested.property('appData.pages[0].layout[0].content[2].definition', widget1Id);
             expect(request.body).to.have.nested.property('appData.pages[0].layout[0].content[2].height');
             expect(request.body).to.have.nested.property('appData.pages[0].layout[0].content[2].x');
             expect(request.body).to.have.nested.property('appData.pages[0].layout[0].content[2].y');
@@ -43,14 +44,12 @@ describe('Edit mode', () => {
         cy.wait('@uaPost');
         cy.get('.react-grid-layout').should('have.length', 2);
 
-        const widgetId = 'blueprints';
+        const widget2Id = 'blueprints';
         cy.get('.addWidgetBtn:last()').click();
-        cy.get(`*[data-id=${widgetId}]`).click();
+        cy.get(`*[data-id=${widget2Id}]`).click();
         cy.contains('Add selected widgets').click();
-        cy.wait('@uaPost')
-            .its('request.body')
-            .should('have.nested.property', 'appData.pages[0].layout[1].content[0].definition', widgetId);
         cy.wait('@uaPost').then(({ request }) => {
+            expect(request.body).to.have.nested.property('appData.pages[0].layout[1].content[0].definition', widget2Id);
             expect(request.body).to.have.nested.property('appData.pages[0].layout[1].content[0].height');
             expect(request.body).to.have.nested.property('appData.pages[0].layout[1].content[0].x');
             expect(request.body).to.have.nested.property('appData.pages[0].layout[1].content[0].y');

--- a/test/cypress/integration/page_spec.ts
+++ b/test/cypress/integration/page_spec.ts
@@ -32,6 +32,8 @@ describe('Page', () => {
     }
 
     it('should allow to switch tabs and maximize widgets', () => {
+        cy.intercept('POST', '/console/ua').as('updateUserApps');
+
         cy.contains('.widgetName', 'Cluster Status');
         cy.contains('.widgetName', 'Blueprints');
 
@@ -50,6 +52,7 @@ describe('Page', () => {
 
         cy.log('Verify widget maximize button works for widgets inside tabs');
         cy.get('.blueprintsWidget .expand').click({ force: true });
+        cy.wait('@updateUserApps');
 
         cy.contains('.widgetName', 'Cluster Status').should('not.be.visible');
         cy.contains('.widgetName', 'Catalog').should('not.be.visible');
@@ -61,6 +64,7 @@ describe('Page', () => {
 
         cy.log('Verify widget maximize button works for top level widgets');
         cy.get('.blueprintCatalogWidget .expand').click({ force: true });
+        cy.wait('@updateUserApps');
 
         cy.contains('.widgetName', 'Cluster Status').should('not.be.visible');
         cy.contains('.widgetName', 'Blueprints').should('not.be.visible');
@@ -75,6 +79,8 @@ describe('Page', () => {
 
         cy.log('Verify widget collapse button works');
         cy.get('.blueprintCatalogWidget .compress').click({ force: true });
+        cy.wait('@updateUserApps');
+
         verifyAllWidgetsVisible();
     });
 });

--- a/test/cypress/support/commands.ts
+++ b/test/cypress/support/commands.ts
@@ -263,6 +263,7 @@ const commands = {
                                       content: [
                                           {
                                               id: 'filter',
+                                              name: 'Resource Filter',
                                               definition: 'filter',
                                               configuration: {
                                                   filterByBlueprints: true,
@@ -270,20 +271,23 @@ const commands = {
                                                   filterByExecutionsStatus: true,
                                                   allowMultipleSelection: true
                                               },
+                                              drillDownPages: {},
                                               height: 2,
                                               width: widgetsWidth,
                                               x: 0,
-                                              y: 0
+                                              y: 0,
+                                              maximized: false
                                           },
                                           ..._.map(widgetIdsArray, (widgetId, index) => ({
                                               id: widgetId,
                                               definition: widgetId,
                                               configuration: widgetConfiguration,
-                                              height: 20,
                                               drillDownPages: {},
+                                              height: 20,
                                               width: widgetsWidth,
                                               x: 0,
-                                              y: 2 + (index + 1) * 20
+                                              y: 2 + (index + 1) * 20,
+                                              maximized: false
                                           }))
                                       ]
                                   }
@@ -300,12 +304,18 @@ const commands = {
                                 content: [
                                     {
                                         id: 'pluginsCatalog',
+                                        name: 'Plugins Catalog',
                                         definition: 'pluginsCatalog',
                                         configuration: {
                                             jsonPath:
                                                 'http://repository.cloudifysource.org/cloudify/wagons/plugins.json'
                                         },
-                                        height: 20
+                                        drillDownPages: {},
+                                        height: 20,
+                                        width: widgetsWidth,
+                                        x: 0,
+                                        y: 0,
+                                        maximized: false
                                     }
                                 ]
                             }

--- a/test/jest/reducers/pagesReducer.test.ts
+++ b/test/jest/reducers/pagesReducer.test.ts
@@ -357,7 +357,8 @@ describe('(Reducer) Pages', () => {
                                 x: 1,
                                 y: 1,
                                 configuration: {},
-                                drillDownPages: {}
+                                drillDownPages: {},
+                                maximized: false
                             }
                         ]
                     }


### PR DESCRIPTION
## Description
Looks like the reason for the problem (RD-2999) was that `POST /console/ua` was called multiple times and in some cases it was hard to know how many times it will be called. In this PR I changed how we save `userApp` data in `UserAppDataAutoSaver` instance by using `lodash.debounce` and sending request only after 1 second since last trigger.
Within this PR I also improved our test page to include all standard widget parameters.

## Screenshots / Videos
### Before

https://user-images.githubusercontent.com/5202105/129903986-706b8bae-f392-4c9a-ba88-dbcbeb9b13e6.mp4

### After

https://user-images.githubusercontent.com/5202105/129903999-d49ae648-0144-4258-8fd8-bd7544125f4c.mp4


## Checklist
- [x] My code follows the UI Code Style.
- [x] I verified that all tests and checks have passed.
- [x] I verified if that change requires a documentation update.
- [x] I added proper labels to this PR.

## Tests
As this issue was not always happening, I have triggered 3 builds:

1. [Stage-UI-System-Test/1099](https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/1099/pipeline) (2021-08-18 15:15 CEST) - 1 test failed (`page_spec.ts`)
2. [Stage-UI-System-Test/1100](https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/1100/pipeline) (2021-08-18 15:16 CEST) - 1 test failed (`page_spec.ts`)
3. [Stage-UI-System-Test/1101](https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/1101/pipeline) (2021-08-18 15:17 CEST) - 1 test failed (`page_spec.ts`) + CI environment issue
4. [Stage-UI-System-Test/1105](https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/1105/pipeline) (2021-08-19 08:30 CEST) - PASSED

## Documentation
N/A
