### PR TITLE
RD-3099 Fix uploading blueprint that contains directories recognized as files by `decompress` library [6.2]

### DIFF
--- a/backend/handler/ArchiveHelper.js
+++ b/backend/handler/ArchiveHelper.js
@@ -146,7 +146,10 @@ module.exports = (() => {
 
         fs.mkdirsSync(targetDir);
 
-        return decompress(archivePath, targetDir);
+        return decompress(archivePath, targetDir, {
+            // NOTE: Workaround for https://github.com/kevva/decompress/issues/46
+            filter: file => !file.path.endsWith('/')
+        });
     }
 
     function removeOldExtracts(tempDir) {


### PR DESCRIPTION
## Description
This PR fixes RD-3099 in `6.2.0-build` branch. Cherry pick from `master` was not possible as in `6.2.0-build` branch Stage backend does not have TS support, so I decided just to apply the fix in the backend JS file without adding the test created on `master` branch.

## Screenshots / Videos
N/A

## Checklist
- [x] My code follows the UI Code Style.
- [x] I verified that all tests and checks have passed.
- [x] I verified if that change requires a documentation update.
- [x] I added proper labels to this PR.

## Tests
Unit test only on `master` branch.
[Stage-UI-System-Test/1269](https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/1269/pipeline) (15.09.2021 09:30:21 CEST) - PASSED

## Documentation
N/A