### PR TITLE
RD-3806 Adjust height of Deployments View widget in Services and Environments pages

### DIFF
--- a/templates/pages/environments.json
+++ b/templates/pages/environments.json
@@ -16,7 +16,7 @@
         {
           "name": "Environments",
           "width": 12,
-          "height": 28,
+          "height": 100,
           "definition": "deploymentsView",
           "configuration": {
             "filterId": "csys-environment-filter"

--- a/templates/pages/services.json
+++ b/templates/pages/services.json
@@ -16,7 +16,7 @@
         {
           "name": "Services",
           "width": 12,
-          "height": 28,
+          "height": 100,
           "definition": "deploymentsView",
           "configuration": {
             "filterId": "csys-service-filter",

--- a/widgets/common/src/deploymentsView/DeploymentsView.tsx
+++ b/widgets/common/src/deploymentsView/DeploymentsView.tsx
@@ -204,6 +204,7 @@ export const DeploymentsView: FunctionComponent<DeploymentsViewProps> = ({
                     defaultSize="40%"
                     split="vertical"
                     resizerClassName="master-details-view-resizer"
+                    style={{ position: 'relative' }}
                 >
                     <DeploymentsTableContainer>
                         <DeploymentsTable

--- a/widgets/common/src/deploymentsView/layout.ts
+++ b/widgets/common/src/deploymentsView/layout.ts
@@ -24,7 +24,7 @@ export const DeploymentsMapLayoutContainer = styled.div<{ height: number }>`
 `;
 
 export const DeploymentsMasterDetailViewContainer = styled.div`
-    grid-area: 'table-with-details';
+    grid-area: table-with-details;
 `;
 
 export const DeploymentsTableContainer = styled.div`


### PR DESCRIPTION
## Description
See RD-3806 description for reasoning. It's another "bandage" solution. I did not change the height 10x because I think it is more than enough changing the height from 28 to 100 in our page JSON files. All widgets in the right pane in all tabs are visible and there is still much space left. There is no scrollbar on the right side. So both main requirements for RD-3806 are met.

In addition to the change I fixed minor styling issues.

## Screenshots / Videos

Adding screenshots only for Services page, the same change was done in Environments page.

### Before
![image](https://user-images.githubusercontent.com/5202105/146328761-ffe377c0-005a-4930-9031-df1381b6df70.png)

### After
![image](https://user-images.githubusercontent.com/5202105/146328576-891fdf41-1cf1-403a-ac1f-413e2fc202b1.png)

## Checklist
- [x] My code follows the UI Code Style.
- [x] I verified that all tests and checks have passed.
- [x] I verified if that change requires a documentation update.
- [x] I added proper labels to this PR.

## Tests
[Stage-UI-System-Test #1677](https://jenkins.cloudify.co/view/UI%20Health%20View/job/Stage-UI-System-Test/1677/) (16.12.2021 08:46) - PASSED

## Documentation
N/A