### PR TITLE
RD-3123 Refactor waiting in login_spec.ts

### DIFF
--- a/test/cypress/integration/login_spec.ts
+++ b/test/cypress/integration/login_spec.ts
@@ -19,7 +19,7 @@ describe('Login', () => {
         cy.location('pathname').should('be.equal', redirectUrl);
     });
 
-    it('succeeds and resets user pages when application version is different than the one stored in the DB', () => {
+    it.only('succeeds and resets user pages when application version is different than the one stored in the DB', () => {
         const currentAppDataVersion = getCurrentAppVersion();
         const fetchUserAppsTimeout = 20000;
 
@@ -35,12 +35,8 @@ describe('Login', () => {
         cy.activate().login('admin', 'admin', false);
 
         cy.wait('@fetchUserApps', { timeout: fetchUserAppsTimeout });
-        cy.wait('@fetchTemplateId').then(({ response }) => {
-            expect(response.body).to.equal('main-sys_admin');
-        });
-        cy.wait('@updateUserApps').then(({ response }) => {
-            expect(response.body.appDataVersion).to.equal(currentAppDataVersion);
-        });
+        cy.wait('@fetchTemplateId').its('response.body').should('equal', 'main-sys_admin');
+        cy.wait('@updateUserApps').its('response.body.appDataVersion').should('equal', currentAppDataVersion);
     });
 
     it('succeeds when provided credentials are valid and license is not active', () => {

--- a/test/cypress/integration/login_spec.ts
+++ b/test/cypress/integration/login_spec.ts
@@ -19,7 +19,7 @@ describe('Login', () => {
         cy.location('pathname').should('be.equal', redirectUrl);
     });
 
-    it.only('succeeds and resets user pages when application version is different than the one stored in the DB', () => {
+    it('succeeds and resets user pages when application version is different than the one stored in the DB', () => {
         const currentAppDataVersion = getCurrentAppVersion();
         const fetchUserAppsTimeout = 20000;
 


### PR DESCRIPTION
## Description
The reason for the problem described in RD-3123 is unknown for me. From the screenshot and video it seems like the awaited `updateUserApps` (`POST /console/ua`) was present, but only after the assertion was already executed 😕:

![Screenshot from 2021-09-09 07-57-39](https://user-images.githubusercontent.com/5202105/132631231-f0bc5c60-4ced-4bd4-8deb-a3debb0b47c0.png)


The problem is not reproducible in local environment and didn't happen in the last nightly ([Nightly-UI/228](https://jenkins.cloudify.co/view/UI%20Health%20View/job/Nightly-UI/228/) - 9th Sep), so I think it is not worth to spend much time on it. 

I just refactored waiting for the response which we want to verify in that test, it should be a bit more verbose right now. Instead of `cy.wait(...).then(...)` chain, I used `cy.wait(...).its(...)` chain.

![Screenshot from 2021-09-09 08-01-08](https://user-images.githubusercontent.com/5202105/132631544-48ab2674-6499-43cb-86ba-c7f198f4babb.png)

For the future we may:
1. Dig into cypress issues and try to find something similar as it seems like possible bug in Cypress - https://github.com/cypress-io/cypress/issues
2. Check if the caching is not the problem here - https://glebbahmutov.com/blog/cypress-intercept-problems/#cached-response

## Screenshots / Videos
N/A

## Checklist
- [x] My code follows the UI Code Style.
- [x] I verified that all tests and checks have passed.
- [x] I verified if that change requires a documentation update.
- [x] I added proper labels to this PR.

## Tests
Only `login_spec.ts`:
1. [Stage-UI-System-Test/1224](https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/1224/pipeline) - PASSED
2. [Stage-UI-System-Test/1225](https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/1225/pipeline) - PASSED
3. [Stage-UI-System-Test/1226](https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/1226/pipeline) - PASSED

## Documentation
N/A
