### PR TITLE
RD-3972 Switch documentation and blueprint examples to 6.3

### DIFF
--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -668,7 +668,7 @@
                 }
             },
             "readmes": {
-                "linksBasePath": "https://docs.cloudify.co/staging/dev",
+                "linksBasePath": "https://docs.cloudify.co/6.3.0",
                 "params": {
                     "cfy_composer_link": "/developer/composer/",
                     "cfy_composer_name": "Cloudify Composer",
@@ -681,7 +681,7 @@
             },
             "revertToDefault": "Revert to default value",
             "urls": {
-                "blueprintsCatalog": "http://repository.cloudifysource.org/cloudify/blueprints/6.2/examples.json",
+                "blueprintsCatalog": "http://repository.cloudifysource.org/cloudify/blueprints/6.3/examples.json",
                 "helloWorldBlueprint": "https://github.com/cloudify-cosmo/cloudify-hello-world-example/archive/master.zip",
                 "linkParameterExample": "https://cloudify.co"
             },
@@ -776,27 +776,27 @@
                         "defaultValues": [
                             {
                                 "name": "AWS",
-                                "url": "https://repository.cloudifysource.org/cloudify/blueprints/6.2/aws_services.json"
+                                "url": "https://repository.cloudifysource.org/cloudify/blueprints/6.3/aws_services.json"
                             },
                             {
                                 "name": "Azure",
-                                "url": "https://repository.cloudifysource.org/cloudify/blueprints/6.2/azure_services.json"
+                                "url": "https://repository.cloudifysource.org/cloudify/blueprints/6.3/azure_services.json"
                             },
                             {
                                 "name": "GCP",
-                                "url": "https://repository.cloudifysource.org/cloudify/blueprints/6.2/gcp_services.json"
+                                "url": "https://repository.cloudifysource.org/cloudify/blueprints/6.3/gcp_services.json"
                             },
                             {
                                 "name": "Terraform",
-                                "url": "https://repository.cloudifysource.org/cloudify/blueprints/6.2/terraform_services.json"
+                                "url": "https://repository.cloudifysource.org/cloudify/blueprints/6.3/terraform_services.json"
                             },
                             {
                                 "name": "Helm",
-                                "url": "https://repository.cloudifysource.org/cloudify/blueprints/6.2/helm_services.json"
+                                "url": "https://repository.cloudifysource.org/cloudify/blueprints/6.3/helm_services.json"
                             },
                             {
                                 "name": "Other",
-                                "url": "https://repository.cloudifysource.org/cloudify/blueprints/6.2/other_services.json"
+                                "url": "https://repository.cloudifysource.org/cloudify/blueprints/6.3/other_services.json"
                             }
                         ]
                     }

--- a/scripts/readmesConfig.json
+++ b/scripts/readmesConfig.json
@@ -1,5 +1,5 @@
 {
-  "rawContentBasePath": "https://raw.githubusercontent.com/cloudify-cosmo/docs.getcloudify.org/master",
+  "rawContentBasePath": "https://raw.githubusercontent.com/cloudify-cosmo/docs.getcloudify.org/6.3.0-build",
   "files": [
     {"widget": "agents", "link": "/content/working_with/console/widgets/agents.md"},
     {"widget": "blueprintActionButtons", "link": "/content/working_with/console/widgets/blueprintActionButtons.md"},

--- a/templates/pages/adminDash.json
+++ b/templates/pages/adminDash.json
@@ -93,7 +93,7 @@
             "label": "Create Kubernetes cluster",
             "marketplaceTabs": [{
               "name": "Clusters",
-              "url": "https://repository.cloudifysource.org/cloudify/blueprints/6.2/k8s-examples.json"
+              "url": "https://repository.cloudifysource.org/cloudify/blueprints/6.3/k8s-examples.json"
             }]
           }
         },
@@ -110,7 +110,7 @@
             "label": "Run Terraform module",
             "marketplaceTabs": [{
               "name": "Terraform",
-              "url": "https://repository.cloudifysource.org/cloudify/blueprints/6.2/terraform_services.json"
+              "url": "https://repository.cloudifysource.org/cloudify/blueprints/6.3/terraform_services.json"
             }]
           }
         },

--- a/templates/pages/blueprints.json
+++ b/templates/pages/blueprints.json
@@ -47,7 +47,7 @@
                         "marketplaceTabs": [
                             {
                                 "name": "Clusters",
-                                "url": "https://repository.cloudifysource.org/cloudify/blueprints/6.2/k8s-examples.json"
+                                "url": "https://repository.cloudifysource.org/cloudify/blueprints/6.3/k8s-examples.json"
                             }
                         ]
                     }
@@ -66,7 +66,7 @@
                         "marketplaceTabs": [
                             {
                                 "name": "Terraform",
-                                "url": "https://repository.cloudifysource.org/cloudify/blueprints/6.2/terraform_services.json"
+                                "url": "https://repository.cloudifysource.org/cloudify/blueprints/6.3/terraform_services.json"
                             }
                         ]
                     }

--- a/test/cypress/integration/widgets/blueprint_catalog_spec.ts
+++ b/test/cypress/integration/widgets/blueprint_catalog_spec.ts
@@ -5,7 +5,7 @@ describe('Blueprints catalog widget', () => {
         cy
             .activate()
             .usePageMock('blueprintCatalog', {
-                jsonPath: 'https://repository.cloudifysource.org/cloudify/blueprints/6.2/vm-examples.json',
+                jsonPath: 'https://repository.cloudifysource.org/cloudify/blueprints/6.3/vm-examples.json',
                 displayStyle: 'catalog',
                 fieldsToShow: ['Name', 'Description', 'Created', 'Updated']
             })

--- a/test/cypress/integration/widgets/blueprints_spec.ts
+++ b/test/cypress/integration/widgets/blueprints_spec.ts
@@ -7,15 +7,15 @@ describe('Blueprints widget', () => {
     const marketplaceTabs = [
         {
             name: 'VM Blueprint Examples',
-            url: 'https://repository.cloudifysource.org/cloudify/blueprints/6.2/vm-examples.json'
+            url: 'https://repository.cloudifysource.org/cloudify/blueprints/6.3/vm-examples.json'
         },
         {
             name: 'Kubernetes Blueprint Examples',
-            url: 'https://repository.cloudifysource.org/cloudify/blueprints/6.2/k8s-examples.json'
+            url: 'https://repository.cloudifysource.org/cloudify/blueprints/6.3/k8s-examples.json'
         },
         {
             name: 'Orchestrator Blueprint Examples',
-            url: 'https://repository.cloudifysource.org/cloudify/blueprints/6.2/orc-examples.json'
+            url: 'https://repository.cloudifysource.org/cloudify/blueprints/6.3/orc-examples.json'
         }
     ];
     const blueprintsWidgetConfiguration: Partial<BlueprintsWidgetConfiguration> = {


### PR DESCRIPTION
## Description

Both - widget help description documentation and links to blueprint examples - were hardwired to 6.3 branches.

## Screenshots / Videos
N/A

## Checklist
- [x] My code follows the UI Code Style.
- [x] I verified that all tests and checks have passed.
- [x] I verified if that change requires a documentation update.
- [x] I added proper labels to this PR.

## Tests
Did manual tests:
* verified that images links in widget help description points to https://docs.cloudify.co/6.3.0/...
* verified that blueprint examples are available (only in Blueprints widget) - only [Helm examples](https://repository.cloudifysource.org/cloudify/blueprints/6.3/helm_services.json) not available, @alexmolev notified

## Documentation
N/A