### PR TITLE
RD-3838 change node_rpm url to original s3 url instead of edge endpoint

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -34,7 +34,7 @@ pipeline {
     WORKSPACE = "${env.WORKSPACE}"
     STAGE_DIR = "cloudify-stage"
     CFY_MANAGER_URL = 'https://raw.githubusercontent.com/cloudify-cosmo/cloudify-manager'
-    CFY_NODE_RPM = 'http://repository.cloudifysource.org/cloudify/components/nodejs-14.18.1-1nodesource.x86_64.rpm'
+    CFY_NODE_RPM = 'https://cloudify-release-eu.s3.eu-west-1.amazonaws.com/cloudify/components/nodejs-14.18.1-1nodesource.x86_64.rpm'
     MAIN_BRANCH = getMainBranch("${env.BRANCH}")
   }
 


### PR DESCRIPTION

## Description
Due to rare occasions of a failed pull from AWS edge endpoint of s3 items
