### PR TITLE
RD-3110 Enhance Deploy On modal to allow providing a suffix for new deployments

### DIFF
--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -895,7 +895,7 @@
                             "header": "Deploy on",
                             "inputs": {
                                 "name": {
-                                    "label": "Name",
+                                    "label": "Name suffix",
                                     "help": "Specify a text which will be appended to each deployment name"
                                 }
                             },

--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -893,6 +893,12 @@
                         "title": "Deploy On",
                         "modal": {
                             "header": "Deploy on",
+                            "inputs": {
+                                "name": {
+                                    "label": "Name",
+                                    "help": "Specify a text which will be appended to each deployment name"
+                                }
+                            },
                             "steps": {
                                 "validatingData": "1/4: Validating data...",
                                 "fetchingEnvironments": "2/4: Fetching environments list...",

--- a/test/cypress/integration/widgets/deployments_view_spec.ts
+++ b/test/cypress/integration/widgets/deployments_view_spec.ts
@@ -1221,7 +1221,7 @@ describe('Deployments View widget', () => {
             cy.get('.modal').within(() => {
                 cy.setSearchableDropdownValue('Blueprint', blueprintName);
 
-                cy.contains('.field', 'Name').find('input').type(`${name}`);
+                cy.contains('.field', 'Name suffix').find('input').type(`${name}`);
 
                 cy.contains('.field', 'Labels').find('.selection').click();
                 cy.get('div[name=labelKey] > input').type(labelKey);

--- a/test/cypress/integration/widgets/deployments_view_spec.ts
+++ b/test/cypress/integration/widgets/deployments_view_spec.ts
@@ -1209,7 +1209,7 @@ describe('Deployments View widget', () => {
             });
         });
 
-        it('should allow to create child deployments on filtered deployments', () => {
+        it.only('should allow to create child deployments on filtered deployments', () => {
             cy.interceptSp('POST', '/searches/deployments').as('searchDeployments');
 
             useDeploymentsViewWidget({ configurationOverrides: { filterId: siteFilterName } });
@@ -1217,8 +1217,11 @@ describe('Deployments View widget', () => {
 
             const labelKey = 'label_key';
             const labelValue = 'label_value';
+            const name = 'service';
             cy.get('.modal').within(() => {
                 cy.setSearchableDropdownValue('Blueprint', blueprintName);
+
+                cy.contains('.field', 'Name').find('input').type(`${name}`);
 
                 cy.contains('.field', 'Labels').find('.selection').click();
                 cy.get('div[name=labelKey] > input').type(labelKey);
@@ -1238,7 +1241,7 @@ describe('Deployments View widget', () => {
                 expect(request.body.new_deployments).to.deep.equal(
                     deploymentIds.map(id => ({
                         id: '{uuid}',
-                        display_name: '{blueprint_id}-{uuid}',
+                        display_name: `{blueprint_id}-${name}`,
                         labels: [{ 'csys-obj-parent': id }],
                         runtime_only_evaluation: false,
                         skip_plugins_validation: false

--- a/test/cypress/integration/widgets/deployments_view_spec.ts
+++ b/test/cypress/integration/widgets/deployments_view_spec.ts
@@ -1209,7 +1209,7 @@ describe('Deployments View widget', () => {
             });
         });
 
-        it.only('should allow to create child deployments on filtered deployments', () => {
+        it('should allow to create child deployments on filtered deployments', () => {
             cy.interceptSp('POST', '/searches/deployments').as('searchDeployments');
 
             useDeploymentsViewWidget({ configurationOverrides: { filterId: siteFilterName } });

--- a/widgets/common/src/DeployBlueprintModal.tsx
+++ b/widgets/common/src/DeployBlueprintModal.tsx
@@ -77,6 +77,7 @@ const DeployBlueprintModal: FunctionComponent<DeployBlueprintModalProps> = ({ to
             onHide={onHide}
             i18nHeaderKey="widgets.common.deployments.deployModal.header"
             showDeploymentNameInput
+            showDeploymentIdInput
             showDeployButton
             showInstallOptions
             showSitesInput

--- a/widgets/common/src/GenericDeployModal.tsx
+++ b/widgets/common/src/GenericDeployModal.tsx
@@ -218,16 +218,14 @@ class GenericDeployModal extends React.Component {
         return new Promise((resolve, reject) => {
             const { InputsUtils } = Stage.Common;
             const { blueprint, deploymentId, deploymentName, deploymentInputs: stateDeploymentInputs } = this.state;
-            const { showDeploymentNameInput } = this.props;
+            const { showDeploymentNameInput, showDeploymentIdInput } = this.props;
             const errors = {};
 
-            if (showDeploymentNameInput) {
-                if (_.isEmpty(deploymentName)) {
-                    errors.deploymentName = t('errors.noDeploymentName');
-                }
-                if (_.isEmpty(deploymentId)) {
-                    errors.deploymentId = t('errors.noDeploymentId');
-                }
+            if (showDeploymentNameInput && _.isEmpty(deploymentName)) {
+                errors.deploymentName = t('errors.noDeploymentName');
+            }
+            if (showDeploymentIdInput && _.isEmpty(deploymentId)) {
+                errors.deploymentId = t('errors.noDeploymentId');
             }
 
             if (_.isEmpty(blueprint.id)) {
@@ -271,9 +269,12 @@ class GenericDeployModal extends React.Component {
             toolbox,
             i18nHeaderKey,
             showInstallOptions,
+            showDeploymentIdInput,
             showDeploymentNameInput,
             showDeployButton,
-            showSitesInput
+            showSitesInput,
+            deploymentNameLabel,
+            deploymentNameHelp
         } = this.props;
         const {
             blueprint,
@@ -306,34 +307,6 @@ class GenericDeployModal extends React.Component {
                 <Modal.Content>
                     <Form errors={errors} scrollToError onErrorsDismiss={() => this.setState({ errors: {} })}>
                         {loading && <LoadingOverlay message={loadingMessage} />}
-                        {showDeploymentNameInput && (
-                            <>
-                                <Form.Field
-                                    error={errors.deploymentName}
-                                    label={t('inputs.deploymentName.label')}
-                                    required
-                                    help={t('inputs.deploymentName.help')}
-                                >
-                                    <Form.Input
-                                        name="deploymentName"
-                                        value={deploymentName}
-                                        onChange={this.handleInputChange}
-                                    />
-                                </Form.Field>
-                                <Form.Field
-                                    error={errors.deploymentId}
-                                    label={t('inputs.deploymentId.label')}
-                                    required
-                                    help={t('inputs.deploymentId.help')}
-                                >
-                                    <Form.Input
-                                        name="deploymentId"
-                                        value={deploymentId}
-                                        onChange={this.handleInputChange}
-                                    />
-                                </Form.Field>
-                            </>
-                        )}
 
                         {this.isBlueprintSelectable() && (
                             <Form.Field
@@ -349,6 +322,35 @@ class GenericDeployModal extends React.Component {
                                     onChange={this.selectBlueprint}
                                     toolbox={toolbox}
                                     prefetch
+                                />
+                            </Form.Field>
+                        )}
+
+                        {showDeploymentNameInput && (
+                            <Form.Field
+                                error={errors.deploymentName}
+                                label={deploymentNameLabel}
+                                required
+                                help={deploymentNameHelp}
+                            >
+                                <Form.Input
+                                    name="deploymentName"
+                                    value={deploymentName}
+                                    onChange={this.handleInputChange}
+                                />
+                            </Form.Field>
+                        )}
+                        {showDeploymentIdInput && (
+                            <Form.Field
+                                error={errors.deploymentId}
+                                label={t('inputs.deploymentId.label')}
+                                required
+                                help={t('inputs.deploymentId.help')}
+                            >
+                                <Form.Input
+                                    name="deploymentId"
+                                    value={deploymentId}
+                                    onChange={this.handleInputChange}
                                 />
                             </Form.Field>
                         )}
@@ -512,6 +514,11 @@ GenericDeployModal.propTypes = {
     showDeploymentNameInput: PropTypes.bool,
 
     /**
+     * Whether to show deployment ID input
+     */
+    showDeploymentIdInput: PropTypes.bool,
+
+    /**
      * Whether to show 'Deploy' button, if not set only 'Deploy & Install' button is shown
      */
     showDeployButton: PropTypes.bool,
@@ -545,19 +552,32 @@ GenericDeployModal.propTypes = {
     /**
      * Message to be displayed during inputs validation, before steps defined by `deployAndInstallSteps` are executed
      */
-    deployAndInstallValidationMessage: PropTypes.string
+    deployAndInstallValidationMessage: PropTypes.string,
+
+    /**
+     * Deployment Name input label
+     */
+    deploymentNameLabel: PropTypes.string,
+
+    /**
+     * Deployment Name input help description
+     */
+    deploymentNameHelp: PropTypes.string
 };
 
 GenericDeployModal.defaultProps = {
     blueprintId: '',
     onHide: _.noop,
     showDeploymentNameInput: false,
+    showDeploymentIdInput: false,
     showDeployButton: false,
     showInstallOptions: false,
     showSitesInput: false,
     deploySteps: null,
     deployValidationMessage: null,
-    deployAndInstallValidationMessage: null
+    deployAndInstallValidationMessage: null,
+    deploymentNameLabel: t('inputs.deploymentName.label'),
+    deploymentNameHelp: t('inputs.deploymentName.help')
 };
 
 export default GenericDeployModal;

--- a/widgets/common/src/deploymentsView/header/DeployOnModal.tsx
+++ b/widgets/common/src/deploymentsView/header/DeployOnModal.tsx
@@ -39,7 +39,7 @@ const DeployOnModal: FunctionComponent<DeployOnModalProps> = ({ filterRules, too
                 visibility: deploymentParameters.visibility,
                 new_deployments: environments.map(environmentId => ({
                     id: '{uuid}',
-                    display_name: '{blueprint_id}-{uuid}',
+                    display_name: `{blueprint_id}-${deploymentParameters.deploymentName}`,
                     labels: [{ [parentDeploymentLabelKey]: environmentId }],
                     runtime_only_evaluation: deploymentParameters.runtimeOnlyEvaluation,
                     skip_plugins_validation: deploymentParameters.skipPluginsValidation
@@ -85,6 +85,9 @@ const DeployOnModal: FunctionComponent<DeployOnModalProps> = ({ filterRules, too
                 },
                 { executeStep: setExecutionStarted }
             ]}
+            showDeploymentNameInput
+            deploymentNameLabel={t('bulkActions.deployOn.modal.inputs.name.label')}
+            deploymentNameHelp={t('bulkActions.deployOn.modal.inputs.name.help')}
         />
     );
 };

--- a/widgets/deploymentsView/README.md
+++ b/widgets/deploymentsView/README.md
@@ -256,7 +256,7 @@ deploying additional services on the environments that are matched by the
 current filter.
 
 After selecting the base blueprint for the new deployments, providing 
-a name and additional labels, there will be a new child deployment created for each
+a name suffix and additional labels, there will be a new child deployment created for each
 deployment matched by the current filter.
 Each generated deployment will be labeled with the Environment ID of the
 environment on which it is deployed as a parent label, and the capabilities of

--- a/widgets/deploymentsView/README.md
+++ b/widgets/deploymentsView/README.md
@@ -255,8 +255,8 @@ The _Deploy On_ bulk action will show a modal that guides the user through
 deploying additional services on the environments that are matched by the
 current filter.
 
-After selecting the base blueprint for the new deployments and providing any
-additional labels, there will be a new child deployment created for each
+After selecting the base blueprint for the new deployments, providing 
+a name and additional labels, there will be a new child deployment created for each
 deployment matched by the current filter.
 Each generated deployment will be labeled with the Environment ID of the
 environment on which it is deployed as a parent label, and the capabilities of


### PR DESCRIPTION
## Description

Within this PR new field is added to "Deploy On" modal. This is text input field which is then used to create deployment name for newly created deployments.

## Screenshots / Videos

### Deploy On modal

![Screenshot from 2021-09-14 09-41-39](https://user-images.githubusercontent.com/5202105/133216314-1d49d50e-6101-498c-bc81-d7afb7bfb845.png)

### Other deployment creation modals

#### Deploy modal in Create Deployment Button widget
![Screenshot from 2021-09-14 09-42-26](https://user-images.githubusercontent.com/5202105/133216413-cb1612b6-b71c-468f-b091-7c94230cd5d5.png)

#### Deploy modal in Blueprints widget
![Screenshot from 2021-09-14 09-42-57](https://user-images.githubusercontent.com/5202105/133216499-b73aa70f-6918-4f45-b5d8-26f9da20b976.png)

## Checklist
- [x] My code follows the UI Code Style.
- [x] I verified that all tests and checks have passed.
- [x] I verified if that change requires a documentation update.
- [x] I added proper labels to this PR.

## Tests
[Stage-UI-System-Test/1252](https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/1252/pipeline) (14.09.2021, 09:44:01 CEST) - PASSED

## Documentation
Deployments View widget description update PR: https://github.com/cloudify-cosmo/docs.getcloudify.org/pull/1949 .
I'd like to merge it first and then update Deployments View widget's `README.md` within this PR.
