### PR TITLE
RD-3914 Change workflow ID used during deployment updates

### DIFF
--- a/app/utils/shared/ExecutionUtils.ts
+++ b/app/utils/shared/ExecutionUtils.ts
@@ -77,6 +77,8 @@ export default class ExecutionUtils {
         ...ExecutionUtils.WAITING_EXECUTION_STATUSES
     ]);
 
+    static UPDATE_WORKFLOW_ID = 'csys_new_deployment_update';
+
     /* Helper methods */
     static isCancelledExecution(execution) {
         return execution.status === 'cancelled';
@@ -95,7 +97,7 @@ export default class ExecutionUtils {
     }
 
     static isUpdateExecution(execution) {
-        return execution.workflow_id === 'update';
+        return execution.workflow_id === ExecutionUtils.UPDATE_WORKFLOW_ID;
     }
 
     static isActiveExecution(execution) {

--- a/test/cypress/integration/widgets/deployments_spec.ts
+++ b/test/cypress/integration/widgets/deployments_spec.ts
@@ -1,4 +1,4 @@
-// @ts-nocheck File not migrated fully to TS
+import ExecutionUtils from 'app/utils/shared/ExecutionUtils';
 import { exampleBlueprintUrl } from '../../support/resource_urls';
 
 describe('Deployments widget', () => {
@@ -176,7 +176,7 @@ describe('Deployments widget', () => {
 
         cy.wait('@updateDeployment');
         cy.get('.updateDetailsModal').should('not.exist');
-        verifyExecutionHasEnded('update');
+        verifyExecutionHasEnded(ExecutionUtils.UPDATE_WORKFLOW_ID);
         cy.contains('div.row', deploymentId)
             .get('div.column:nth-child(3) h5:nth-child(2)')
             .should('contain.text', 'Updated');

--- a/test/cypress/integration/widgets/deployments_spec.ts
+++ b/test/cypress/integration/widgets/deployments_spec.ts
@@ -9,15 +9,15 @@ describe('Deployments widget', () => {
     const site = { name: siteName };
     const blueprintUrl = exampleBlueprintUrl;
 
-    const selectDeploymentActionFromMenu = (id, menuClassName, action) => {
+    const selectDeploymentActionFromMenu = (id: string, menuClassName: string, action: string) => {
         cy.searchInDeploymentsWidget(id);
         cy.contains('div.row', id).find(menuClassName).click();
         cy.get('.popupMenu > .menu').contains(action).click();
     };
-    const executeDeploymentAction = (id, action) => {
+    const executeDeploymentAction = (id: string, action: string) => {
         selectDeploymentActionFromMenu(id, '.deploymentActionsMenu', action);
     };
-    const executeDeploymentWorkflow = (id, workflow) => {
+    const executeDeploymentWorkflow = (id: string, workflow: string) => {
         selectDeploymentActionFromMenu(id, '.workflowsMenu', workflow);
     };
     const verifyExecutionHasEnded = (workflow: string) => cy.waitForExecutionToEnd(deploymentId, workflow);
@@ -191,7 +191,7 @@ describe('Deployments widget', () => {
         cy.interceptSp('GET', { path: `/deployments/${deploymentId}?_include=labels` }).as('fetchLabels');
         cy.interceptSp('GET', `/labels/deployments`).as('checkLabelPresence');
 
-        const typeInput = (name, value) => {
+        const typeInput = (name: string, value: string) => {
             cy.get(`div[name=${name}]`).click();
             cy.get(`div[name=${name}] input`).type(value);
         };
@@ -215,7 +215,7 @@ describe('Deployments widget', () => {
 
         cy.getDeployment(deploymentId).then(response => {
             const { labels } = response.body;
-            const verifyLabel = (index, key, value) => {
+            const verifyLabel = (index: number, key: string, value: string) => {
                 expect(labels[index]).to.have.property('key', key);
                 expect(labels[index]).to.have.property('value', value);
             };


### PR DESCRIPTION
## Description

This is the second PR for RD-3914. This one fixes `deployments_spec` as well as updates workflow ID used to detect if specific execution is related to deployment update. In addition to that, `deployments_spec` was fully migrated to TypeScript.

## Screenshots / Videos
N/A

## Checklist
- [x] My code follows the UI Code Style.
- [x] I verified that all tests and checks have passed.
- [x] I verified if that change requires a documentation update.
- [x] I added proper labels to this PR.

## Tests
1. `deployments_spec` passes locally 
2. [Stage-UI-System-Test/1832](https://jenkins.cloudify.co/view/UI%20Health%20View/job/Stage-UI-System-Test/1832/) (18.01.2022, 12:58) - PASSED

## Documentation
Executions widget page description should be updated, but to speed up the process, I have added a point to RD-2504.