### PR TITLE
RD-1607 Follow-up PR: Refactor and fix system test for missing secrets error message

### DIFF
--- a/test/cypress/integration/widgets/deployment_button_spec.ts
+++ b/test/cypress/integration/widgets/deployment_button_spec.ts
@@ -229,30 +229,38 @@ describe('Create Deployment Button widget', () => {
             cy.get('@string_constraint_pattern').should('have.class', 'error');
         });
 
-        it('should open Missing Secrets Error message when deploying blueprint with missing secrets', () => {
+        it('should handle missing secrets error', () => {
             const secretName = 'test';
+            cy.deleteSecrets(secretName);
 
             selectBlueprintInModal('required_secrets');
-            cy.stageRequest(`/console/sp/secrets/${secretName}`, 'DELETE', { failOnStatusCode: false });
+            cy.get('.modal').within(() => {
+                cy.getField('Deployment name').find('input').type('blahBlahBlah');
+                cy.contains('button', 'Deploy').click();
+                cy.get('.error.message').within(() => {
+                    cy.get('.header').should('have.text', 'Missing Secrets Error');
+                    cy.get('p').should('have.text', 'The following required secrets are missing in this tenant:');
+                    cy.get('.item').should('have.text', secretName);
+                });
 
-            cy.get('input[name=deploymentName]').type('blahBlahBlah');
-            cy.contains('.modal button', 'Deploy').click();
-            cy.get('form.error .error').within(() => {
-                cy.get('.header').should('have.text', 'Missing Secrets Error');
-                cy.get('p').should('have.text', 'The following required secrets are missing in this tenant:');
-                cy.get('.item').should('have.text', secretName);
+                cy.contains('button', 'Add Missing Secrets').click();
             });
 
-            cy.contains('form.error button', 'Add Missing Secrets').click();
-            cy.contains('.secretsModal button', 'Add').click();
-            cy.get('.secretsModal .error .header').should('have.text', 'Errors in the form');
-            cy.get('.secretsModal .error li').should('have.text', 'Please provide values for secrets');
+            cy.get('.secretsModal').within(() => {
+                cy.interceptSp('PUT', `/secrets/${secretName}`).as('addSecrets');
 
-            cy.get('.secretsModal input').type('aaa');
-            cy.interceptSp('PUT', `/secrets/${secretName}`, { statusCode: 200 }).as('addSecrets');
-            cy.contains('.secretsModal button', 'Add').click();
-            cy.get('form.error .error').should('not.exist');
-            cy.wait('@addSecrets');
+                cy.contains('button', 'Add').click();
+                cy.get('.error.message').within(() => {
+                    cy.get('.header').should('have.text', 'Errors in the form');
+                    cy.get('li').should('have.text', 'Please provide values for secrets');
+                });
+
+                cy.getField(secretName).find('input').type('aaa');
+                cy.contains('button', 'Add').click();
+                cy.wait('@addSecrets');
+            });
+
+            cy.get('.error.message').should('not.exist');
         });
     });
 


### PR DESCRIPTION
<!--- Provide JIRA issue ID and a general summary of your changes in the Title above -->

## Description
This PR is the follow up to https://github.com/cloudify-cosmo/cloudify-stage/pull/1693
The previous PR was merged by mistake before I fixed the interceptSp and refactored according to review comments.
<!--- Describe your changes to help reviewers understand the details. -->

## Screenshots / Videos
https://github.com/cloudify-cosmo/cloudify-stage/pull/1693
<!--- If applicable, add screenshot(s) or video(s) describing the changes you made. -->
<!--- Consider adding comparison screenshot(s) - before and after the change. -->
<!--- If not applicable, just write “N/A” in this section. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the UI Code Style.
- [ ] I verified that all tests and checks have passed.
- [x] I verified if that change requires a documentation update.
- [x] I added proper labels to this PR.

## Tests
- I run one time the relevant system tests on my machine and they passed successfully.
- I started running system tests in Jenkins:
https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/1670/pipeline

<!--- If applicable, describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If applicable, provide a link to system tests, e.g: -->
<!--- [#1039](https://jenkins.cloudify.co/.../1039) (2021-08-06 07:05:50) --> 
<!--- If not applicable, just write “N/A” in this section. -->

## Documentation
https://github.com/cloudify-cosmo/cloudify-stage/pull/1693
<!--- If applicable, describe how you documented or plan to document your changes. -->
<!--- Provide links to JIRA issues, other PRs or related documentation pages. -->
<!--- If not applicable, just write “N/A” in this section. -->
