### PR TITLE
RD-3838 rm rpmlint from jenkinsfile, will be in internal image

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -96,8 +96,8 @@ pipeline {
               echo 'Check for cache'
               restoreArchiveFolder('~/.npm', "${WORKSPACE}/${STAGE_DIR}/package-lock.json ${WORKSPACE}/${STAGE_DIR}/backend/package-lock.json", 'stage-mb', 'npm_dir', '/mnt/data')
 
-              echo 'Install NodeJS & RPM development tools'
-              sh "yum install -y ${CFY_NODE_RPM} rpmlint"
+              echo 'Install NodeJS'
+              sh "yum install -y ${CFY_NODE_RPM}"
 
               echo 'Lint RPM spec file & Install build dependencies for RPM spec file'
               sh '''


### PR DESCRIPTION
rm installation of rpmlint from jenkinsfile as it's now preinstalled in our internal rpmbuild image.
This should solve the occasional yum installation failure in the CI.

And if that won't fix it for good, it saves a few seconds anyway and doesn't harm the CI.