### PR TITLE
RD-3140 Update Blueprint Marketplace modal to use Table view by default

### DIFF
--- a/.size-limit
+++ b/.size-limit
@@ -13,7 +13,7 @@
     },
     {
         "name": "Widgets",
-        "limit": "3.13 MB",
+        "limit": "3.14 MB",
         "gzip": false,
         "running": false,
         "path": ["dist/appData/widgets", "!dist/appData/widgets/**/*.gz"]

--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -732,6 +732,10 @@
             }
         },
         "blueprintCatalog": {
+            "actions": {
+                "openDocumentation": "Open documentation",
+                "uploadBlueprint": "Upload blueprint"
+            },
             "configuration": {
                 "jsonPath": {
                     "label": "Blueprints Examples URL",

--- a/widgets/blueprintCatalog/src/RepositoryTable.tsx
+++ b/widgets/blueprintCatalog/src/RepositoryTable.tsx
@@ -57,7 +57,10 @@ const RepositoryTable: FunctionComponent<RepositoryViewProps> = ({
             <DataTable.Column width="11%" />
 
             {data.items.map(item => {
-                const isLoading = readmeLoading === item.name;
+                const isReadmeLoading = readmeLoading === item.name;
+                const isBlueprintUploading = uploadingInProgress.includes(item.name);
+                const isBlueprintUploaded = data.uploadedBlueprints.includes(item.name);
+
                 return (
                     <DataTable.Row
                         key={item.id}
@@ -76,22 +79,23 @@ const RepositoryTable: FunctionComponent<RepositoryViewProps> = ({
                         <DataTable.Data>{item.updated_at}</DataTable.Data>
                         <DataTable.Data className="center aligned rowActions">
                             <Icon
-                                name={isLoading ? 'spinner' : 'info'}
-                                link={!isLoading}
-                                title="Blueprint Readme"
-                                loading={isLoading}
-                                bordered={!isLoading}
+                                name={isReadmeLoading ? 'spinner' : 'info'}
+                                link={!isReadmeLoading}
+                                title={t('actions.openDocumentation')}
+                                loading={isReadmeLoading}
+                                bordered={!isReadmeLoading}
                                 onClick={(event: Event) => {
                                     event.stopPropagation();
                                     onReadme(item.name, item.readme_url);
                                 }}
                             />
                             <Icon
-                                name={uploadingInProgress.includes(item.name) ? 'spinner' : 'upload'}
-                                disabled={data.uploadedBlueprints.includes(item.name)}
-                                link
-                                title="Upload blueprint"
-                                bordered
+                                name={isBlueprintUploading ? 'spinner' : 'upload'}
+                                disabled={isBlueprintUploaded}
+                                link={!isBlueprintUploading && !isBlueprintUploaded}
+                                title={t('actions.uploadBlueprint')}
+                                loading={isBlueprintUploading}
+                                bordered={!isBlueprintUploading}
                                 onClick={(event: Event) => {
                                     event.stopPropagation();
                                     onUpload(item.name, item.zip_url, item.image_url, item.main_blueprint);

--- a/widgets/common/src/blueprintMarketplace/BlueprintMarketplaceModal.tsx
+++ b/widgets/common/src/blueprintMarketplace/BlueprintMarketplaceModal.tsx
@@ -10,6 +10,7 @@ interface BlueprintMarketplaceModalProps {
 }
 
 const t = Stage.Utils.getT('widgets.common.blueprintMarketplace');
+const tColumns = Stage.Utils.getT('widgets.blueprintCatalog.configuration.fieldsToShow.items');
 
 const getPageLayout = (tabs: MarketplaceTab[], displayStyle: MarketplaceDisplayStyle, columns: string[]) => {
     const getWidgets = (tab: MarketplaceTab, index: number) => [
@@ -48,8 +49,8 @@ const BlueprintMarketplaceModal: FunctionComponent<BlueprintMarketplaceModalProp
     open,
     onHide,
     tabs = [],
-    displayStyle = 'catalog',
-    columns = []
+    displayStyle = 'table',
+    columns = [tColumns('name'), tColumns('description')]
 }) => {
     const { CancelButton, Icon, Modal } = Stage.Basic;
     const { PageContent } = Stage.Shared.Widgets;


### PR DESCRIPTION
## Description
This PR introduces final alignments in Actionable Dashboard. Blueprint Marketplace modal is displayed right now in Table view with just 'Name' and 'Description' columns visible.

Within this PR I fixed also displaying action items in Table view in Blueprint Catalog widget:
* spinner icon showed on blueprint upload was not spinning before (`loading` prop was never set on `Icon` component)
* blueprint upload icon was not disabled properly when blueprint was already uploaded (`link` prop was always set to `true` on `Icon` component)

## Screenshots / Videos

https://user-images.githubusercontent.com/5202105/133035956-541e82a4-6185-41c4-b1d9-f8cec26c2204.mp4


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the UI Code Style.
- [x] I verified that all tests and checks have passed.
- [x] I verified if that change requires a documentation update.
- [x] I added proper labels to this PR.

## Tests
[Stage-UI-System-Test/1248](https://jenkins.cloudify.co/view/UI%20Health%20View/job/Stage-UI-System-Test/1248/) (13.09.2021 08:46:06 CEST) - PASSED

## Documentation
No updates necessary.