### PR TITLE
RD-3017 Add support for switching between Catalog and Table view in Blueprints Marketplace modal. (#1581)

### DIFF
--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -666,7 +666,7 @@
                     "uploadButton": "Upload",
                     "uploadFromMarketplace": "Upload from Marketplace",
                     "uploadFromPackage": "Upload a blueprint package",
-                    "generateInComposer":  "Generate in the Composer"
+                    "generateInComposer": "Generate in the Composer"
                 }
             },
             "blueprintMarketplace": {
@@ -714,6 +714,57 @@
                             }
                         ]
                     }
+                },
+                "marketplaceDisplayStyle": {
+                    "label": "Marketplace display style",
+                    "items": {
+                        "table": "Table",
+                        "catalog": "Catalog"
+                    }
+                },
+                "marketplaceColumnsToShow": {
+                    "label": "List of fields to show in the marketplace table",
+                    "placeholder": "Select fields from the list"
+                }
+            }
+        },
+        "blueprintCatalog": {
+            "configuration": {
+                "jsonPath": {
+                    "label": "Blueprints Examples URL",
+                    "placeholder": "Type URL to blueprint examples JSON file",
+                    "description": "If set, then GitHub options are not used for fetching data."
+                },
+                "username": {
+                    "label": "GitHub User",
+                    "placeholder": "Type GitHub's user or organization name",
+                    "description": "GitHub user or organization account name which is the owner of the repositories to fetch. Used only if Blueprints Examples URL is not set."
+                },
+                "filter": {
+                    "label": "GitHub Filter",
+                    "placeholder": "Type filter for GitHub repositories",
+                    "description": "Optional filter for GitHub repositories. See GitHub's web page 'Searching repositories' for more details. Used only if Blueprints Examples URL is not set."
+                },
+                "displayStyle": {
+                    "label": "Display style",
+                    "option": {
+                        "table": "Table",
+                        "catalog": "Catalog"
+                    }
+                },
+                "fieldsToShow": {
+                    "label": "List of fields to show in the table",
+                    "placeholder": "Select fields from the list",
+                    "items": {
+                        "name": "Name",
+                        "description": "Description",
+                        "created": "Created",
+                        "updated": "Updated"
+                    }
+                },
+                "sortByName": {
+                    "label": "Sort by name",
+                    "description": "If set to true, then blueprints will be sorted by name."
                 }
             }
         },
@@ -749,7 +800,7 @@
                     "description": "Page URL address to open on button click. If URL starts with 'http', then page will be opened in a new window/tab. In other case it will be opened in the same window.",
                     "default": ""
                 }
