### PR TITLE
RD-3760 Improve setting admin authorization in `cfyRequest` Cypress command

### DIFF
--- a/test/cypress/integration/widgets/maintenance_mode_button_spec.ts
+++ b/test/cypress/integration/widgets/maintenance_mode_button_spec.ts
@@ -1,5 +1,4 @@
 import Consts from 'app/utils/consts';
-import { getAdminAuthorizationHeader } from '../../support/commands';
 import { waitUntil } from '../../support/resource_commons';
 
 describe('Maintenance mode button widget', { retries: { runMode: 2 } }, () => {
@@ -11,7 +10,7 @@ describe('Maintenance mode button widget', { retries: { runMode: 2 } }, () => {
 
     const deactivateMaintenanceMode = () =>
         cy
-            .cfyRequest('/maintenance/deactivate', 'POST', getAdminAuthorizationHeader())
+            .cfyRequest('/maintenance/deactivate', 'POST', null, null, { useAdminAuthorization: true })
             .then(() => waitForMaintenanceModeStatus('deactivated'));
     const waitForMaintenanceModeStatus = (status: 'activated' | 'deactivated') =>
         waitUntil('maintenance', response => response.body.status === status, { useAdminAuthorization: true });

--- a/test/cypress/support/commands.ts
+++ b/test/cypress/support/commands.ts
@@ -39,7 +39,7 @@ const getCommonHeaders = () => ({
     tenant: Consts.DEFAULT_TENANT
 });
 
-export const getAdminAuthorizationHeader = () => ({ Authorization: `Basic ${btoa('admin:admin')}` });
+const getAdminAuthorizationHeader = () => ({ Authorization: `Basic ${btoa('admin:admin')}` });
 
 const mockGettingStarted = (modalEnabled: boolean) =>
     cy.interceptSp('GET', `/users/*`, {
@@ -117,7 +117,9 @@ const commands = {
         method = 'GET',
         headers: any = null,
         body: any = null,
-        options: Partial<Cypress.RequestOptions> = {}
+        options: Partial<Cypress.RequestOptions> & { useAdminAuthorization?: boolean } = {
+            useAdminAuthorization: false
+        }
     ) =>
         cy.request({
             method,
@@ -125,6 +127,7 @@ const commands = {
             headers: {
                 'Content-Type': 'application/json',
                 ...getCommonHeaders(),
+                ...(options.useAdminAuthorization ? getAdminAuthorizationHeader() : {}),
                 ...headers
             },
             body,

--- a/test/cypress/support/resource_commons.ts
+++ b/test/cypress/support/resource_commons.ts
@@ -1,5 +1,4 @@
 import _ from 'lodash';
-import { getAdminAuthorizationHeader } from './commands';
 
 function appendQueryParam(url: string, param: string, value: string) {
     return `${url}${url.indexOf('?') > 0 ? '&' : '?'}${param}=${value}`;
@@ -30,7 +29,7 @@ export function waitUntil(
     if (search) {
         url = appendQueryParam(url, `_search`, search);
     }
-    cy.cfyRequest(url, 'GET', useAdminAuthorization ? getAdminAuthorizationHeader() : null).then(response => {
+    cy.cfyRequest(url, 'GET', null, null, { useAdminAuthorization }).then(response => {
         if (predicate(response)) {
             return;
         }


### PR DESCRIPTION
## Description
After #1815 merge I discovered a problem in few tests:
```
An uncaught error was detected outside of a test.An uncaught error was detected outside of a test (from Root Suite)

The following error originated from your test code, not from Cypress.    > resource_commons_1.minutesToMs is not a function  When Cypress detects uncaught errors originating from your test code it will automatically fail the current test.  Cypress could not associate this error to any specific test.  We dynamically generated a new test to display this failure.

Cypress could not associate this error to any specific test.
```

This PR aims to fix it.

## Screenshots / Videos
N/A

## Checklist
- [x] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [x] I verified that all tests and checks have passed.
- [x] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [x] I added proper labels to this PR.

## Tests
[Stage-UI-System-Test #2070](https://jenkins.cloudify.co/job/Stage-UI-System-Test/2070/console) - all tests - PASSED 

## Documentation
N/A