### PR TITLE
RD-1107 Allow user with `sys_admin` role and without tenant assigned to log in

### DIFF
--- a/app/components/AuthRoutes.tsx
+++ b/app/components/AuthRoutes.tsx
@@ -42,8 +42,8 @@ const AuthRoutes: FunctionComponent = () => {
     useEffect(() => {
         if (isProductOperational && isManagerDataFetched) {
             dispatch(getUserData())
-                .then(({ tenantsRoles }: any) => {
-                    if (_.isEmpty(tenantsRoles)) {
+                .then(({ tenantsRoles, role }: any) => {
+                    if (_.isEmpty(tenantsRoles) && role !== Consts.ROLE.SYS_ADMIN) {
                         return Promise.reject(NO_TENANTS_ERR);
                     }
                     setUserDataFetched();

--- a/app/utils/consts.ts
+++ b/app/utils/consts.ts
@@ -27,6 +27,11 @@ export default {
     NO_LICENSE_ERROR_CODE: 'missing_cloudify_license',
     EXPIRED_LICENSE_ERROR_CODE: 'expired_cloudify_license',
 
+    ROLE: {
+        DEFAULT: 'default',
+        SYS_ADMIN: 'sys_admin'
+    },
+
     DEFAULT_TENANT: 'default_tenant',
     MODE_MAIN: 'main',
     MODE_CUSTOMER: 'customer',

--- a/test/cypress/integration/login_spec.ts
+++ b/test/cypress/integration/login_spec.ts
@@ -57,6 +57,18 @@ describe('Login', () => {
         cy.location('pathname').should('be.equal', '/console/license');
     });
 
+    it('succeeds when provided credentials are valid, license is active and user has sys_admin role and no tenants assigned', () => {
+        cy.intercept('GET', '/console/auth/user', {
+            statusCode: 200,
+            body: { username: 'test', role: 'sys_admin', groupSystemRoles: {}, tenantsRoles: {} }
+        });
+
+        cy.activate();
+        forceLogin();
+
+        cy.location('pathname').should('be.equal', '/console/');
+    });
+
     it('provides SSO login button when SAML is enabled', () => {
         cy.activate();
 


### PR DESCRIPTION
## Description
With this change it will be possible to log in to the Cloudify UI as a user with `sys_admin` role and without tenants assigned.

I added RD-1103 to coming sprints, so we'll be able to deduplicate some consts between frontend (framework and widgets) and backend.

## Screenshots / Videos
N/A

## Checklist
- [x] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [x] I verified that all tests and checks have passed.
- [x] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [x] I added proper labels to this PR.

## Tests

Updated Login spec.
Full run - [![Build Status](https://jenkins.cloudify.co/buildStatus/icon?job=Stage-UI-System-Test&build=2707)](https://jenkins.cloudify.co/view/UI%20Health%20View/job/Stage-UI-System-Test/2707/)


## Documentation
No necessary updates I think.