### PR TITLE
RD-4090 Update plugins catalog link to the latest version

### DIFF
--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -2,7 +2,7 @@
     "backToApps": "Back to apps",
     "backToLogin": "Back to login",
     "urls": {
-        "pluginsCatalog": "http://repository.cloudifysource.org/cloudify/wagons/plugins.json"
+        "pluginsCatalog": "http://repository.cloudifysource.org/cloudify/wagons/v2_plugins.json"
     },
     "cluster": {
         "manager": "Manager",

--- a/test/cypress/fixtures/widgets/splitViewWidget.tsx
+++ b/test/cypress/fixtures/widgets/splitViewWidget.tsx
@@ -22,7 +22,7 @@ Stage.defineWidget({
                         widget: {
                             id: 'pluginsCatalog',
                             configuration: {
-                                jsonPath: 'http://repository.cloudifysource.org/cloudify/wagons/plugins.json'
+                                jsonPath: 'http://repository.cloudifysource.org/cloudify/wagons/v2_plugins.json'
                             },
                             definition: 'pluginsCatalog',
                             drillDownPages: {},

--- a/test/cypress/integration/getting_started_spec.ts
+++ b/test/cypress/integration/getting_started_spec.ts
@@ -2,7 +2,7 @@ import { escapeRegExp, find } from 'lodash';
 import { PluginDescription } from 'widgets/pluginsCatalog/src/types';
 import { minutesToMs } from '../support/resource_commons';
 
-const pluginsCatalogUrl = 'http://repository.cloudifysource.org/cloudify/wagons/plugins.json';
+const pluginsCatalogUrl = 'http://repository.cloudifysource.org/cloudify/wagons/v2_plugins.json';
 const awsSecrets = ['aws_access_key_id', 'aws_secret_access_key'];
 const awsPlugins = ['cloudify-utilities-plugin', 'cloudify-kubernetes-plugin', 'cloudify-aws-plugin'];
 const awsBlueprints = ['AWS-Basics-VM-Setup', 'AWS-VM-Setup-using-CloudFormation', 'Kubernetes-AWS-EKS'];

--- a/test/cypress/integration/widgets/plugins_catalog_spec.ts
+++ b/test/cypress/integration/widgets/plugins_catalog_spec.ts
@@ -21,7 +21,7 @@ function uploadPlugins(pluginNames: string[]) {
 
 describe('Plugins Catalog widget', () => {
     const widgetConfiguration: PluginsCatalogWidgetConfiguration = {
-        jsonPath: 'http://repository.cloudifysource.org/cloudify/wagons/plugins.json',
+        jsonPath: 'http://repository.cloudifysource.org/cloudify/wagons/v2_plugins.json',
         sortByName: true
     };
 

--- a/test/cypress/support/commands.ts
+++ b/test/cypress/support/commands.ts
@@ -323,7 +323,7 @@ const commands = {
                                         definition: 'pluginsCatalog',
                                         configuration: {
                                             jsonPath:
-                                                'http://repository.cloudifysource.org/cloudify/wagons/plugins.json'
+                                                'http://repository.cloudifysource.org/cloudify/wagons/v2_plugins.json'
                                         },
                                         drillDownPages: {},
                                         height: 20,


### PR DESCRIPTION
## Description

As per @alexmolev request this PR updates plugins catalog link to the latest available version.

There is more occurrences of "repository.cloudifysource.org/cloudify/wagons/plugins.json" string, but they are only in `backend/test/snapshots` (in .sql files), so I decided not to change them.

Will create cherry-pick PR for 6.3 once this one is merged.

## Screenshots / Videos
N/A

## Checklist
- [x] My code follows the UI Code Style.
- [ ] I verified that all tests and checks have passed.
- [x] I verified if that change requires a documentation update.
- [x] I added proper labels to this PR.

## Tests
[Stage-UI-System-Test #1926](https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/1926/tests) - PASSED

## Documentation
N/A