### PR TITLE
RD-4304 Downgrade `vm2` package to v3.9.5

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9472,25 +9472,9 @@
       }
     },
     "vm2": {
-      "version": "3.9.8",
-      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.8.tgz",
-      "integrity": "sha512-/1PYg/BwdKzMPo8maOZ0heT7DLI0DAFTm7YQaz/Lim9oIaFZsJs3EdtalvXuBfZwczNwsYhju75NW4d6E+4q+w==",
-      "requires": {
-        "acorn": "^8.7.0",
-        "acorn-walk": "^8.2.0"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "8.7.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-          "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ=="
-        },
-        "acorn-walk": {
-          "version": "8.2.0",
-          "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-          "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA=="
-        }
-      }
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.5.tgz",
+      "integrity": "sha512-LuCAHZN75H9tdrAiLFf030oW7nJV5xwNMuk1ymOZwopmuK3d2H4L1Kv4+GFHgarKiLfXXLFU+7LDABHnwOkWng=="
     },
     "w3c-hr-time": {
       "version": "1.0.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -63,7 +63,7 @@
     "supertest": "^5.0.0",
     "ts-node": "^10.2.1",
     "typescript": "^4.3.5",
-    "vm2": "^3.9.8",
+    "vm2": "^3.9.5",
     "wait-on": "^3.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description

Within #1835 `vm2` package version was bumped from `3.9.5` to `3.9.8` to fix security issues.
Unfortunately it turned out that there was a breaking change in `3.9.6`, so this PR reverts the bump.

Additionally an issue in `vm2` package repository was created: https://github.com/patriksimek/vm2/issues/411
Looking at the

## Screenshots / Videos
N/A

## Checklist
- [x] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [ ] I verified that all tests and checks have passed.
- [x] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [x] I added proper labels to this PR.

## Tests
[Stage-UI-System-Test #2111](https://jenkins.cloudify.co/view/UI%20Health%20View/job/Stage-UI-System-Test/2111/) - IN PROGRESS

## Documentation
N/A