### PR TITLE
RD-4320 Fix typo in vSphere Secrets dialog in Getting Started modal

### DIFF
--- a/app/components/GettingStartedModal/schema/cloudSetup.schema.json
+++ b/app/components/GettingStartedModal/schema/cloudSetup.schema.json
@@ -319,8 +319,8 @@
              "type": "text"
           },
           {
-             "name": "vsphere_datacenter_nameas",
-             "label": "vSphere Datacenter Nameas",
+             "name": "vsphere_datacenter_name",
+             "label": "vSphere Datacenter Name",
              "type": "text"
           },
           {


### PR DESCRIPTION
## Description

Just a typo fix. Planned for `6.3.1`, so I'll create cherry-pick PR once this is merged to `master`.

## Screenshots / Videos

1. ![image](https://user-images.githubusercontent.com/5202105/155115911-559659cd-958b-42f9-9873-58495a090e03.png)
2. ![image](https://user-images.githubusercontent.com/5202105/155116129-7868924e-b8d0-4f59-8ffc-f486603b3df2.png)
3. ![image](https://user-images.githubusercontent.com/5202105/155116198-af82bdce-3132-4ba5-8df2-76be87dd9b11.png)

## Checklist
- [x] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [x] I verified that all tests and checks have passed.
- [x] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [x] I added proper labels to this PR.

## Tests
Did manual tests only, see screenshots.
We don't have `vSphere` tests, so I'm not planning system tests run.

## Documentation
N/A