### PR TITLE
RD-3024 Change build result to UNSTABLE when audit stage fails

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -43,7 +43,7 @@ pipeline {
       parallel{
         stage('Audit'){
           steps {
-            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE'){
+            catchError(buildResult: 'UNSTABLE', stageResult: 'FAILURE'){
               container('node'){
                 dir("${STAGE_DIR}") {
                   echo 'Run npm production dependencies security audit'


### PR DESCRIPTION
## Description
This PR changes build result when Audit stage fails from `SUCESS` to `UNSTABLE`. That way we can save UI Guardian's time - as he will only need to check job details in case of yellow (`UNSTABLE`) or red (`FAILURE`) build colors.

I'm planning to update all other UI repositories once we get this PR merged.

## Screenshots / Videos

### Old view
![Screenshot from 2021-08-23 08-08-14](https://user-images.githubusercontent.com/5202105/130398549-1ee5e002-e571-4726-9597-3eb9bd06df51.png)

### Blue Ocean
![Screenshot from 2021-08-23 08-09-16](https://user-images.githubusercontent.com/5202105/130398662-f9637419-5273-44e6-845e-5e9146fcddb3.png)

## Checklist
- [x] My code follows the UI Code Style.
- [x] I verified that all tests and checks have passed.
- [x] I verified if that change requires a documentation update.
- [x] I added proper labels to this PR.

## Tests
Taking advantage of stage encountering audit issue since some time, I just check build status with the changes:
* build is marked yellow (unstable)
* none of the stages are blocked after marking build as unstable

[cloudify-stage/job/RD-3024](https://jenkins.cloudify.co/job/cloudify-stage/job/RD-3024/3/)

## Documentation
I'll update [UI Health Monitoring - Process](https://cloudifysource.atlassian.net/wiki/spaces/RD/pages/1759346689/Process) page with information that audit failure should be indicated by the main job (will have yellow color).