### PR TITLE
RD-3222 eslint part 1: Update cloudify-ui-common to v5.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12469,9 +12469,9 @@
       }
     },
     "cloudify-ui-common": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cloudify-ui-common/-/cloudify-ui-common-5.1.0.tgz",
-      "integrity": "sha512-cqJWwno0ED8xJCHz0KzHeGsOexshrz8vptD2sp3uTieHDm9MRHeahwD5q24X6ZJdbEVL/lDMN8lgZR91oZZaLA==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/cloudify-ui-common/-/cloudify-ui-common-5.1.2.tgz",
+      "integrity": "sha512-h585Ef/nChrLft3eaXOPpejjF5aY670LY0knIyyudzHiqWkDaFvt+QU27K91Skhlrs/e7MEqV9IIA8LXO8ycCA==",
       "requires": {
         "eslint-config-airbnb": "^18.2.1",
         "eslint-config-airbnb-base": "^14.2.1",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "better-console": "^0.2.4",
     "blueimp-md5": "^2.7.0",
     "cloudify-blueprint-topology": "^2.5.5",
-    "cloudify-ui-common": "^5.1.0",
+    "cloudify-ui-common": "^5.1.2",
     "cloudify-ui-components": "^2.11.0",
     "connected-react-router": "^6.5.2",
     "d3": "^3.5.17",


### PR DESCRIPTION
<!--- Provide JIRA issue ID and a general summary of your changes in the Title above -->

## Description
This pull-request is part of RD-3222. It was created to make it merge fast. Because PRs from other developers need `cloudify-ui-common` to be updated to v5.1.2.

PR Part 2 of RD-3222 task in Cloudify-stage is: https://github.com/cloudify-cosmo/cloudify-stage/pull/1796

<!--- Describe your changes to help reviewers understand the details. -->

## Screenshots / Videos
N/A
<!--- If applicable, add screenshot(s) or video(s) describing the changes you made. -->
<!--- Consider adding comparison screenshot(s) - before and after the change. -->
<!--- If not applicable, just write “N/A” in this section. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the UI Code Style.
- [x] I verified that all tests and checks have passed.
- [x] I verified if that change requires a documentation update.
- [x] I added proper labels to this PR.

## Tests
System tests passed:
https://jenkins.cloudify.co/blue/organizations/jenkins/Stage-UI-System-Test/detail/Stage-UI-System-Test/1998/pipeline
<!--- If applicable, describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If applicable, provide a link to system tests, e.g: -->
<!--- [#1039](https://jenkins.cloudify.co/.../1039) (2021-08-06 07:05:50) --> 
<!--- If not applicable, just write “N/A” in this section. -->

## Documentation
I think it is `N/A` because if there documentation update needed it probably was explained in the description of the PRs in cloudify-ui-common.
<!--- If applicable, describe how you documented or plan to document your changes. -->
<!--- Provide links to JIRA issues, other PRs or related documentation pages. -->
<!--- If not applicable, just write “N/A” in this section. -->
