### PR TITLE
RD-4666 Fix error 500 in Topology widget & make Topology widget spec more robust

### DIFF
--- a/backend/routes/Plugins.ts
+++ b/backend/routes/Plugins.ts
@@ -77,8 +77,10 @@ router.get('/icons/:pluginId', (req, res) => {
         res,
         options
     ).catch(err => {
-        if (err.response?.status === 404 || err.response?.status === 304) {
+        if (err.response?.status === 404) {
             res.status(200).end();
+        } else if (err.response?.status === 304) {
+            res.status(304).end();
         } else {
             logger.error(err.message);
             res.status(500).end();

--- a/backend/routes/Plugins.ts
+++ b/backend/routes/Plugins.ts
@@ -77,7 +77,7 @@ router.get('/icons/:pluginId', (req, res) => {
         res,
         options
     ).catch(err => {
-        if (err.response?.status === 404) {
+        if (err.response?.status === 404 || err.response?.status === 304) {
             res.status(200).end();
         } else {
             logger.error(err.message);

--- a/test/cypress/integration/widgets/topology_spec.ts
+++ b/test/cypress/integration/widgets/topology_spec.ts
@@ -63,7 +63,7 @@ describe('Topology', () => {
 
             cy.log('Check terraform module details');
             waitForDeploymentToBeInstalled(deploymentId);
-            cy.clearBlueprintContext().setDeploymentContext(deploymentId);
+            cy.clearBlueprintContext().clearDeploymentContext().setDeploymentContext(deploymentId);
             cy.contains('#gridContainer > #gridSvg > #gridContent > .nodeContainer > .title', 'terraform');
             cy.contains('#gridContainer > #gridSvg > #gridContent > .nodeContainer > .title', 'cloud_resources');
             getTerraformDetailsButton().should('not.have.css', 'visibility', 'hidden').click({ force: true });

--- a/test/cypress/integration/widgets/topology_spec.ts
+++ b/test/cypress/integration/widgets/topology_spec.ts
@@ -63,7 +63,7 @@ describe('Topology', () => {
 
             cy.log('Check terraform module details');
             waitForDeploymentToBeInstalled(deploymentId);
-            cy.clearDeploymentContext().setDeploymentContext(deploymentId);
+            cy.clearBlueprintContext().setDeploymentContext(deploymentId);
             cy.contains('#gridContainer > #gridSvg > #gridContent > .nodeContainer > .title', 'terraform');
             cy.contains('#gridContainer > #gridSvg > #gridContent > .nodeContainer > .title', 'cloud_resources');
             getTerraformDetailsButton().should('not.have.css', 'visibility', 'hidden').click({ force: true });

--- a/test/cypress/support/commands.ts
+++ b/test/cypress/support/commands.ts
@@ -462,5 +462,5 @@ function setContext(field: string, value: string) {
 }
 
 function clearContext(field: string) {
-    cy.get(`.${field}FilterField .dropdown.icon`).click();
+    return cy.get(`.${field}FilterField .dropdown.icon`).click();
 }


### PR DESCRIPTION
## Description
This small PR fixes two bugs:
1. Topology widget was throwing Internal Server Error (as 304 error was converted to 500 in the backend)
2. Topology widget spec was not refreshing the widget properly after deployment installation finished, so the Terraform Resources modal was not always filled with data

## Screenshots / Videos
N/A

## Checklist
- [x] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [x] I verified that all tests and checks have passed.
- [x] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [x] I added proper labels to this PR.

## Tests
[![Build Status](https://jenkins.cloudify.co/buildStatus/icon?job=Stage-UI-System-Test&build=2335)](https://jenkins.cloudify.co/view/UI%20Health%20View/job/Stage-UI-System-Test/2335/) - only Topology widget spec - PASSED

## Documentation
N/A