### PR TITLE
RD-3322 Make snapshot widget test less prone to timeout errors

### DIFF
--- a/test/cypress/integration/widgets/snapshots_spec.ts
+++ b/test/cypress/integration/widgets/snapshots_spec.ts
@@ -1,4 +1,6 @@
 // @ts-nocheck File not migrated fully to TS
+import { waitUntilNotEmpty } from 'test/cypress/support/resource_commons';
+
 describe('Snapshots list widget', () => {
     const createdSnapshotName = 'snapshots_test_created';
     const uploadedSnapshotName = 'snapshots_test_uploaded';
@@ -23,6 +25,7 @@ describe('Snapshots list widget', () => {
         cy.contains('.snapshotsWidget tr', createdSnapshotName).within(() => {
             cy.contains('creating');
             cy.get('.trash.disabled');
+            waitUntilNotEmpty(`snapshots?_include=id,status&id=${createdSnapshotName}&status=created`);
             cy.contains('creating').should('not.exist');
             cy.get('.trash').click();
         });

--- a/test/cypress/integration/widgets/snapshots_spec.ts
+++ b/test/cypress/integration/widgets/snapshots_spec.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck File not migrated fully to TS
 import { waitUntilNotEmpty } from 'test/cypress/support/resource_commons';
 
 describe('Snapshots list widget', () => {


### PR DESCRIPTION
## Description
Seems like snapshot creation time increased recently, so I improved Snapshot widgets test not only to wait for the change in the table, but also verify that the snapshot was created by polling status from the Cloudify Manager API.

In addition to that removed `@ts-check` annotation form `snaphost_spec.ts` file as it has already been fully TS migrated.

## Screenshots / Videos

https://user-images.githubusercontent.com/5202105/136204783-370d2d05-74bd-482f-837a-9e3c5dd62d6e.mp4

## Checklist
- [x] My code follows the UI Code Style.
- [x] I verified that all tests and checks have passed.
- [x] I verified if that change requires a documentation update.
- [x] I added proper labels to this PR.

## Tests
[Stage-UI-System-Test/1352](https://jenkins.cloudify.co/view/UI%20Health%20View/job/Stage-UI-System-Test/1352/) - only Snapshots widget test - PASSED

## Documentation
N/A