### PR TITLE
RD-1349 Move SAML configuration and Cloudify API timeouts parameters to the user configuration

### DIFF
--- a/conf/README.md
+++ b/conf/README.md
@@ -7,13 +7,6 @@ The following section describes different configuration files used in cloudify-s
 * `maintenancePollingInterval` - integer, time interval for Manager status polling (milliseconds) 
 * `singleManager` - boolean, defines if Manager is executed as single (depracated)
 
-* `proxy` - object, configuration of Stage Backend proxy to Manager 
-  * `timeouts`
-    * `get` - integer, GET request timeout (milliseconds)
-    * `post` - integer, POST request timeout (milliseconds)
-    * `put` - integer, PUT request timeout (milliseconds)
-    * `delete` - integer, DELETE request timeout (milliseconds)
-
 * `github` - object, configuration for accessing GitHub resources
   * `username` - string, GitHub username secret name, eg. "secret(github-username)"
   * `password` - string, GitHub password secret name, eg. "secret(github-password)"
@@ -31,12 +24,6 @@ The following section describes different configuration files used in cloudify-s
 
 * `ssl` - object, configuration for SSL connection
   * `ca` - string, absolute path to SSL CA certificate
-  
-* `saml` - object, SAML configuration
-  * `enabled` - boolean, if set to true SAML will be enabled
-  * `certPath` - string, SAML certificate path
-  * `ssoUrl` - string, redirect URL to the application at the Single Sign-On identity provider
-  * `portalUrl` - string, redirect URL to the organization portal
 
 ## Application (`app.json`)
 
@@ -76,6 +63,19 @@ This configuration can be overridden by: `/dist/userData/userConfig.json`.
   * `tilesUrlTemplate` - string, template map tiles provider URL, check URL template section at [TileLayer page](https://leafletjs.com/reference-1.5.0.html#tilelayer) for details
   * `attribution` -  string, attribution data to be displayed as small text box on a map,  HTML allowed, it is required by map providers, check [Leaflet-providers preview](https://leaflet-extras.github.io/leaflet-providers/preview/) for examples and requirements from different providers
   * `accessToken` - string, API key to be passed to map tile tiles provider 
+
+* `proxy` - object, configuration of Stage Backend proxy to Manager
+  * `timeouts`
+    * `get` - integer, GET request timeout (milliseconds)
+    * `post` - integer, POST request timeout (milliseconds)
+    * `put` - integer, PUT request timeout (milliseconds)
+    * `delete` - integer, DELETE request timeout (milliseconds)
+
+* `saml` - object, SAML configuration
+  * `enabled` - boolean, if set to true SAML will be enabled
+  * `certPath` - string, SAML certificate path
+  * `ssoUrl` - string, redirect URL to the application at the Single Sign-On identity provider
+  * `portalUrl` - string, redirect URL to the organization portal
 
 * `whiteLabel` - object, UI white-labelling configuration
   * `logoUrl` - string, relative URL to logo image

--- a/conf/config.json
+++ b/conf/config.json
@@ -2,14 +2,6 @@
     "maintenancePollingInterval": 10000,
     "singleManager": true,
 
-    "proxy": {
-        "timeouts": {
-            "get": 10000,
-            "post": 30000,
-            "put": 30000,
-            "delete": 10000
-        }
-    },
     "github": {
         "username": "secret(github-username)",
         "password": "secret(github-password)"
@@ -27,11 +19,5 @@
     },
     "ssl": {
         "ca": "/etc/cloudify/ssl/cloudify_internal_ca_cert.pem"
-    },
-    "saml":{
-        "enabled": false,
-        "certPath": "",
-        "ssoUrl": "",
-        "portalUrl": ""
     }
 }

--- a/conf/userConfig.json
+++ b/conf/userConfig.json
@@ -3,6 +3,20 @@
     "tilesUrlTemplate": "https://tiles.stadiamaps.com/tiles/osm_bright/${z}/${x}/${y}${r}.png?api_key=${accessToken}",
     "attribution": "&copy; <a href=\"https://stadiamaps.com/\">Stadia Maps</a>, &copy; <a href=\"https://openmaptiles.org/\">OpenMapTiles</a> &copy; <a href=\"http://openstreetmap.org\">OpenStreetMap</a> contributors"
   },
+  "proxy": {
+    "timeouts": {
+      "get": 10000,
+      "post": 30000,
+      "put": 30000,
+      "delete": 10000
+    }
+  },
+  "saml":{
+    "enabled": false,
+    "certPath": "",
+    "ssoUrl": "",
+    "portalUrl": ""
+  },
   "whiteLabel": {
     "logoUrl": "",
     "mainColor": "#0077FC",


### PR DESCRIPTION
## Description
This PR simply moves two sections from internal configuration (`config.json`) into user configuration which is part of the snapshot (`userData/userConfig.json`). See RD-1349 for reasoning.

## Screenshots / Videos
N/A

## Checklist
- [x] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [ ] I verified that all tests and checks have passed.
- [x] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [x] I added proper labels to this PR.

## Tests
TODO

## Documentation
User documentation update PR - 
