### PR TITLE
RD-5032 Improve robustness of Getting Started spec

### DIFF
--- a/test/cypress/integration/getting_started_spec.ts
+++ b/test/cypress/integration/getting_started_spec.ts
@@ -141,7 +141,7 @@ describe('Getting started modal', () => {
 
     describe('without mocked pages', () => {
         beforeEach(() => {
-            cy.mockLogin({ disableGettingStarted: false });
+            cy.mockLoginWithoutWaiting({ disableGettingStarted: false }).waitUntilAppLoaded();
         });
 
         it('should redirect to the dashboard page upon canceling the modal process', () => {


### PR DESCRIPTION
## Description

The flakiness in Getting Started spec (`beforeEach` hook in `without mocked pages` tests) was due to the fact that after the splash screen disappears, not always Dashboard page is displayed. `mockLogin` expects a Dashboard page to be displayed and it waits for all widgets to be loaded. It can happen that Getting Started modal appears just after splash screen and there's no Dashboard (nor widgets) displayed.

So I decided to omit waiting for widgets to be loaded and wait only for splash screen to disappear.

## Screenshots / Videos
N/A

## Checklist
- [x] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [x] I verified that all tests and checks have passed.
- [x] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [x] I added proper labels to this PR.

## Tests
1. [![Build Status](https://jenkins.cloudify.co/buildStatus/icon?job=Stage-UI-System-Test&build=2808)](https://jenkins.cloudify.co/job/Stage-UI-System-Test/2808/) (only Getting Started spec) (27th May 2022)
2. [![Build Status](https://jenkins.cloudify.co/buildStatus/icon?job=Stage-UI-System-Test&build=2813)](https://jenkins.cloudify.co/job/Stage-UI-System-Test/2813/) (only Getting Started spec) (30th May 2022)

## Documentation
N/A