### PR TITLE
RD-4589 Add test retries to one test in Templates spec

### DIFF
--- a/test/cypress/integration/templateManagement/templates_spec.ts
+++ b/test/cypress/integration/templateManagement/templates_spec.ts
@@ -82,7 +82,7 @@ describe('Templates segment', () => {
         );
     });
 
-    it('allows users to create and modify templates', () => {
+    it('allows users to create and modify templates', { retries: { runMode: 2 } }, () => {
         const clickOnHeader = () => cy.get('.header').click();
         cy.removeUserTemplates().mockLogin();
 


### PR DESCRIPTION
## Description
There is an issue occurring from time to time in Stage-UI-System-Test job revealing Templates spec test flakiness. I didn't find a way to solve it properly, so according to our rules I'm adding test retries to the test case.

Tested retries locally (with `openMode: 2`) to check if test is independent, seems working fine.

Ref. RD-4589

## Screenshots / Videos
N/A

## Checklist
- [x] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [x] I verified that all tests and checks have passed.
- [x] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [x] I added proper labels to this PR.

## Tests
Tested locally, all passed.

## Documentation
N/A