### PR TITLE
RD-3105 Update documentation links to use `6.2.0-build` branch

### DIFF
--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -598,7 +598,7 @@
                 }
             },
             "readmes": {
-                "linksBasePath": "https://docs.cloudify.co/6.0.0",
+                "linksBasePath": "https://docs.cloudify.co/6.2.0",
                 "params": {
                     "cfy_composer_link": "/developer/composer/",
                     "cfy_composer_name": "Cloudify Composer",

--- a/scripts/readmesConfig.json
+++ b/scripts/readmesConfig.json
@@ -1,5 +1,5 @@
 {
-  "rawContentBasePath": "https://raw.githubusercontent.com/cloudify-cosmo/docs.getcloudify.org/master",
+  "rawContentBasePath": "https://raw.githubusercontent.com/cloudify-cosmo/docs.getcloudify.org/6.2.0-build",
   "files": [
     {"widget": "agents", "link": "/content/working_with/console/widgets/agents.md"},
     {"widget": "blueprintActionButtons", "link": "/content/working_with/console/widgets/blueprintActionButtons.md"},


### PR DESCRIPTION
## Description

This change hardcodes links to documentation pages to `6.2.0-build` branch.

## Screenshots / Videos

N/A

## Checklist

- [x] My code follows the UI Code Style.
- [x] I verified that all tests and checks have passed.
- [x] I verified if that change requires a documentation update.
- [x] I added proper labels to this PR.

## Tests

I verified manually that image links are constructed properly:

![Untitled](https://user-images.githubusercontent.com/5202105/133571889-f2c55af5-a475-46d0-999d-8bd5e08987b8.png)

## Documentation

N/A