### PR TITLE
RD-3106 Update documentation links after 6.2 release

### DIFF
--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -599,7 +599,7 @@
                 }
             },
             "readmes": {
-                "linksBasePath": "https://docs.cloudify.co/6.0.0",
+                "linksBasePath": "https://docs.cloudify.co/staging/dev",
                 "params": {
                     "cfy_composer_link": "/developer/composer/",
                     "cfy_composer_name": "Cloudify Composer",

--- a/templates/pages/adminDash.json
+++ b/templates/pages/adminDash.json
@@ -99,7 +99,7 @@
             "basic": true,
             "color": "blue",
             "label": "Getting Started Walkthrough",
-            "url": "https://docs.cloudify.co/latest/trial_getting_started/examples/",
+            "url": "https://docs.cloudify.co/staging/dev/trial_getting_started/examples/",
             "fullHeight": true
           }
         },


### PR DESCRIPTION
## Description
Despite that 6.2 is not yet released, the UI development is: 1. separated to `6.2.0-build` branch, 2. completed.
No need to change `rawContentBasePath` in `scripts/readmesConfig.json` as it already points to `master` branch in docs repo.

## Screenshots / Videos
N/A

## Checklist
- [x] My code follows the UI Code Style.
- [x] I verified that all tests and checks have passed.
- [x] I verified if that change requires a documentation update.
- [x] I added proper labels to this PR.

## Tests
I've checked locally if the documentation links work properly.

## Documentation
N/A