### PR TITLE
RD-2936 Fix useModalOpenState to allow closing Getting Started modal in all cases [6.2]

### DIFF
--- a/app/components/GettingStartedModal/useModalOpenState.ts
+++ b/app/components/GettingStartedModal/useModalOpenState.ts
@@ -18,16 +18,20 @@ const useModalOpenState = () => {
     const manager = useManager();
     const { response } = useFetch<UserResponse>(manager, `/users/${manager.getCurrentUsername()}`);
     const [modalOpen, setModalOpen] = useState(false);
-    const [gettingStartedParameter, setGettingStartedParameter, deleteGettingStartedParameter] = useSearchParam(
-        gettingStartedParameterName
-    );
+    const [gettingStartedParameter, , deleteGettingStartedParameter] = useSearchParam(gettingStartedParameterName);
 
     useEffect(() => {
-        if (response?.show_getting_started || gettingStartedParameter === gettingStartedParameterValue) {
+        if (response?.show_getting_started) {
             setModalOpen(true);
-            if (!gettingStartedParameter) setGettingStartedParameter(gettingStartedParameterValue);
         }
-    }, [response, gettingStartedParameter]);
+    }, [response]);
+
+    useEffect(() => {
+        if (gettingStartedParameter === gettingStartedParameterValue) {
+            setModalOpen(true);
+        }
+    }, [gettingStartedParameter]);
+
     const closeModal = async (disabled: boolean) => {
         try {
             if (disabled) {


### PR DESCRIPTION
## Description
Cherry-pick of #1572 on `6.2.0-build` branch.

## Screenshots / Videos
N/A

## Checklist
- [x] My code follows the UI Code Style.
- [x] I verified that all tests and checks have passed.
- [x] I verified if that change requires a documentation update.
- [x] I added proper labels to this PR.

## Tests
Just a cherry-pick, so not planning any testing.

## Documentation
N/A