### PR TITLE
RD-5365 Fix Topology widget data loading

### DIFF
--- a/widgets/common/src/inputs/fields/ValueListInputField.tsx
+++ b/widgets/common/src/inputs/fields/ValueListInputField.tsx
@@ -1,3 +1,4 @@
+import { map } from 'lodash';
 import { PositionedRevertToDefaultIcon } from './RevertToDefaultIcon';
 import type { ErrorAwareInputFieldProps, RevertableInputFieldProps } from './types';
 
@@ -7,15 +8,27 @@ type ValueListInputFieldProps = ErrorAwareInputFieldProps &
         multiple: boolean;
     };
 
+const isStringifiedNumber = (value: unknown): boolean => {
+    return typeof value === 'string' && !Number.isNaN(+value);
+};
+
+const parseOptionValue = (value: ValueListInputFieldProps['validValues'][0]) => {
+    return isStringifiedNumber(value) ? `"${value}"` : value;
+};
+
 export default function ValueListInputField(props: ValueListInputFieldProps) {
     const { Form } = Stage.Basic;
-    const { name, value, onChange, error, validValues, multiple = false } = props;
+    const { name, value, onChange, error, validValues, multiple = false, defaultValue } = props;
 
-    const options = _.map(validValues, validValue => ({
-        name: validValue,
-        text: validValue,
-        value: validValue
-    }));
+    const options = map(validValues, validValue => {
+        const parsedOptionValue = parseOptionValue(validValue);
+
+        return {
+            name: validValue,
+            text: validValue,
+            value: parsedOptionValue
+        };
+    });
 
     return (
         <>
@@ -28,6 +41,7 @@ export default function ValueListInputField(props: ValueListInputFieldProps) {
                 options={options}
                 onChange={onChange}
                 multiple={multiple}
+                defaultValue={defaultValue}
             />
             <PositionedRevertToDefaultIcon {...props} right={30} />
         </>

--- a/widgets/topology/src/Topology.tsx
+++ b/widgets/topology/src/Topology.tsx
@@ -30,6 +30,7 @@ interface TopologyProps {
     configuration: unknown;
     data: {
         blueprintDeploymentData: unknown;
+        componentDeploymentsData: unknown;
         icons: Record<string, string>;
         layout: unknown;
     };
@@ -397,11 +398,11 @@ Topology.propTypes = {
     blueprintId: PropTypes.string,
     deploymentId: PropTypes.string,
     configuration: PropTypes.shape({
-        showToolbar: PropTypes.boolean,
-        enableGroupClick: PropTypes.boolean,
-        enableNodeClick: PropTypes.boolean,
-        enableZoom: PropTypes.boolean,
-        enableDrag: PropTypes.boolean
+        showToolbar: PropTypes.bool,
+        enableGroupClick: PropTypes.bool,
+        enableNodeClick: PropTypes.bool,
+        enableZoom: PropTypes.bool,
+        enableDrag: PropTypes.bool
     }),
     data: PropTypes.shape({
         blueprintDeploymentData: PropTypes.shape({}),

--- a/widgets/topology/src/Topology.tsx
+++ b/widgets/topology/src/Topology.tsx
@@ -9,19 +9,7 @@ import TerraformDetailsModal from './TerraformDetailsModal';
 const saveConfirmationTimeout = 2500;
 
 function isNodesChanged(topologyNodes, newNodes) {
-    // compare # of nodes
-    if (topologyNodes.length !== newNodes.length) {
-        return true;
-    }
-
-    // compare node names, and if in the same order
-    for (let i = 0; i < topologyNodes.length; i += 1) {
-        if (topologyNodes[i].name !== newNodes[i].name) {
-            return true;
-        }
-    }
-
-    return false;
+    return !_.isEqual(topologyNodes, newNodes);
 }
 
 interface TopologyProps {

--- a/widgets/topology/src/Topology.tsx
+++ b/widgets/topology/src/Topology.tsx
@@ -87,18 +87,19 @@ export default class Topology extends React.Component<TopologyProps, TopologySta
         const { blueprintId, configuration, data } = this.props;
         const { expandedDeployments, expandedTerraformNodes } = this.state;
 
-        const topologyRestartAndUpdateRequired =
+        const topologyRestartRequired =
             configuration !== prevProps.configuration ||
             blueprintId !== prevProps.blueprintId ||
             !_.isEqual(data.icons, prevProps.data.icons);
 
         const topologyUpdateRequired =
+            topologyRestartRequired ||
             !_.isEqual(data.blueprintDeploymentData, prevProps.data.blueprintDeploymentData) ||
             expandedDeployments !== prevState.expandedDeployments ||
             expandedTerraformNodes !== prevState.expandedTerraformNodes;
 
-        if (topologyRestartAndUpdateRequired) this.startTopology();
-        if (topologyRestartAndUpdateRequired || topologyUpdateRequired) this.updateTopology();
+        if (topologyRestartRequired) this.startTopology();
+        if (topologyUpdateRequired) this.updateTopology();
     }
 
     componentWillUnmount() {


### PR DESCRIPTION
## Description
As described in RD-5365 the topology view didn't load on second time open.
The reason for that problem was the fact that topology data was set (`topology.setTopology` calls in [widgets/topology/src/Topology.tsx](https://github.com/cloudify-cosmo/cloudify-stage/blob/master/widgets/topology/src/Topology.tsx)) only in case of blueprint data update. On `Topology` component mount the view was not initialized properly.

Small refactorings added: 
1. fixed `propTypes` definition
2. simplified nodes difference checking function

NOTE: This widget is hard to maintain (it's using non-React library for rendering the view) and the code is very messy. I considered TS migration, but I decided to drop it as a time-consuming and risky before the release.

## Screenshots / Videos

https://user-images.githubusercontent.com/5202105/179209766-a429fd00-3377-4e7d-854e-a8326754b004.mp4


## Checklist
- [x] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [x] I verified that all tests and checks have passed.
- [x] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [x] I added proper labels to this PR.

## Tests
1. Topology spec passes locally
2. [![Build Status](https://jenkins.cloudify.co/buildStatus/icon?job=Stage-UI-System-Test&build=3148)](https://jenkins.cloudify.co/view/UI%20Health%20View/job/Stage-UI-System-Test/3148/) - PASSED

## Documentation
N/A
