### PR TITLE
RD-2936 Fix useModalOpenState to allow closing Getting Started modal in all cases

### DIFF
--- a/app/components/GettingStartedModal/useModalOpenState.ts
+++ b/app/components/GettingStartedModal/useModalOpenState.ts
@@ -18,16 +18,20 @@ const useModalOpenState = () => {
     const manager = useManager();
     const { response } = useFetch<UserResponse>(manager, `/users/${manager.getCurrentUsername()}`);
     const [modalOpen, setModalOpen] = useState(false);
-    const [gettingStartedParameter, setGettingStartedParameter, deleteGettingStartedParameter] = useSearchParam(
-        gettingStartedParameterName
-    );
+    const [gettingStartedParameter, , deleteGettingStartedParameter] = useSearchParam(gettingStartedParameterName);
 
     useEffect(() => {
-        if (response?.show_getting_started || gettingStartedParameter === gettingStartedParameterValue) {
+        if (response?.show_getting_started) {
             setModalOpen(true);
-            if (!gettingStartedParameter) setGettingStartedParameter(gettingStartedParameterValue);
         }
-    }, [response, gettingStartedParameter]);
+    }, [response]);
+
+    useEffect(() => {
+        if (gettingStartedParameter === gettingStartedParameterValue) {
+            setModalOpen(true);
+        }
+    }, [gettingStartedParameter]);
+
     const closeModal = async (disabled: boolean) => {
         try {
             if (disabled) {


### PR DESCRIPTION
## Description
In the clean Cloudify Manager installation, when the user logs in Getting Started modal is presented. After #1565 implementation it was not working properly as it was not possible to close the modal. 

The reason for that: 
* once Close button is clicked, the modal is being closed, `gettingStarted` query parameter is removed and location is updated
* `gettingStarted` query parameter change triggers useEffect hook to be fired, sets `gettingStarted` query parameter again and opens the modal

As a result of that, the user was not able to close the modal.

## Screenshots / Videos

https://user-images.githubusercontent.com/5202105/131479023-440d52eb-deea-4544-9dc1-4608bbf09515.mp4

## Checklist
- [x] My code follows the UI Code Style.
- [x] I verified that all tests and checks have passed.
- [x] I verified if that change requires a documentation update.
- [x] I added proper labels to this PR.

## Tests
[Stage-UI-System-Test/1165](https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/1165/pipeline) - PASSED

## Documentation
N/A
