### PR TITLE
RD-2061 Disable no-namespace ESLint rule in widgets

### DIFF
--- a/widgets/.eslintrc.json
+++ b/widgets/.eslintrc.json
@@ -6,7 +6,8 @@
     ],
     "rules": {
         "no-console": "error",
-        "prefer-promise-reject-errors": "off"
+        "prefer-promise-reject-errors": "off",
+        "@typescript-eslint/no-namespace": "off"
     },
     "globals": {
         "_": true,

--- a/widgets/common/src/blueprintMarketplace/index.ts
+++ b/widgets/common/src/blueprintMarketplace/index.ts
@@ -9,7 +9,6 @@ const BlueprintMarketplace = {
 
 declare global {
     namespace Stage.Common {
-        // eslint-disable-next-line @typescript-eslint/no-namespace
         namespace BlueprintMarketplace {
             export type Tab = MarketplaceTab;
             export type DisplayStyle = MarketplaceDisplayStyle;

--- a/widgets/common/src/deploymentsView/index.ts
+++ b/widgets/common/src/deploymentsView/index.ts
@@ -7,13 +7,10 @@ import { DeploymentStatus } from './types';
 
 declare global {
     namespace Stage.Common {
-        // eslint-disable-next-line @typescript-eslint/no-namespace
         namespace DeploymentsView {
             // NOTE: necessary rename to DCommon, since `Common` resolves to `Stage.Common`, not the `Common` import
             export { DCommon as Common, sharedDefinition, DDeploymentsView as DeploymentsView };
 
-            // NOTE: no-namespace rule does not detect that `export namespace` are in a `declare` context
-            /* eslint-disable @typescript-eslint/no-namespace */
             export namespace Configuration {
                 export { SharedDeploymentsViewWidgetConfiguration, sharedConfiguration };
             }

--- a/widgets/common/src/filters/index.ts
+++ b/widgets/common/src/filters/index.ts
@@ -15,7 +15,6 @@ const Filters = {
 const FiltersAlias = Filters;
 declare global {
     namespace Stage.Common {
-        // eslint-disable-next-line @typescript-eslint/no-namespace
         namespace Filters {
             export type Rule = FilterRule;
         }

--- a/widgets/common/src/labels/index.ts
+++ b/widgets/common/src/labels/index.ts
@@ -19,7 +19,6 @@ const Labels = {
 const LabelsAlias = Labels;
 declare global {
     namespace Stage.Common {
-        // eslint-disable-next-line @typescript-eslint/no-namespace
         namespace Labels {
             type Label = LabelType;
         }


### PR DESCRIPTION
## Description
The `@typescript-eslint/no-namespace` ESLint rule is often disabled locally in files in widgets because we are using namespaces to define the Stage global API. To avoid disabling it locally, I have disabled it for all files in the `widgets` directory.

## Screenshots / Videos
N/A

## Checklist
- [x] My code follows the UI Code Style.
- [ ] I verified that all tests and checks have passed.
- [x] I verified if that change requires a documentation update.
- [x] I added proper labels to this PR.

## Tests
`npm run lint` passes locally.

## Documentation
N/A