### PR TITLE
RD-2561 Remove e2e:ci script

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "docCheck": "scripts/checkDocs.sh",
     "docWidgets": "node scripts/updateReadmes.js",
     "e2e": "cypress run -C node_modules/cloudify-ui-common/cypress/cypress.json",
-    "e2e:ci": "npm run beforebuild && cross-env TEST=1 run-system-tests ${TEST_SPEC}",
     "lint": "eslint --cache --ignore-path .gitignore --ext js,jsx,ts,tsx .",
     "size": "[ -d \"dist\" ] && size-limit",
     "test": "npm run test:frontend && npm run test:backend",


### PR DESCRIPTION
## Description

Once https://github.com/cloudify-cosmo/cloudify-build-system/pull/634 is merged, there will be no need for keeping `e2e:ci` NPM script, so this PR removes it from `package.json`.

## Screenshots / Videos
N/A

## Checklist
- [x] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [x] I verified that all tests and checks have passed.
- [x] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [x] I added proper labels to this PR.

## Tests
N/A

## Documentation
N/A