### PR TITLE
RD-3806 Increase height of Deployments View widget in Services and Environments pages

### DIFF
--- a/templates/pages/environments.json
+++ b/templates/pages/environments.json
@@ -16,7 +16,7 @@
         {
           "name": "Environments",
           "width": 12,
-          "height": 100,
+          "height": 150,
           "definition": "deploymentsView",
           "configuration": {
             "filterId": "csys-environment-filter"

--- a/templates/pages/services.json
+++ b/templates/pages/services.json
@@ -16,7 +16,7 @@
         {
           "name": "Services",
           "width": 12,
-          "height": 100,
+          "height": 150,
           "definition": "deploymentsView",
           "configuration": {
             "filterId": "csys-service-filter",


### PR DESCRIPTION
## Description

It's a continuation of https://github.com/cloudify-cosmo/cloudify-stage/pull/1709 - it turned out that the increase was too small for Deployment Info tab. See video how it looks right now.

## Screenshots / Videos

https://user-images.githubusercontent.com/5202105/146364814-e3a647b7-eb97-42f9-91d8-b4662516467d.mp4

## Checklist
- [x] My code follows the UI Code Style.
- [x] I verified that all tests and checks have passed.
- [x] I verified if that change requires a documentation update.
- [x] I added proper labels to this PR.

## Tests
No need to run tests IMHO. https://github.com/cloudify-cosmo/cloudify-stage/pull/1709 validates that height change does no affect test results.
 
## Documentation
N/A