### PR TITLE
RD-2826 & RD-2479 Update widget help description for "Number of Deployments", "Plugins" and "Plugins Catalog" widgets

### DIFF
--- a/widgets/deploymentNum/README.md
+++ b/widgets/deploymentNum/README.md
@@ -1,6 +1,12 @@
 # Number of deployments
 Displays the total number of deployments in the tenant, according to the user’s permissions and the blueprints’ visibility levels.
-The widget is clickable, and upon clicking will redirect by default to the “Deployments” page. You can set the widget’s configuration to lead to a different page.
+
+The widget is clickable, and upon clicking will redirect by default to the
+“Services” page. You can set the widget’s configuration to lead to a different
+page. If the page contains Deployments View widget, then deployments will be
+filtered according to the filter selected in widget's configuration.
+
+The label and image displayed along with deployments count are configurable.
 
 ![number_of_deployments]( /images/ui/widgets/num_of_deployments.png )
 
@@ -8,4 +14,9 @@ The widget is clickable, and upon clicking will redirect by default to the “De
 ## Settings
 
 * `Refresh time interval` - The time interval in which the widget’s data will be refreshed, in seconds. Default: 10 seconds.
-* `Page to open on click` -  The name of the page to be redirected to upon clicking on the widget. Default: 'Deployments'
+* `Label` - The label displayed under deployments count. Default: 'Deployments'
+* `Icon` - Name of the icon displayed on the left side of the deployments count. Available icons list can be found 
+  at: [Icon - Semantic UI React](https://react.semantic-ui.com/elements/icon). Default: 'cube'
+* `Image URL` - URL of the image displayed on the left side of the deployments count. Default: ''
+* `Filter ID` - Name of the saved filter to apply on deployments. Default: ''
+* `Page to open on click` -  The name of the page to be redirected to upon clicking on the widget. Default: 'Services'

--- a/widgets/plugins/README.md
+++ b/widgets/plugins/README.md
@@ -13,7 +13,7 @@ The widget displays the following information:
 * **Plugin Package version**
 * **Supported platform**
 * **Distribution the plugin is supported on**
-* **Distribute release**
+* **Distribution release**
 * **Uploaded at**
 * **Creator**
 
@@ -22,17 +22,23 @@ Upon hovering over ID label a pop up with the plugin’s ID will open, allowing 
 ![Plugins list]( /images/ui/widgets/plugins-list.png )
 
 
-### Uploading a Plugin
+### Uploading a Plugin package
 
 1. Click **Upload** above the Plugins table.
-2. Either enter the URL of the wagon or select the wagon file from your file repository.
-3. Either enter the URL of the plugin yaml file or select the plugin yaml file from your file repository.
-4. Provide a title for the plugin (should be automatically filled with package name upon providing YAML file).
-5. Optionally provide icon file for the plugin.
-6. Click **Upload**.
+2. Click **Upload a package**
+3. Either enter the URL of the wagon or select the wagon file from your file repository.
+4. Either enter the URL of the plugin yaml file or select the plugin yaml file from your file repository.
+5. Provide a title for the plugin (should be automatically filled with package name upon providing YAML file).
+6. Optionally provide icon file for the plugin.
+7. Click **Upload**.
 
 ![Upload Plugin modal]( /images/ui/widgets/plugins_upload-plugin.png )
 
+### Uploading a Plugin from the Marketplace
+
+1. Click **Upload** above the Plugins table.
+2. Click **Upload from Marketplace**
+3. Upload selected plugins using the displayed [Plugins Catalog widget](/working_with/console/widgets/pluginsCatalog)
 
 ### Downloading a Plugin
 

--- a/widgets/pluginsCatalog/README.md
+++ b/widgets/pluginsCatalog/README.md
@@ -1,5 +1,5 @@
 # Plugins Catalog
-A widget listing all the latest releases of the certified plugins, allowing plugin upload to the current tenant.
+A widget listing all the latest releases of the certified plugins, allowing plugin upload to the current tenant. You can upload selected plugins or upload all plugins at once by clicking the **Upload all plugins** button.
 
 ![plugins_catalog]( /images/ui/widgets/plugins-catalog.png )
 


### PR DESCRIPTION
## Description
As https://github.com/cloudify-cosmo/docs.getcloudify.org/pull/1918 and https://github.com/cloudify-cosmo/docs.getcloudify.org/pull/1919 were merged, this PR updates `README.md` files for all changed widgets' documentation pages.

## Screenshots / Videos
N/A

## Checklist
- [x] My code follows the UI Code Style.
- [x] I verified that all tests and checks have passed.
- [x] I verified if that change requires a documentation update.
- [x] I added proper labels to this PR.

## Tests
Docs stage in CI pipeline passes.

## Documentation
N/A