### PR TITLE
RD-1051 Update restrictions on password changing

### DIFF
--- a/.size-limit
+++ b/.size-limit
@@ -1,7 +1,7 @@
 [
     {
         "name": "Main JS bundle",
-        "limit": "367 KB",
+        "limit": "370 KB",
         "gzip": false,
         "path": "dist/static/js/main.bundle.js"
     },

--- a/app/actions/app.ts
+++ b/app/actions/app.ts
@@ -7,7 +7,7 @@ import { loadWidgetDefinitions } from './widgets';
 
 import { getClientConfig } from './clientConfig';
 import { loadOrCreateUserAppData } from './userApp';
-import { getLdap } from './managers';
+import { getIdentityProviders } from './managers';
 import { getClusterStatus } from './clusterStatus';
 
 export function intialPageLoad() {
@@ -19,7 +19,7 @@ export function intialPageLoad() {
             dispatch(loadWidgetDefinitions()),
             dispatch(getClientConfig()),
             dispatch(getClusterStatus()),
-            dispatch(getLdap())
+            dispatch(getIdentityProviders())
         ])
             .then(() => dispatch(loadOrCreateUserAppData()))
             .then(() => {

--- a/app/actions/managers.ts
+++ b/app/actions/managers.ts
@@ -108,7 +108,7 @@ export function getUserData(): ThunkAction<void, ReduxState, never, AnyAction> {
         });
 }
 
-function responseIdentityProviders(identityProviders: string) {
+function responseIdentityProviders(identityProviders: string[]) {
     return {
         type: types.SET_IDENTITY_PROVIDERS,
         identityProviders
@@ -118,7 +118,9 @@ function responseIdentityProviders(identityProviders: string) {
 export function getIdentityProviders() {
     return (dispatch, getState) => {
         const manager = new Manager(getState().manager);
-        manager.doGet('/idp').then(identityProviders => dispatch(responseIdentityProviders(identityProviders)));
+        manager
+            .doGet('/idp')
+            .then(identityProviders => dispatch(responseIdentityProviders(identityProviders.split(','))));
     };
 }
 

--- a/app/actions/managers.ts
+++ b/app/actions/managers.ts
@@ -108,17 +108,17 @@ export function getUserData(): ThunkAction<void, ReduxState, never, AnyAction> {
         });
 }
 
-function responseLdap(isLdapEnabled) {
+function responseIdentityProviders(identityProviders: string) {
     return {
-        type: types.SET_LDAP_ENABLED,
-        isLdapEnabled
+        type: types.SET_IDENTITY_PROVIDERS,
+        identityProviders
     };
 }
 
-export function getLdap() {
+export function getIdentityProviders() {
     return (dispatch, getState) => {
         const manager = new Manager(getState().manager);
-        manager.doGet('/ldap').then(data => dispatch(responseLdap(data === 'enabled')));
+        manager.doGet('/idp').then(identityProviders => dispatch(responseIdentityProviders(identityProviders)));
     };
 }
 

--- a/app/actions/types.ts
+++ b/app/actions/types.ts
@@ -56,7 +56,7 @@ export const ERR_LOGIN = 'ERR_LOGIN';
 export const LOGOUT = 'LOGOUT';
 
 export const SET_USER_DATA = 'SET_USER_DATA';
-export const SET_LDAP_ENABLED = 'SET_LDAP_ENABLED';
+export const SET_IDENTITY_PROVIDERS = 'SET_IDENTITY_PROVIDERS';
 
 export const REQ_TENANTS = 'REQ_TENANTS';
 export const RES_TENANTS = 'RES_TENANTS';

--- a/app/components/sidebar/UserMenu.tsx
+++ b/app/components/sidebar/UserMenu.tsx
@@ -26,7 +26,7 @@ const UserMenu: FunctionComponent<SystemMenuGroupItemProps> = ({ expanded, onMod
     const dispatch = useDispatch();
 
     const username = useSelector((state: ReduxState) => state.manager.auth.username);
-    const { isUserAuthorized } = StageUtils;
+    const { isUserAuthorized, Idp } = StageUtils;
     const canEnterEditMode = useSelector(
         (state: ReduxState) =>
             state.config.mode !== Consts.MODE_CUSTOMER &&
@@ -45,7 +45,7 @@ const UserMenu: FunctionComponent<SystemMenuGroupItemProps> = ({ expanded, onMod
     );
     const canChangePassword = useSelector(
         (state: ReduxState) =>
-            state.manager.auth.identityProviders === 'local' || state.manager.auth.username === 'admin'
+            Idp.isLocal(state.manager) || state.manager.auth.username === Consts.DEFAULT_ADMIN_USERNAME
     );
     const tenantNames = useSelector((state: ReduxState) =>
         state.manager.tenants.items!.map((tenant: { name: string }) => tenant.name)

--- a/app/components/sidebar/UserMenu.tsx
+++ b/app/components/sidebar/UserMenu.tsx
@@ -43,7 +43,10 @@ const UserMenu: FunctionComponent<SystemMenuGroupItemProps> = ({ expanded, onMod
             isUserAuthorized(Consts.permissions.LICENSE_UPLOAD, state.manager) &&
             state.manager.license.isRequired
     );
-    const canChangePassword = useSelector((state: ReduxState) => !state.manager.isLdapEnabled);
+    const canChangePassword = useSelector(
+        (state: ReduxState) =>
+            state.manager.auth.identityProviders === 'local' || state.manager.auth.username === 'admin'
+    );
     const tenantNames = useSelector((state: ReduxState) =>
         state.manager.tenants.items!.map((tenant: { name: string }) => tenant.name)
     );

--- a/app/reducers/managerReducer/authReducer.ts
+++ b/app/reducers/managerReducer/authReducer.ts
@@ -11,7 +11,7 @@ export interface AuthData {
     groupSystemRoles: Record<string, any>;
     tenantsRoles: Record<string, any>;
     state: AuthState;
-    identityProviders: IdentityProvider;
+    identityProviders: IdentityProvider[];
     error: any;
 }
 

--- a/app/reducers/managerReducer/authReducer.ts
+++ b/app/reducers/managerReducer/authReducer.ts
@@ -3,6 +3,7 @@ import * as types from '../../actions/types';
 import emptyState from './emptyState';
 
 export type AuthState = 'loggedOut' | 'loggingIn' | 'loggedIn';
+export type IdentityProvider = 'local' | 'okta' | 'ldap' | string;
 
 export interface AuthData {
     username: string;
@@ -10,7 +11,7 @@ export interface AuthData {
     groupSystemRoles: Record<string, any>;
     tenantsRoles: Record<string, any>;
     state: AuthState;
-    identityProviders: string;
+    identityProviders: IdentityProvider;
     error: any;
 }
 

--- a/app/reducers/managerReducer/authReducer.ts
+++ b/app/reducers/managerReducer/authReducer.ts
@@ -10,6 +10,7 @@ export interface AuthData {
     groupSystemRoles: Record<string, any>;
     tenantsRoles: Record<string, any>;
     state: AuthState;
+    identityProviders: string;
     error: any;
 }
 
@@ -44,6 +45,11 @@ const auth: Reducer<AuthData> = (state = emptyAuthState, action) => {
                 role: action.role,
                 groupSystemRoles: action.groupSystemRoles,
                 tenantsRoles: action.tenantsRoles
+            };
+        case types.SET_IDENTITY_PROVIDERS:
+            return {
+                ...state,
+                identityProviders: action.identityProviders
             };
         default:
             return state;

--- a/app/reducers/managerReducer/emptyState.ts
+++ b/app/reducers/managerReducer/emptyState.ts
@@ -7,10 +7,10 @@ export default {
         groupSystemRoles: {},
         tenantsRoles: {},
         state: 'loggedOut',
+        identityProviders: '',
         error: null
     },
     clusterStatus: {},
-    isLdapEnabled: false,
     lastUpdated: null,
     license: {},
     maintenance: '',

--- a/app/reducers/managerReducer/emptyState.ts
+++ b/app/reducers/managerReducer/emptyState.ts
@@ -7,7 +7,7 @@ export default {
         groupSystemRoles: {},
         tenantsRoles: {},
         state: 'loggedOut',
-        identityProviders: '',
+        identityProviders: ['local'],
         error: null
     },
     clusterStatus: {},

--- a/app/reducers/managerReducer/managerReducer.ts
+++ b/app/reducers/managerReducer/managerReducer.ts
@@ -14,7 +14,6 @@ import type { AuthData } from './authReducer';
 export interface ManagerData {
     auth: AuthData;
     clusterStatus: ClusterStatusData;
-    isLdapEnabled: boolean;
     lastUpdated: number | null;
     license: LicenseData;
     maintenance: string;
@@ -35,8 +34,7 @@ const manager: Reducer<ManagerData> = (state = emptyState, action) => {
                 auth: auth(state.auth, action),
                 lastUpdated: action.receivedAt
             };
-        case types.SET_LDAP_ENABLED:
-            return { ...state, isLdapEnabled: action.isLdapEnabled };
+        case types.SET_IDENTITY_PROVIDERS:
         case types.SET_USER_DATA:
             return { ...state, auth: auth(state.auth, action) };
         case types.REQ_CLUSTER_STATUS:

--- a/app/utils/consts.ts
+++ b/app/utils/consts.ts
@@ -27,6 +27,7 @@ export default {
     NO_LICENSE_ERROR_CODE: 'missing_cloudify_license',
     EXPIRED_LICENSE_ERROR_CODE: 'expired_cloudify_license',
 
+    DEFAULT_ADMIN_USERNAME: 'admin',
     DEFAULT_TENANT: 'default_tenant',
     MODE_MAIN: 'main',
     MODE_CUSTOMER: 'customer',

--- a/app/utils/shared/IdpUtils.ts
+++ b/app/utils/shared/IdpUtils.ts
@@ -1,0 +1,16 @@
+import _ from 'lodash';
+import type { ManagerData } from '../../reducers/managerReducer';
+
+export default class IdpUtils {
+    static isLocal(managerData: ManagerData) {
+        return managerData.auth.identityProviders === 'local';
+    }
+
+    static isLdap(managerData: ManagerData) {
+        return managerData.auth.identityProviders.includes('ldap');
+    }
+
+    static isOkta(managerData: ManagerData) {
+        return managerData.auth.identityProviders.includes('okta');
+    }
+}

--- a/app/utils/shared/IdpUtils.ts
+++ b/app/utils/shared/IdpUtils.ts
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import type { ManagerData } from '../../reducers/managerReducer';
 
 export default class IdpUtils {

--- a/app/utils/shared/IdpUtils.ts
+++ b/app/utils/shared/IdpUtils.ts
@@ -2,7 +2,8 @@ import type { ManagerData } from '../../reducers/managerReducer';
 
 export default class IdpUtils {
     static isLocal(managerData: ManagerData) {
-        return managerData.auth.identityProviders === 'local';
+        const { identityProviders } = managerData.auth;
+        return identityProviders.length === 1 && identityProviders[0] === 'local';
     }
 
     static isLdap(managerData: ManagerData) {

--- a/app/utils/stageUtils.ts
+++ b/app/utils/stageUtils.ts
@@ -10,6 +10,7 @@ import { GenericField } from '../components/basic';
 import type { ManagerData } from '../reducers/managerReducer';
 
 import ExecutionUtils from './shared/ExecutionUtils';
+import IdpUtils from './shared/IdpUtils';
 import JsonUtils from './shared/JsonUtils';
 import TimeUtils from './shared/TimeUtils';
 import UrlUtils from './shared/UrlUtils';
@@ -20,6 +21,8 @@ import { isEmptyWidgetData } from './StageAPI';
 
 export default class StageUtils {
     static Execution = ExecutionUtils;
+
+    static Idp = IdpUtils;
 
     static Json = JsonUtils;
 

--- a/backend/handler/AuthHandler.ts
+++ b/backend/handler/AuthHandler.ts
@@ -33,10 +33,6 @@ export function getToken(basicAuth: string) {
     );
 }
 
-export function getTenants(token: string) {
-    return jsonRequest('GET', '/tenants?_get_all_results=true&_include=name', getHeadersWithAuthenticationToken(token));
-}
-
 export function getUser(token: string): Promise<UserResponse> {
     return jsonRequest('GET', '/user?_get_data=true', getHeadersWithAuthenticationToken(token));
 }

--- a/backend/routes/External.ts
+++ b/backend/routes/External.ts
@@ -17,7 +17,7 @@ function pipeRequest(
     url: string,
     queryString: any
 ) {
-    logger.debug(`Piping get request to url: ${url} with query string: ${queryString}`);
+    logger.debug('Piping get request to url:', url, 'with query string:', queryString);
 
     requestAndForwardResponse(url.startsWith('//') ? `http:${url}` : url, res, { params: queryString }).catch(err =>
         res.status(500).send({ message: err.message })

--- a/test/cypress/components/app/sidebar/SideBar_spec.tsx
+++ b/test/cypress/components/app/sidebar/SideBar_spec.tsx
@@ -22,7 +22,7 @@ describe('SideBar', () => {
                     pages,
                     manager: {
                         ...emptyState,
-                        auth: { ...emptyState.auth, username, identityProviders: 'local' },
+                        auth: { ...emptyState.auth, username },
                         tenants: { items: [] },
                         version: { version },
                         license: {}

--- a/test/cypress/components/app/sidebar/SideBar_spec.tsx
+++ b/test/cypress/components/app/sidebar/SideBar_spec.tsx
@@ -4,6 +4,8 @@ import '../../initAppContext';
 import Consts from 'app/utils/consts';
 import SideBar from 'app/components/sidebar/SideBar';
 import { ThemeContext } from 'styled-components';
+import type { ManagerData } from 'app/reducers/managerReducer';
+import { emptyState } from 'app/reducers/managerReducer';
 import { mountWithProvider } from '../../utils';
 
 describe('SideBar', () => {
@@ -18,7 +20,13 @@ describe('SideBar', () => {
                 </ThemeContext.Provider>,
                 {
                     pages,
-                    manager: { auth: { username }, tenants: { items: [] }, version: { version }, license: {} },
+                    manager: {
+                        ...emptyState,
+                        auth: { ...emptyState.auth, username, identityProviders: 'local' },
+                        tenants: { items: [] },
+                        version: { version },
+                        license: {}
+                    } as ManagerData,
                     config: { mode: Consts.MODE_CUSTOMER }
                 }
             );

--- a/test/cypress/integration/widgets/user_groups_spec.ts
+++ b/test/cypress/integration/widgets/user_groups_spec.ts
@@ -5,8 +5,8 @@ describe('User group management widget', () => {
     const ldapGroupColumnName = 'LDAP group';
     const widgetId = 'userGroups';
     const setLdapAvailability = (isEnabled: boolean) => {
-        const ldapResponse = isEnabled ? 'enabled' : 'disabled';
-        cy.intercept('GET', '/console/sp/ldap', ldapResponse);
+        const idpResponse = isEnabled ? 'ldap' : 'local';
+        cy.intercept('GET', '/console/sp/idp', idpResponse);
     };
     const mockPageAndLogin = () => {
         cy.usePageMock(widgetId).mockLogin();

--- a/test/cypress/integration/widgets/user_groups_spec.ts
+++ b/test/cypress/integration/widgets/user_groups_spec.ts
@@ -1,11 +1,12 @@
 import Consts from 'app/utils/consts';
+import type { IdentityProvider } from 'app/reducers/managerReducer/authReducer';
 
 describe('User group management widget', () => {
     const groupName = 'user_groups_test';
     const ldapGroupColumnName = 'LDAP group';
     const widgetId = 'userGroups';
     const setLdapAvailability = (isEnabled: boolean) => {
-        const idpResponse = isEnabled ? 'ldap' : 'local';
+        const idpResponse: IdentityProvider = isEnabled ? 'ldap' : 'local';
         cy.intercept('GET', '/console/sp/idp', idpResponse);
     };
     const mockPageAndLogin = () => {

--- a/test/jest/reducers/managerReducer/managerReducer.test.ts
+++ b/test/jest/reducers/managerReducer/managerReducer.test.ts
@@ -8,6 +8,7 @@ import type { Reducer } from 'redux';
 
 import { getManagerData, login, logout } from 'actions/managers';
 import * as types from 'actions/types';
+import type { ManagerData } from 'reducers/managerReducer';
 import managerReducer, { emptyState } from 'reducers/managerReducer';
 import licenseReducer from 'reducers/managerReducer/licenseReducer';
 import rbac from '../../resources/rbac';
@@ -72,16 +73,13 @@ describe('(Reducer) Manager', () => {
                     expect(store.getState()).toEqual({
                         ...emptyState,
                         auth: {
+                            ...emptyState.auth,
                             username,
                             role,
-                            groupSystemRoles: {},
-                            tenantsRoles: {},
-                            state: 'loggedIn',
-                            error: null,
-                            identityProviders: ''
+                            state: 'loggedIn'
                         },
                         lastUpdated: Date.now()
-                    });
+                    } as ManagerData);
                 });
             });
         });

--- a/test/jest/reducers/managerReducer/managerReducer.test.ts
+++ b/test/jest/reducers/managerReducer/managerReducer.test.ts
@@ -77,7 +77,8 @@ describe('(Reducer) Manager', () => {
                             groupSystemRoles: {},
                             tenantsRoles: {},
                             state: 'loggedIn',
-                            error: null
+                            error: null,
+                            identityProviders: ''
                         },
                         lastUpdated: Date.now()
                     });

--- a/test/jest/utils/Manager.test.ts
+++ b/test/jest/utils/Manager.test.ts
@@ -21,6 +21,7 @@ describe('(Utils) Manager', () => {
                     }
                 },
                 state: 'loggedIn',
+                identityProviders: 'local',
                 error: null
             },
             tenants: {

--- a/test/jest/utils/Manager.test.ts
+++ b/test/jest/utils/Manager.test.ts
@@ -11,6 +11,7 @@ describe('(Utils) Manager', () => {
         manager: {
             ...emptyState,
             auth: {
+                ...emptyState.auth,
                 username: 'admin',
                 role: 'sys_admin',
                 groupSystemRoles: {},
@@ -21,7 +22,6 @@ describe('(Utils) Manager', () => {
                     }
                 },
                 state: 'loggedIn',
-                identityProviders: 'local',
                 error: null
             },
             tenants: {

--- a/widgets/userGroups/src/CreateModal.tsx
+++ b/widgets/userGroups/src/CreateModal.tsx
@@ -1,10 +1,14 @@
-// @ts-nocheck File not migrated fully to TS
-
+import type { FunctionComponent } from 'react';
 import Actions from './actions';
 
 const t = Stage.Utils.getT('widgets.userGroups.modals.create');
 
-export default function CreateModal({ toolbox, isLdapEnabled }) {
+interface CreateModalProps {
+    toolbox: Stage.Types.Toolbox;
+    isLdapEnabled?: boolean;
+}
+
+const CreateModal: FunctionComponent<CreateModalProps> = ({ toolbox, isLdapEnabled = false }) => {
     const { useBoolean, useErrors, useOpen, useInputs } = Stage.Hooks;
 
     const [isLoading, setLoading, unsetLoading] = useBoolean();
@@ -81,9 +85,6 @@ export default function CreateModal({ toolbox, isLdapEnabled }) {
             </Modal.Actions>
         </Modal>
     );
-}
-
-CreateModal.propTypes = {
-    toolbox: Stage.PropTypes.Toolbox.isRequired,
-    isLdapEnabled: PropTypes.bool
 };
+
+export default CreateModal;

--- a/widgets/userGroups/src/UserGroupsTable.tsx
+++ b/widgets/userGroups/src/UserGroupsTable.tsx
@@ -322,7 +322,7 @@ UserGroupsTable.propTypes = {
 
 export default connectToStore(
     state => ({
-        isLdapEnabled: _.get(state, 'manager.isLdapEnabled', false)
+        isLdapEnabled: Stage.Utils.Idp.isLdap(state.manager)
     }),
     {}
 )(UserGroupsTable);

--- a/widgets/userManagement/src/MenuAction.tsx
+++ b/widgets/userManagement/src/MenuAction.tsx
@@ -1,7 +1,7 @@
 // @ts-nocheck File not migrated fully to TS
 import UserPropType from './props/UserPropType';
 
-export default class MenuAction extends React.Component {
+class MenuAction extends React.Component {
     static CHANGE_PASSWORD_ACTION = 'password';
 
     static EDIT_TENANTS_ACTION = 'tenants';
@@ -29,16 +29,18 @@ export default class MenuAction extends React.Component {
 
     render() {
         const { PopupMenu, Menu } = Stage.Basic;
+        const { item, isLocalIdp } = this.props;
+        const canChangePassword = isLocalIdp || item.username === Stage.Common.Consts.adminUsername;
 
         return (
             <PopupMenu>
                 <Menu pointing vertical>
-                    <Menu.Item
+                    {canChangePassword && <Menu.Item
                         icon="lock"
                         content="Change password"
                         name={MenuAction.CHANGE_PASSWORD_ACTION}
                         onClick={this.actionClick}
-                    />
+                    />}
                     <Menu.Item
                         icon="users"
                         content="Edit user's groups"
@@ -63,4 +65,15 @@ export default class MenuAction extends React.Component {
     }
 }
 
-MenuAction.propTypes = { item: UserPropType.isRequired, onSelectAction: PropTypes.func.isRequired };
+MenuAction.propTypes = {
+    item: UserPropType.isRequired,
+    onSelectAction: PropTypes.func.isRequired,
+    isLocalIdp: PropTypes.bool.isRequired
+};
+
+export default connectToStore(
+    state => ({
+        isLocalIdp: Stage.Utils.Idp.isLocal(state.manager)
+    }),
+    {}
+)(MenuAction);

--- a/widgets/userManagement/src/MenuAction.tsx
+++ b/widgets/userManagement/src/MenuAction.tsx
@@ -35,12 +35,14 @@ class MenuAction extends React.Component {
         return (
             <PopupMenu>
                 <Menu pointing vertical>
-                    {canChangePassword && <Menu.Item
-                        icon="lock"
-                        content="Change password"
-                        name={MenuAction.CHANGE_PASSWORD_ACTION}
-                        onClick={this.actionClick}
-                    />}
+                    {canChangePassword && (
+                        <Menu.Item
+                            icon="lock"
+                            content="Change password"
+                            name={MenuAction.CHANGE_PASSWORD_ACTION}
+                            onClick={this.actionClick}
+                        />
+                    )}
                     <Menu.Item
                         icon="users"
                         content="Edit user's groups"


### PR DESCRIPTION
## Description

The main idea behind this PR is to align password changing restrictions along Cloudify UI application. For more details and requirements see RD-1051.

List of main changes:
* introduced `identityProviders` parameter inside Redux store (replaced `isLdapEnabled` parameter)
* used `identityProviders` in sidebar's user menu and User Management widget (Change Password option visibility)
* used `identityProviders` in User Groups Management widget (LDAP options visibility)

## Screenshots / Videos
N/A

## Checklist
- [x] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [x] I verified that all tests and checks have passed.
- [x] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [x] I added proper labels to this PR.

## Tests
1. Updated tests (unit, component, e2e).
2. Full system tests run [![Build Status](https://jenkins.cloudify.co/buildStatus/icon?job=Stage-UI-System-Test&build=2719)](https://jenkins.cloudify.co/view/UI%20Health%20View/job/Stage-UI-System-Test/2719/) - all passed.
3. Another full system tests run [![Build Status](https://jenkins.cloudify.co/buildStatus/icon?job=Stage-UI-System-Test&build=2728)](https://jenkins.cloudify.co/view/UI%20Health%20View/job/Stage-UI-System-Test/2728/) - failed one test (`servers_num_spec.ts`), executed locally and it passed, so I consider it as an one-time issue not related to this PR changes.

## Documentation
I don't see a place requiring update.
