### PR TITLE
RD-3828 Change rules for setting Secure flag on token cookie

### DIFF
--- a/backend/consts.ts
+++ b/backend/consts.ts
@@ -18,7 +18,7 @@ export const USERNAME_COOKIE_NAME = 'USERNAME';
 export const EDITION = {
     PREMIUM: 'premium',
     COMMUNITY: 'community'
-};
+} as const;
 
 export const SERVER_HOST = 'localhost';
 export const SERVER_PORT = 8088;

--- a/backend/handler/AuthHandler.ts
+++ b/backend/handler/AuthHandler.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck File not migrated fully to TS
 import _ from 'lodash';
 import { EDITION } from '../consts';
 import { jsonRequest } from './ManagerHandler';
@@ -8,44 +7,80 @@ import { getLogger } from './LoggerHandler';
 
 const logger = getLogger('AuthHandler');
 
-let authorizationCache = {};
+let authorizationCache = {} as ConfigResponse['authorization'];
 
-export function getToken(basicAuth) {
-    return jsonRequest('GET', '/tokens', {
+export interface TokenResponse {
+    username: string;
+    value: string;
+    role: string;
+}
+
+export interface ConfigResponse {
+    metadata: any;
+    items: any[];
+    authorization: {
+        roles: {
+            id: number;
+            name: string;
+            type: string;
+            description: string;
+        }[];
+        permissions: Record<string, string[]>[];
+    };
+}
+
+export interface VersionResponse {
+    edition: typeof EDITION.PREMIUM | typeof EDITION.COMMUNITY;
+    version: string;
+    build: any;
+    date: any;
+    commit: any;
+    distribution: string;
+    // eslint-disable-next-line camelcase
+    distro_release: string;
+}
+
+export function getToken(basicAuth: string) {
+    return jsonRequest<TokenResponse>('GET', '/tokens', {
         Authorization: basicAuth
     });
 }
 
-export function getTenants(token) {
+export function getTenants(token: string) {
     return jsonRequest('GET', '/tenants?_get_all_results=true&_include=name', {
         'Authentication-Token': token
     });
 }
 
-export function getUser(token) {
+export function getUser(token: string) {
     return jsonRequest('GET', '/user?_get_data=true', {
         'Authentication-Token': token
     });
 }
 
-export function isProductLicensed(version) {
+export function isProductLicensed(version: VersionResponse) {
     return !_.isEqual(version.edition, EDITION.COMMUNITY);
 }
 
-export function getLicense(token) {
+export function getLicense(token: string) {
     return jsonRequest('GET', '/license', {
         'Authentication-Token': token
     });
 }
 
-export function getTokenViaSamlResponse(samlResponse) {
-    return jsonRequest('POST', '/tokens', null, {
-        'saml-response': samlResponse
-    });
+export function getTokenViaSamlResponse(samlResponse: string) {
+    return jsonRequest<TokenResponse>(
+        'POST',
+        '/tokens',
+        {},
+        {
+            'saml-response': samlResponse
+        }
+    );
 }
 
-export function getAndCacheConfig(token) {
-    return jsonRequest('GET', '/config', {
+export function getAndCacheConfig(token: string | undefined) {
+    return jsonRequest<ConfigResponse>('GET', '/config', {
         'Authentication-Token': token
     }).then(config => {
         authorizationCache = config.authorization;
@@ -58,7 +93,7 @@ export function isRbacInCache() {
     return !_.isEmpty(authorizationCache);
 }
 
-export async function getRBAC(token): Promise<{ roles: any }> {
+export async function getRBAC(token: string): Promise<{ roles: any }> {
     if (!isRbacInCache()) {
         logger.debug('No RBAC data in cache.');
         await getAndCacheConfig(token);
@@ -68,8 +103,8 @@ export async function getRBAC(token): Promise<{ roles: any }> {
     return authorizationCache;
 }
 
-export function getManagerVersion(token) {
-    return jsonRequest('GET', '/version', { 'Authentication-Token': token }).then(version => {
+export function getManagerVersion(token: string) {
+    return jsonRequest<VersionResponse>('GET', '/version', { 'Authentication-Token': token }).then(version => {
         // set community mode from manager API only if mode is not set from the command line
         if (getMode() === MODE_MAIN && version.edition === MODE_COMMUNITY) {
             setMode(MODE_COMMUNITY);
@@ -79,7 +114,7 @@ export function getManagerVersion(token) {
     });
 }
 
-export function isAuthorized(user, authorizedRoles) {
+export function isAuthorized(user: Express.User, authorizedRoles: string[]) {
     const systemRole = user.role;
     const groupSystemRoles = _.keys(user.group_system_roles);
 

--- a/backend/handler/AuthHandler.ts
+++ b/backend/handler/AuthHandler.ts
@@ -79,7 +79,7 @@ export function getTokenViaSamlResponse(samlResponse: string) {
     );
 }
 
-export function getAndCacheConfig(token: string | undefined) {
+export function getAndCacheConfig(token?: string) {
     return jsonRequest<ConfigResponse>('GET', '/config', {
         'Authentication-Token': token
     }).then(config => {

--- a/backend/routes/Auth.ts
+++ b/backend/routes/Auth.ts
@@ -17,7 +17,7 @@ router.use(bodyParser.json());
 router.use(bodyParser.urlencoded({ extended: true }));
 
 function getCookieOptions(req) {
-    const httpsUsed = req.header('X-Scheme')?.includes('https');
+    const httpsUsed = req.header('X-Scheme')?.includes('https') || req.header('X-Force-Secure') === 'true';
     return { sameSite: 'strict', secure: httpsUsed };
 }
 

--- a/backend/routes/Auth.ts
+++ b/backend/routes/Auth.ts
@@ -16,7 +16,7 @@ router.use(bodyParser.json());
 router.use(bodyParser.urlencoded({ extended: true }));
 
 function getCookieOptions(req: Request) {
-    const httpsUsed = req.header('X-Scheme')?.includes('https') || req.header('X-Force-Secure') === 'true';
+    const httpsUsed = req.header('X-Scheme') === 'https' || req.header('X-Force-Secure') === 'true';
     return { sameSite: 'strict', secure: httpsUsed } as CookieOptions;
 }
 

--- a/backend/routes/ServerProxy.ts
+++ b/backend/routes/ServerProxy.ts
@@ -54,7 +54,7 @@ async function proxyRequest(req: RequestWithServerUrl, res: Response) {
 
     // if is a maintenance status fetch then update RBAC cache if empty
     if (req.su === `${getApiUrl()}/maintenance` && req.method === 'GET' && !isRbacInCache()) {
-        await getAndCacheConfig(req.headers['authentication-token']);
+        await getAndCacheConfig(req.headers['authentication-token'] as string);
     }
 
     updateOptions(options, req.method);

--- a/backend/test/routes/Auth.test.ts
+++ b/backend/test/routes/Auth.test.ts
@@ -30,7 +30,20 @@ function mockSamlConfig() {
 
 describe('/auth endpoint', () => {
     describe('/login handles', () => {
-        it('valid token via https', () => {
+        it('valid token via https in CaaS environment', () => {
+            (<jest.Mock>getToken).mockResolvedValue({ value: 'xyz', role: 'default' });
+            return request(app)
+                .post('/console/auth/login')
+                .set('X-Force-Secure', 'true')
+                .expect(200)
+                .then(response => {
+                    expect(response.body).toStrictEqual({ role: 'default' });
+                    const { 'set-cookie': setCookie } = response.headers;
+                    expect(setCookie).toEqual(['XSRF-TOKEN=xyz; Path=/; Secure; SameSite=Strict']);
+                });
+        });
+
+        it('valid token via https in non-CaaS environment', () => {
             (<jest.Mock>getToken).mockResolvedValue({ value: 'xyz', role: 'default' });
             return request(app)
                 .post('/console/auth/login')

--- a/backend/test/routes/Auth.test.ts
+++ b/backend/test/routes/Auth.test.ts
@@ -47,7 +47,7 @@ describe('/auth endpoint', () => {
             (<jest.Mock>getToken).mockResolvedValue({ value: 'xyz', role: 'default' });
             return request(app)
                 .post('/console/auth/login')
-                .set('X-Scheme', 'http,https')
+                .set('X-Scheme', 'https')
                 .expect(200)
                 .then(response => {
                     expect(response.body).toStrictEqual({ role: 'default' });


### PR DESCRIPTION
## Description
As a result of discussion in RD-3828 a change in `Auth.ts` had to be implemented to satisfy different environment needs. `getCookieOptions` function had to be updated to check both - `X-Scheme` and `X-Force-Secure` headers - to determine if token cookie should have `Secure` flag set.
In addition to that change few backend files were migrated to TypeScript.

## Screenshots / Videos
N/A

## Checklist
- [x] My code follows the UI Code Style.
- [x] I verified that all tests and checks have passed.
- [x] I verified if that change requires a documentation update.
- [x] I added proper labels to this PR.

## Tests
1. Updated backend unit tests.
2. [Stage-UI-System-Test/1834](https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/1834/tests) - only one test failing, it's reported already as RD-3760, not related to this PR, so I'm considering it as PASSED

## Documentation
N/A
