### PR TITLE
RD-4254 Set minimal width for the main layout

### DIFF
--- a/app/components/layout/Grid.tsx
+++ b/app/components/layout/Grid.tsx
@@ -1,13 +1,10 @@
 import _ from 'lodash';
-import PropTypes from 'prop-types';
-import type { CSSProperties, PropsWithChildren, ReactNode } from 'react';
+import type { CSSProperties, FunctionComponent, ReactNode } from 'react';
 import React from 'react';
 import type { ReactGridLayoutProps } from 'react-grid-layout';
-import { Responsive } from 'react-grid-layout';
+import ReactGridLayout from 'react-grid-layout';
 import { useWidthObserver } from '../../utils/hooks';
 import GridItem from './GridItem';
-
-const ReactGridLayout = Responsive;
 
 interface GridProps {
     isEditMode: boolean;
@@ -15,7 +12,7 @@ interface GridProps {
     style?: CSSProperties;
 }
 
-export default function Grid({ children, isEditMode, onGridDataChange, style }: PropsWithChildren<GridProps>) {
+const Grid: FunctionComponent<GridProps> = ({ children, isEditMode, onGridDataChange, style }) => {
     const [wrapperRef, getWidth] = useWidthObserver();
 
     const saveChangedItems: ReactGridLayoutProps['onLayoutChange'] = layout => {
@@ -66,8 +63,7 @@ export default function Grid({ children, isEditMode, onGridDataChange, style }: 
             {width && (
                 <ReactGridLayout
                     className={['layout', isEditMode && 'isEditMode'].join(' ')}
-                    breakpoints={{ lg: 1000, md: 800, sm: 640, xs: 320, xxs: 0 }}
-                    cols={{ lg: 12, md: 10, sm: 8, xs: 6, xxs: 2 }}
+                    cols={12}
                     rowHeight={10}
                     onLayoutChange={saveChangedItems}
                     isDraggable={isEditMode}
@@ -82,15 +78,5 @@ export default function Grid({ children, isEditMode, onGridDataChange, style }: 
             )}
         </div>
     );
-}
-
-Grid.propTypes = {
-    children: PropTypes.node.isRequired,
-    onGridDataChange: PropTypes.func.isRequired,
-    isEditMode: PropTypes.bool.isRequired,
-    style: PropTypes.shape({})
 };
-
-Grid.defaultProps = {
-    style: undefined
-};
+export default Grid;

--- a/app/styles/style.scss
+++ b/app/styles/style.scss
@@ -21,6 +21,7 @@ a:hover {
 }
 
 .main {
+  min-width: 1100px;
   overflow: auto;
 
   .sidebar {

--- a/widgets/common/src/blueprintMarketplace/BlueprintMarketplaceModal.tsx
+++ b/widgets/common/src/blueprintMarketplace/BlueprintMarketplaceModal.tsx
@@ -18,7 +18,7 @@ const getPageLayout = (tabs: MarketplaceTab[], displayStyle: MarketplaceDisplayS
             id: `blueprint-catalog-${index}`,
             name: t('modal.blueprintCatalogName'),
             height: 24,
-            maximized: true,
+            width: 12,
             definition: 'blueprintCatalog',
             configuration: {
                 jsonPath: tab.url,

--- a/widgets/plugins/src/MarketplaceModal.tsx
+++ b/widgets/plugins/src/MarketplaceModal.tsx
@@ -7,7 +7,7 @@ const modalContentLayout: { type: 'widgets'; content: any } = {
             id: 'pluginsCatalog',
             name: t('upload.catalog'),
             height: 24,
-            maximized: true,
+            width: 12,
             definition: 'pluginsCatalog',
             configuration: { jsonPath: Stage.i18n.t('urls.pluginsCatalog') }
         }


### PR DESCRIPTION
## Description

According to recently settled requirement: "Minimal supported screen width: 1280px" and decision to use horizontal scrollbar for smaller screens, I have adjusted minimal width for `div.main` element.

In addition to the main change I did the following:
* Used `ReactGridLayout` component with fixed number of columns (no need to use responsive grid with minimal width set)
* Fixed content of blueprint and plugin marketplace modals to always use full width of the modal (using `maximized` does not work, RD-5023 should make it possible to use `maximized` in layout definition JSON)

## Screenshots / Videos
https://user-images.githubusercontent.com/5202105/176841106-23ab05a9-b5cb-4ca9-a8e6-7bf1c0d2535d.mp4

## Checklist
- [x] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [x] I verified that all tests and checks have passed.
- [x] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [x] I added proper labels to this PR.

## Tests
1. I did many manual tests - didn't spot any issues
2. [![Build Status](https://jenkins.cloudify.co/buildStatus/icon?job=Stage-UI-System-Test&build=3024)](https://jenkins.cloudify.co/view/UI%20Health%20View/job/Stage-UI-System-Test/3024/) - PASSED (one test failed - known issue - RD-5020)

## Documentation
I don't think we need any update right now.
There's RD-4998 to document supported screen size, which seems enough.