### PR TITLE
RD-4906 Skip two test cases in Plugins Catalog spec

### DIFF
--- a/test/cypress/integration/widgets/plugins_catalog_spec.ts
+++ b/test/cypress/integration/widgets/plugins_catalog_spec.ts
@@ -29,7 +29,7 @@ describe('Plugins Catalog widget', () => {
         cy.activate().deletePlugins().usePageMock(['pluginsCatalog', 'plugins'], widgetConfiguration).mockLogin()
     );
 
-    it('should allow uploading multiple plugins', () => {
+    it.skip('should allow uploading multiple plugins', () => {
         const pluginsToUpload = ['Helm', 'Libvirt'];
         uploadPlugins(pluginsToUpload);
         pluginsToUpload.forEach(pluginToUpload => {
@@ -109,7 +109,7 @@ describe('Plugins Catalog widget', () => {
         );
     });
 
-    it('should upload all plugins', () => {
+    it.skip('should upload all plugins', () => {
         // eslint-disable-next-line security/detect-non-literal-regexp
         cy.intercept('POST', new RegExp(`console/plugins/upload.*title=AWS`)).as('awsPluginUpload');
         cy.contains('Upload all plugins').click().should('be.disabled');


### PR DESCRIPTION
## Description
There was a change in http://repository.cloudifysource.org/cloudify/wagons/v2_plugins.json which does not allow to detect if the uploaded version of the plugin is the same as the one listed in the Plugins Catalog for some of the plugins (those which has no explicit version set, but version set to "latest").

Until we have final decision about the Plugins Catalog JSON file (see discussion in RD-4906), this PR adds skipping failing tests. 

## Screenshots / Videos
N/A

## Checklist
- [x] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [x] I verified that all tests and checks have passed.
- [x] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [x] I added proper labels to this PR.

## Tests
[![Build Status](https://jenkins.cloudify.co/buildStatus/icon?job=Stage-UI-System-Test&build=2672)](https://jenkins.cloudify.co/view/UI%20Health%20View/job/Stage-UI-System-Test/2672/)

## Documentation
N/A