### PR TITLE
RD-5153 Improve 'Getting started' column header styling in Users Management widget

### DIFF
--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -1450,7 +1450,7 @@
                 "lastLoginAt": "Last login",
                 "isAdmin": "Admin",
                 "active": "Active",
-                "showGettingStarted": "Getting\nstarted",
+                "showGettingStarted": "Getting started",
                 "groupCount": "# Groups",
                 "tenantCount": "# Tenants"
             }

--- a/widgets/userManagement/src/UsersTable.tsx
+++ b/widgets/userManagement/src/UsersTable.tsx
@@ -349,8 +349,9 @@ export default class UsersTable extends React.Component {
                     <DataTable.Column label={columnT('isAdmin')} width="10%" />
                     <DataTable.Column label={columnT('active')} name="active" width="10%" />
                     <DataTable.Column
-                        label={Stage.Utils.renderMultilineText(columnT('showGettingStarted'))}
+                        label={columnT('showGettingStarted')}
                         name="show_getting_started"
+                        style={{ whiteSpace: 'normal' }}
                         width="10%"
                     />
                     <DataTable.Column label={columnT('groupCount')} width="10%" />


### PR DESCRIPTION
## Description
This PR is a follow-up for #2038 and it:
1. Fixes `user_management_spec.ts`
2. Improves "Getting started" column header styling in Users Management widget

## Screenshots / Videos
"Getting started" column header is being adjusted automatically (single line when screen width is high, two lines when screen width is lower). Before it was always displayed in two lines.

https://user-images.githubusercontent.com/5202105/177487644-3a2288f9-ce57-49a0-b752-421a00fb5159.mp4

## Checklist
- [x] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [x] I verified that all tests and checks have passed.
- [x] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [x] I added proper labels to this PR.

## Tests
[![Build Status](https://jenkins.cloudify.co/buildStatus/icon?job=Stage-UI-System-Test&build=3062)](https://jenkins.cloudify.co/view/UI%20Health%20View/job/Stage-UI-System-Test/3062/) - only `user_management_spec.ts` - in progress

## Documentation
N/A