### PR TITLE
RD-4048: Added component which is used to animate menu subitems

### DIFF
--- a/.size-limit
+++ b/.size-limit
@@ -1,7 +1,7 @@
 [
     {
         "name": "Main JS bundle",
-        "limit": "359 KB",
+        "limit": "361 KB",
         "gzip": false,
         "path": "dist/static/js/main.bundle.js"
     },

--- a/app/components/sidebar/SideBar.tsx
+++ b/app/components/sidebar/SideBar.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent, useContext, useState } from 'react';
 
-import styled, { ThemeContext } from 'styled-components';
+import styled, { css, ThemeContext } from 'styled-components';
 import { useSelector } from 'react-redux';
 import { without } from 'lodash';
 import PagesList from './PagesList';
@@ -9,6 +9,7 @@ import { ReduxState } from '../../reducers';
 import SystemMenu, { SystemMenuGroup } from './SystemMenu';
 import { useBoolean, useResettableState } from '../../utils/hooks';
 import SideBarHeader from './SideBarHeader';
+import { SideBarAnimatedItemWrapper } from './SideBarItem';
 
 export const collapsedSidebarWidth = '4.3rem';
 export const expandedSidebarWidth = '18rem';
@@ -23,7 +24,13 @@ const ThemedSidebar = styled(Sidebar)`
     }
     .item {
         color: ${props => props.theme.sidebarTextColor} !important;
-        padding-left: ${props => !props.$expanded && '15px !important'};
+    }
+    ${SideBarAnimatedItemWrapper} {
+        ${props =>
+            !props.$expanded &&
+            css`
+                transform: translateX(0px);
+            `}
     }
     .item.active,
     .item:hover {

--- a/app/components/sidebar/SideBarItem.tsx
+++ b/app/components/sidebar/SideBarItem.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import type { FunctionComponent, ReactNode } from 'react';
-import styled from 'styled-components';
+import type { FunctionComponent, ReactNode, CSSProperties } from 'react';
+import styled, { css } from 'styled-components';
 import type { MenuItemProps, SemanticICONS } from 'semantic-ui-react';
 import { Icon, Menu } from '../basic';
 import { expandedSidebarWidth } from './SideBar';
@@ -16,6 +16,18 @@ export const SideBarItemWrapper = styled.div`
     .item:hover {
         text-decoration: none !important; // override semantic ui styles
     }
+`;
+
+type SideBarAnimatedItemWrapperProps = Pick<SideBarItemProps, 'subItem'>;
+
+export const SideBarAnimatedItemWrapper = styled.div<SideBarAnimatedItemWrapperProps>`
+    transition: transform 500ms ease;
+
+    ${({ subItem }) =>
+        subItem &&
+        css`
+            transform: translateX(10px);
+        `}
 `;
 
 export interface SideBarItemProps extends MenuItemProps {
@@ -36,28 +48,30 @@ const SideBarItem: FunctionComponent<SideBarItemProps> = ({
     children,
     ...rest
 }) => {
-    const menuItemStyle = {
+    const menuItemStyle: CSSProperties = {
         height: '100%',
         width: expandedSidebarWidth,
         paddingTop: 13,
-        paddingLeft: subItem && 25,
+        paddingLeft: subItem && 15,
         ...style
     };
 
     return (
-        <SideBarItemWrapper className="sidebarItemWrapper">
+        <SideBarItemWrapper>
             {/* eslint-disable-next-line react/jsx-props-no-spreading */}
             <Menu.Item style={menuItemStyle} {...rest}>
-                {typeof icon === 'string' ? <SideBarItemIcon name={icon as SemanticICONS} /> : icon}
-                {label && <span style={{ verticalAlign: 'top', fontSize: sideBarItemFontSize }}>{label}</span>}
-                {children}
-                {expandable && (
-                    <Icon
-                        name="dropdown"
-                        rotated={expanded ? undefined : 'counterclockwise'}
-                        style={{ position: 'absolute', right: 12, margin: 0 }}
-                    />
-                )}
+                <SideBarAnimatedItemWrapper subItem={subItem}>
+                    {typeof icon === 'string' ? <SideBarItemIcon name={icon as SemanticICONS} /> : icon}
+                    {label && <span style={{ verticalAlign: 'top', fontSize: sideBarItemFontSize }}>{label}</span>}
+                    {children}
+                    {expandable && (
+                        <Icon
+                            name="dropdown"
+                            rotated={expanded ? undefined : 'counterclockwise'}
+                            style={{ position: 'absolute', right: 12, margin: 0 }}
+                        />
+                    )}
+                </SideBarAnimatedItemWrapper>
             </Menu.Item>
         </SideBarItemWrapper>
     );

--- a/test/cypress/integration/widgets/blueprints_spec.ts
+++ b/test/cypress/integration/widgets/blueprints_spec.ts
@@ -666,8 +666,6 @@ describe('Blueprints widget', () => {
         });
 
         describe('create installable blueprint on submit from', () => {
-            before(() => cy.uploadPluginFromCatalog('Terraform'));
-
             beforeEach(openTerraformModal);
 
             function testBlueprintGeneration(terraformTemplateUrl: string, modulePath: string) {


### PR DESCRIPTION
<!--- Provide JIRA issue ID and a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes to help reviewers understand the details. -->
Changes consists of adding transition to the menu subitems, so that they won't "jump", while the sidebar is being expanded.

## Screenshots / Videos
<!--- If applicable, add screenshot(s) or video(s) describing the changes you made. -->
<!--- Consider adding comparison screenshot(s) - before and after the change. -->
<!--- If not applicable, just write “N/A” in this section. -->

Same before/after effect has been achieved as shown in [jira task](https://cloudifysource.atlassian.net/browse/RD-4048)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the UI Code Style.
- [ ] I verified that all tests and checks have passed.
- [x] I verified if that change requires a documentation update.
- [x] I added proper labels to this PR.

## Tests
<!--- If applicable, describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If applicable, provide a link to system tests, e.g: -->
<!--- [#1039](https://jenkins.cloudify.co/.../1039) (2021-08-06 07:05:50) --> 
<!--- If not applicable, just write “N/A” in this section. -->

N/A, as the changes are strictly styling related 🚀 

## Documentation
<!--- If applicable, describe how you documented or plan to document your changes. -->
<!--- Provide links to JIRA issues, other PRs or related documentation pages. -->
<!--- If not applicable, just write “N/A” in this section. -->

N/A