-        }
+            }
         },
         "cloudNum": {
             "name": "Number of clouds",

--- a/test/cypress/integration/widgets/blueprint_catalog_spec.ts
+++ b/test/cypress/integration/widgets/blueprint_catalog_spec.ts
@@ -5,7 +5,9 @@ describe('Blueprints catalog widget', () => {
         cy
             .activate()
             .usePageMock('blueprintCatalog', {
-                jsonPath: 'https://repository.cloudifysource.org/cloudify/blueprints/6.2/vm-examples.json'
+                jsonPath: 'https://repository.cloudifysource.org/cloudify/blueprints/6.2/vm-examples.json',
+                displayStyle: 'catalog',
+                fieldsToShow: ['Name', 'Description', 'Created', 'Updated']
             })
             .mockLogin()
             .deleteBlueprints(blueprintName, true)
@@ -33,5 +35,26 @@ describe('Blueprints catalog widget', () => {
 
         cy.contains('.segment', blueprintName).contains('Upload').click();
         cy.contains('.ui.label.section.active.pageTitle', blueprintName);
+    });
+
+    it('should allow to change display style', () => {
+        cy.editWidgetConfiguration('blueprintCatalog', () => {
+            cy.setDropdownValues('Display style', ['Table']);
+        });
+
+        cy.get('.blueprintCatalogWidget table').should('be.visible');
+    });
+
+    it('should allow to customize fields to show', () => {
+        cy.editWidgetConfiguration('blueprintCatalog', () => {
+            cy.clearMultipleDropdown('List of fields to show in the table');
+            cy.setDropdownValues('List of fields to show in the table', ['Name', 'Created']);
+        });
+        cy.get('.blueprintCatalogWidget').within(() => {
+            cy.contains('Name').should('be.visible');
+            cy.contains('Created').should('be.visible');
+            cy.contains('Updated').should('not.exist');
+            cy.contains('Description').should('not.exist');
+        });
     });
 });

--- a/test/cypress/integration/widgets/blueprints_spec.ts
+++ b/test/cypress/integration/widgets/blueprints_spec.ts
@@ -22,7 +22,9 @@ describe('Blueprints widget', () => {
         clickToDrillDown: true,
         pollingTime: 5,
         showComposerOptions: true,
-        marketplaceTabs
+        marketplaceTabs,
+        marketplaceDisplayStyle: 'catalog',
+        marketplaceColumnsToShow: ['Name', 'Description']
     };
 
     before(() =>

--- a/test/cypress/support/commands.ts
+++ b/test/cypress/support/commands.ts
@@ -375,18 +375,18 @@ const commands = {
             .then(commandResult => commandResult.stdout);
     },
 
-    setSearchableDropdownValue: (fieldName: string, value: string) => {
-        const getDropdownField = () => cy.contains('.field', fieldName);
+    getField: (fieldName: string) => cy.contains('.field', fieldName),
 
+    setSearchableDropdownValue: (fieldName: string, value: string) => {
         if (value) {
-            getDropdownField()
+            cy.getField(fieldName)
                 .click()
                 .within(() => {
                     cy.get('input').type(value);
                     cy.get(`div[option-value="${value}"]`).click();
                 });
         } else {
-            getDropdownField()
+            cy.getField(fieldName)
                 .find('i.dropdown')
                 .then($icon => {
                     if ($icon.hasClass('clear')) cy.clearSearchableDropdown(fieldName);
@@ -394,15 +394,16 @@ const commands = {
         }
     },
 
-    clearSearchableDropdown: (fieldName: string) =>
-        cy.contains('.field', fieldName).find('.dropdown.clear.icon').click(),
+    clearSearchableDropdown: (fieldName: string) => cy.getField(fieldName).find('.dropdown.clear.icon').click(),
 
     setDropdownValues: (fieldName: string, values: string[]) => {
-        cy.contains('.field', fieldName)
+        cy.getField(fieldName)
             .click()
             .within(() => values.forEach(value => cy.contains('div[role=option]', value).click()))
             .click();
     },
+
+    clearMultipleDropdown: (fieldName: string) => cy.getField(fieldName).find('.delete.icon').click({ multiple: true }),
 
     openTab: (tabName: string) => {
         cy.get('.tabular.menu').contains(tabName).click();

--- a/widgets/blueprintCatalog/src/RepositoryTable.tsx
+++ b/widgets/blueprintCatalog/src/RepositoryTable.tsx
@@ -4,6 +4,8 @@ import type { FunctionComponent } from 'react';
 import Consts from './consts';
 import type { RepositoryViewProps } from './types';
 
+const t = Stage.Utils.getT('widgets.blueprintCatalog');
+
 const RepositoryTable: FunctionComponent<RepositoryViewProps> = ({
     fetchData = noop,
     onSelect = noop,
@@ -20,6 +22,7 @@ const RepositoryTable: FunctionComponent<RepositoryViewProps> = ({
     // Show pagination only in case when data is provided from GitHub
     const pageSize = data.source === Consts.GITHUB_DATA_SOURCE ? widget.configuration.pageSize : data.total;
     const totalSize = data.source === Consts.GITHUB_DATA_SOURCE ? data.total : -1;
+    const { fieldsToShow } = widget.configuration;
 
     return (
         <DataTable
@@ -31,10 +34,26 @@ const RepositoryTable: FunctionComponent<RepositoryViewProps> = ({
             selectable
             noDataMessage={noDataMessage}
         >
-            <DataTable.Column label="Name" width="25%" />
-            <DataTable.Column label="Description" width="40%" />
-            <DataTable.Column label="Created" width="12%" />
-            <DataTable.Column label="Updated" width="12%" />
+            <DataTable.Column
+                label={t('configuration.fieldsToShow.items.name')}
+                width="25%"
+                show={fieldsToShow.includes(t('configuration.fieldsToShow.items.name'))}
+            />
+            <DataTable.Column
+                label={t('configuration.fieldsToShow.items.description')}
+                width="40%"
+                show={fieldsToShow.includes(t('configuration.fieldsToShow.items.description'))}
+            />
+            <DataTable.Column
+                label={t('configuration.fieldsToShow.items.created')}
+                width="12%"
+                show={fieldsToShow.includes(t('configuration.fieldsToShow.items.created'))}
+            />
+            <DataTable.Column
+                label={t('configuration.fieldsToShow.items.updated')}
+                width="12%"
+                show={fieldsToShow.includes(t('configuration.fieldsToShow.items.updated'))}
+            />
             <DataTable.Column width="11%" />
 
             {data.items.map(item => {

--- a/widgets/blueprintCatalog/src/types.ts
+++ b/widgets/blueprintCatalog/src/types.ts
@@ -8,6 +8,7 @@ export interface BlueprintCatalogWidgetConfiguration {
     pageSize: number;
     sortColumn: string;
     sortAscending: boolean;
+    fieldsToShow: string[];
 }
 
 export interface Blueprint {

--- a/widgets/blueprintCatalog/src/widget.tsx
+++ b/widgets/blueprintCatalog/src/widget.tsx
@@ -4,13 +4,23 @@ import Consts from './consts';
 
 import type { BlueprintCatalogPayload, BlueprintCatalogWidgetConfiguration, Blueprint } from './types';
 
+const widgetId = 'blueprintCatalog';
+const t = Stage.Utils.getT(`widgets.${widgetId}`);
+
+const fieldsToShowItems = [
+    t('configuration.fieldsToShow.items.name'),
+    t('configuration.fieldsToShow.items.description'),
+    t('configuration.fieldsToShow.items.created'),
+    t('configuration.fieldsToShow.items.updated')
+];
+
 Stage.defineWidget<
     Record<string, string | number>,
     BlueprintCatalogPayload | Error,
     BlueprintCatalogWidgetConfiguration
 >({
     hasTemplate: false,
-    id: 'blueprintCatalog',
+    id: widgetId,
     name: 'Blueprints Catalog',
     description: 'Shows blueprints catalog',
     initialWidth: 8,
@@ -26,46 +36,50 @@ Stage.defineWidget<
         Stage.GenericConfig.PAGE_SIZE_CONFIG(),
         {
             id: 'jsonPath',
-            name: 'Blueprints Examples URL',
-            placeHolder: 'Type URL to blueprint examples JSON file',
-            description: 'If set, then GitHub options are not used for fetching data.',
+            name: t('configuration.jsonPath.label'),
+            placeholder: t('configuration.jsonPath.placeholder'),
+            description: t('configuration.jsonPath.description'),
             default: Stage.i18n.t('widgets.common.urls.blueprintsCatalog'),
             type: Stage.Basic.GenericField.STRING_TYPE
         },
         {
             id: 'username',
-            name: 'GitHub User',
-            placeHolder: "Type GitHub's user or organization name",
-            description:
-                'GitHub user or organization account name which is the owner of the repositories to fetch. ' +
-                'Used only if Blueprints Examples URL is not set.',
+            name: t('configuration.username.label'),
+            placeholder: t('configuration.username.placeholder'),
+            description: t('configuration.username.description'),
             default: 'cloudify-examples',
             type: Stage.Basic.GenericField.STRING_TYPE
         },
         {
             id: 'filter',
-            name: 'GitHub Filter',
-            placeHolder: 'Type filter for GitHub repositories',
-            description:
-                "Optional filter for GitHub repositories. See GitHub's web page 'Searching repositories' for more details. " +
-                'Used only if Blueprints Examples URL is not set.',
+            name: t('configuration.filter.label'),
+            placeholder: t('configuration.filter.placeholder'),
+            description: t('configuration.filter.description'),
             default: 'blueprint in:name NOT local',
             type: Stage.Basic.GenericField.STRING_TYPE
         },
         {
             id: 'displayStyle',
-            name: 'Display style',
+            name: t('configuration.displayStyle.label'),
             items: [
-                { name: 'Table', value: 'table' },
-                { name: 'Catalog', value: 'catalog' }
+                { name: t('configuration.displayStyle.option.table'), value: 'table' },
+                { name: t('configuration.displayStyle.option.catalog'), value: 'catalog' }
             ],
             default: 'table',
             type: Stage.Basic.GenericField.LIST_TYPE
         },
         {
+            id: 'fieldsToShow',
+            name: t('configuration.fieldsToShow.label'),
+            placeholder: t('configuration.fieldsToShow.placeholder'),
+            items: fieldsToShowItems,
+            default: fieldsToShowItems.join(),
+            type: Stage.Basic.GenericField.MULTI_SELECT_LIST_TYPE
+        },
+        {
             id: 'sortByName',
-            name: 'Sort by name',
-            description: 'If set to true, then blueprints will be sorted by name.',
+            name: t('configuration.sortByName.label'),
+            description: t('configuration.sortByName.description'),
             default: false,
             type: Stage.Basic.GenericField.BOOLEAN_TYPE
         }

--- a/widgets/blueprints/src/BlueprintsList.tsx
+++ b/widgets/blueprints/src/BlueprintsList.tsx
@@ -148,10 +148,14 @@ export default class BlueprintList extends React.Component<BlueprintListProps, B
                     <BlueprintUploadActionsMenu
                         direction="left"
                         toolbox={toolbox}
-                        marketplaceTabs={widget.configuration.marketplaceTabs}
                         showGenerateInComposerButton={
                             !toolbox.getManager().isCommunityEdition() && widget.configuration.showComposerOptions
                         }
+                        marketplaceConfig={{
+                            tabs: widget.configuration.marketplaceTabs,
+                            displayStyle: widget.configuration.marketplaceDisplayStyle,
+                            columns: widget.configuration.marketplaceColumnsToShow
+                        }}
                     />
                 </div>
                 <BlueprintsView

--- a/widgets/blueprints/src/types.ts
+++ b/widgets/blueprints/src/types.ts
@@ -8,6 +8,8 @@ export interface BlueprintsWidgetConfiguration {
     hideFailedBlueprints: boolean;
     showComposerOptions: boolean;
     marketplaceTabs: Stage.Common.BlueprintMarketplace.Tab[];
+    marketplaceDisplayStyle: Stage.Common.BlueprintMarketplace.DisplayStyle;
+    marketplaceColumnsToShow: string[];
 }
 
 interface Blueprint {

--- a/widgets/blueprints/src/widget.tsx
+++ b/widgets/blueprints/src/widget.tsx
@@ -2,6 +2,8 @@
 import BlueprintsList from './BlueprintsList';
 import type { BlueprintsWidgetConfiguration } from './types';
 
+const t = Stage.Utils.getT('widgets.blueprints');
+
 Stage.defineWidget<unknown, unknown, BlueprintsWidgetConfiguration>({
     id: 'blueprints',
     name: 'Blueprints',
@@ -20,16 +22,16 @@ Stage.defineWidget<unknown, unknown, BlueprintsWidgetConfiguration>({
         Stage.GenericConfig.PAGE_SIZE_CONFIG(5),
         {
             id: 'clickToDrillDown',
-            name: Stage.i18n.t('widgets.blueprints.configuration.clickToDrillDown'),
+            name: t('configuration.clickToDrillDown'),
             default: true,
             type: Stage.Basic.GenericField.BOOLEAN_TYPE
         },
         {
             id: 'displayStyle',
-            name: Stage.i18n.t('widgets.blueprints.configuration.displayStyle.label'),
+            name: t('configuration.displayStyle.label'),
             items: [
-                { name: Stage.i18n.t('widgets.blueprints.configuration.displayStyle.items.table'), value: 'table' },
-                { name: Stage.i18n.t('widgets.blueprints.configuration.displayStyle.items.catalog'), value: 'catalog' }
+                { name: t('configuration.displayStyle.items.table'), value: 'table' },
+                { name: t('configuration.displayStyle.items.catalog'), value: 'catalog' }
             ],
             default: 'table',
             type: Stage.Basic.GenericField.LIST_TYPE
@@ -38,17 +40,49 @@ Stage.defineWidget<unknown, unknown, BlueprintsWidgetConfiguration>({
         Stage.GenericConfig.SORT_ASCENDING_CONFIG(false),
         {
             id: 'hideFailedBlueprints',
-            name: Stage.i18n.t('widgets.blueprints.configuration.hideFailedBlueprints'),
+            name: t('configuration.hideFailedBlueprints'),
             default: false,
             type: Stage.Basic.GenericField.BOOLEAN_TYPE
         },
         {
             id: 'showComposerOptions',
             type: Stage.Basic.GenericField.BOOLEAN_TYPE,
-            name: Stage.i18n.t('widgets.blueprints.configuration.showComposerOptions'),
+            name: t('configuration.showComposerOptions'),
             default: false
         },
-        Stage.Common.BlueprintMarketplace.tabsConfig
+        Stage.Common.BlueprintMarketplace.tabsConfig,
+        {
+            id: 'marketplaceDisplayStyle',
+            name: t('configuration.marketplaceDisplayStyle.label'),
+            items: [
+                {
+                    name: t('configuration.marketplaceDisplayStyle.items.table'),
+                    value: 'table'
+                },
+                {
+                    name: t('configuration.marketplaceDisplayStyle.items.catalog'),
+                    value: 'catalog'
+                }
+            ],
+            default: 'table',
+            type: Stage.Basic.GenericField.LIST_TYPE
+        },
+        {
+            id: 'marketplaceColumnsToShow',
+            name: t('configuration.marketplaceColumnsToShow.label'),
+            placeholder: t('configuration.marketplaceColumnsToShow.placeholder'),
+            items: [
+                Stage.i18n.t('widgets.blueprintCatalog.configuration.fieldsToShow.items.name'),
+                Stage.i18n.t('widgets.blueprintCatalog.configuration.fieldsToShow.items.description'),
+                Stage.i18n.t('widgets.blueprintCatalog.configuration.fieldsToShow.items.created'),
+                Stage.i18n.t('widgets.blueprintCatalog.configuration.fieldsToShow.items.updated')
+            ],
+            default: `${Stage.i18n.t('widgets.blueprintCatalog.configuration.fieldsToShow.items.name')}, ${Stage.i18n.t(
+                'widgets.blueprintCatalog.configuration.fieldsToShow.items.description'
+            )}`,
+
+            type: Stage.Basic.GenericField.MULTI_SELECT_LIST_TYPE
+        }
     ],
 
     fetchData(widget, toolbox, params) {

--- a/widgets/common/src/BlueprintUploadActionsMenu.tsx
+++ b/widgets/common/src/BlueprintUploadActionsMenu.tsx
@@ -22,17 +22,23 @@ const getMenuItems = (includeComposerButton: boolean) => {
 
 type ActionName = typeof baseMenuItems[number]['name'] | typeof generateInComposerMenuItem['name'];
 
+interface MarketplaceModalConfig {
+    tabs?: MarketplaceTab[];
+    displayStyle: 'table' | 'catalog';
+    columns: string[];
+}
+
 interface BlueprintUploadActionsMenuProps {
     direction?: 'left' | 'right';
-    marketplaceTabs?: MarketplaceTab[];
     toolbox: Stage.Types.Toolbox;
+    marketplaceConfig: MarketplaceModalConfig;
     showGenerateInComposerButton?: boolean;
 }
 
 const BlueprintUploadActionsMenu: FunctionComponent<BlueprintUploadActionsMenuProps> = ({
     direction,
     toolbox,
-    marketplaceTabs = [],
+    marketplaceConfig,
     showGenerateInComposerButton = false
 }) => {
     const {
@@ -57,7 +63,15 @@ const BlueprintUploadActionsMenu: FunctionComponent<BlueprintUploadActionsMenuPr
 
             switch (name) {
                 case 'uploadFromMarketplace':
-                    return <BlueprintMarketplace.Modal open onHide={hideModal} tabs={marketplaceTabs} />;
+                    return (
+                        <BlueprintMarketplace.Modal
+                            open
+                            onHide={hideModal}
+                            tabs={marketplaceConfig.tabs}
+                            displayStyle={marketplaceConfig.displayStyle}
+                            columns={marketplaceConfig.columns}
+                        />
+                    );
                 case 'uploadFromPackage':
                     return <UploadBlueprintModal open onHide={hideModal} toolbox={toolbox} />;
                 case 'generateInComposer':

--- a/widgets/common/src/blueprintMarketplace/BlueprintMarketplaceModal.tsx
+++ b/widgets/common/src/blueprintMarketplace/BlueprintMarketplaceModal.tsx
@@ -1,15 +1,17 @@
 import type { FunctionComponent } from 'react';
-import { MarketplaceTab } from './types';
+import type { MarketplaceDisplayStyle, MarketplaceTab } from './types';
 
 interface BlueprintMarketplaceModalProps {
     open: boolean;
-    tabs: MarketplaceTab[];
+    tabs?: MarketplaceTab[];
+    displayStyle?: MarketplaceDisplayStyle;
+    columns?: string[];
     onHide: () => void;
 }
 
 const t = Stage.Utils.getT('widgets.common.blueprintMarketplace');
 
-const getPageLayout = (tabs: MarketplaceTab[]) => {
+const getPageLayout = (tabs: MarketplaceTab[], displayStyle: MarketplaceDisplayStyle, columns: string[]) => {
     const getWidgets = (tab: MarketplaceTab, index: number) => [
         {
             id: `blueprint-catalog-${index}`,
@@ -19,7 +21,8 @@ const getPageLayout = (tabs: MarketplaceTab[]) => {
             definition: 'blueprintCatalog',
             configuration: {
                 jsonPath: tab.url,
-                displayStyle: 'catalog'
+                displayStyle,
+                fieldsToShow: columns
             },
             drillDownPages: {}
         }
@@ -41,7 +44,13 @@ const getPageLayout = (tabs: MarketplaceTab[]) => {
     };
 };
 
-const BlueprintMarketplaceModal: FunctionComponent<BlueprintMarketplaceModalProps> = ({ open, onHide, tabs }) => {
+const BlueprintMarketplaceModal: FunctionComponent<BlueprintMarketplaceModalProps> = ({
+    open,
+    onHide,
+    tabs = [],
+    displayStyle = 'catalog',
+    columns = []
+}) => {
     const { CancelButton, Icon, Modal } = Stage.Basic;
     const { PageContent } = Stage.Shared.Widgets;
     const onlyTabsWithUrl = tabs.filter(tab => Boolean(tab.url));
@@ -52,7 +61,9 @@ const BlueprintMarketplaceModal: FunctionComponent<BlueprintMarketplaceModalProp
                 <Icon name="upload" /> {t(`modal.header`)}
             </Modal.Header>
             <Modal.Content>
-                {onlyTabsWithUrl.length !== 0 && <PageContent page={getPageLayout(onlyTabsWithUrl) as any} />}
+                {onlyTabsWithUrl.length !== 0 && (
+                    <PageContent page={getPageLayout(onlyTabsWithUrl, displayStyle, columns) as any} />
+                )}
             </Modal.Content>
             <Modal.Actions>
                 <CancelButton onClick={onHide} content={t(`modal.cancelButton`)} />

--- a/widgets/common/src/blueprintMarketplace/index.ts
+++ b/widgets/common/src/blueprintMarketplace/index.ts
@@ -1,6 +1,6 @@
 import Modal from './BlueprintMarketplaceModal';
 import tabsConfig from './blueprintMarketplaceTabsConfig';
-import { MarketplaceTab } from './types';
+import { MarketplaceDisplayStyle, MarketplaceTab } from './types';
 
 const BlueprintMarketplace = {
     Modal,
@@ -12,6 +12,7 @@ declare global {
         // eslint-disable-next-line @typescript-eslint/no-namespace
         namespace BlueprintMarketplace {
             export type Tab = MarketplaceTab;
+            export type DisplayStyle = MarketplaceDisplayStyle;
             export { Modal, tabsConfig };
         }
     }

--- a/widgets/common/src/blueprintMarketplace/types.ts
+++ b/widgets/common/src/blueprintMarketplace/types.ts
@@ -2,3 +2,4 @@ export interface MarketplaceTab {
     name: string;
     url: string;
 }
+export type MarketplaceDisplayStyle = 'table' | 'catalog';


### PR DESCRIPTION
Cherry pick of #1581 RD-3017 Add support for switching between Catalog and Table view in Blueprints Marketplace modal.

* RD-3017 Add support for switching between Catalog and Table view in Blueprints Marketplace modal.

* Added translations and fix pr comments.

* Update test/cypress/support/commands.ts

<!--- Provide JIRA issue ID and a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes to help reviewers understand the details. -->

## Screenshots / Videos
<!--- If applicable, add screenshot(s) or video(s) describing the changes you made. -->
<!--- Consider adding comparison screenshot(s) - before and after the change. -->
<!--- If not applicable, just write “N/A” in this section. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the UI Code Style.
- [x] I verified that all tests and checks have passed.
- [x] I verified if that change requires a documentation update.
- [x] I added proper labels to this PR.

## Tests
<!--- If applicable, describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If applicable, provide a link to system tests, e.g: -->
<!--- [#1039](https://jenkins.cloudify.co/.../1039) (2021-08-06 07:05:50) --> 
<!--- If not applicable, just write “N/A” in this section. -->

## Documentation
<!--- If applicable, describe how you documented or plan to document your changes. -->
<!--- Provide links to JIRA issues, other PRs or related documentation pages. -->
<!--- If not applicable, just write “N/A” in this section. -->
