### PR TITLE
RD-5301: Synchronized mechanism for scanning zip and git files

### DIFF
--- a/backend/routes/Terraform.ts
+++ b/backend/routes/Terraform.ts
@@ -152,7 +152,11 @@ const getTfFileBufferListFromGitRepositoryUrl = async (url: string, resourceLoca
             return;
         }
         const mainPath = path.dirname(filePath);
-        files.push(filePath);
+
+        const smthPath = path.join(mainPath, 'main.tf');
+        if (fs.existsSync(smthPath)) {
+            files.push(smthPath);
+        }
 
         const outputsPath = path.join(mainPath, 'outputs.tf');
         if (fs.existsSync(outputsPath)) {
@@ -164,6 +168,8 @@ const getTfFileBufferListFromGitRepositoryUrl = async (url: string, resourceLoca
             files.push(variablesPath);
         }
     });
+
+    logger.error(files.length);
 
     const fileBufferList = files.map(filePath => {
         return fs.readFileSync(filePath);
@@ -295,6 +301,8 @@ async function getTerraformFileBufferListFromZip(zipBuffer: Buffer, resourceLoca
     ];
 
     const files = await decompress(zipBuffer);
+
+    logger.error(files.length);
     return files.filter(file => acceptableFilePaths.includes(`${file.path}`)).map(file => file?.data);
 }
 

--- a/backend/routes/Terraform.ts
+++ b/backend/routes/Terraform.ts
@@ -166,8 +166,6 @@ const getTfFileBufferListFromGitRepositoryUrl = async (url: string, resourceLoca
         });
     });
 
-    logger.error(files.length);
-
     const fileBufferList = files.map(filePath => {
         return fs.readFileSync(filePath);
     });
@@ -294,8 +292,6 @@ async function getTerraformFileBufferListFromZip(zipBuffer: Buffer, resourceLoca
     const acceptableFilePaths = getTerraformFilePaths(resourceLocationTrimmed);
 
     const files = await decompress(zipBuffer);
-
-    logger.error(files.length);
     return files.filter(file => acceptableFilePaths.includes(`${file.path}`)).map(file => file?.data);
 }
 

--- a/backend/routes/Terraform.ts
+++ b/backend/routes/Terraform.ts
@@ -35,6 +35,7 @@ const templatePath = path.resolve(__dirname, '../templates/terraform');
 const template = fs.readFileSync(path.resolve(templatePath, 'blueprint.ejs'), 'utf8');
 // NOTE: The idea behind the code below has been described in more details here: https://serverfault.com/questions/544156/git-clone-fail-instead-of-prompting-for-credentials
 const disableGitAuthenticationPromptOption = '-c core.askPass=echo';
+const terraformFilesToScan = ['main.tf', 'outputs.tf', 'variables.tf'];
 
 router.use(express.json());
 
@@ -46,6 +47,10 @@ type ResourcesRequest = Request<
         templateUrl: string;
     }
 >;
+
+const getTerraformFilePaths = (pathPrefix: string): string[] => {
+    return terraformFilesToScan.map(fileName => path.join(pathPrefix, fileName));
+};
 
 const throwExceptionIfModuleListEmpty = (modules: string[]) => {
     if (modules.length === 0) throw new Error("Couldn't find a Terraform module in the provided package");
@@ -152,21 +157,13 @@ const getTfFileBufferListFromGitRepositoryUrl = async (url: string, resourceLoca
             return;
         }
         const mainPath = path.dirname(filePath);
+        const acceptableFilePaths = getTerraformFilePaths(mainPath);
 
-        const smthPath = path.join(mainPath, 'main.tf');
-        if (fs.existsSync(smthPath)) {
-            files.push(smthPath);
-        }
-
-        const outputsPath = path.join(mainPath, 'outputs.tf');
-        if (fs.existsSync(outputsPath)) {
-            files.push(outputsPath);
-        }
-
-        const variablesPath = path.join(mainPath, 'variables.tf');
-        if (fs.existsSync(variablesPath)) {
-            files.push(variablesPath);
-        }
+        acceptableFilePaths.forEach(acceptableFilePath => {
+            if (fs.existsSync(acceptableFilePath)) {
+                files.push(acceptableFilePath);
+            }
+        });
     });
 
     logger.error(files.length);
@@ -294,11 +291,7 @@ router.post('/resources', async (req: ResourcesRequest, res) => {
 
 async function getTerraformFileBufferListFromZip(zipBuffer: Buffer, resourceLocation: string) {
     const resourceLocationTrimmed = trimStart(resourceLocation, '/');
-    const acceptableFilePaths = [
-        `${resourceLocationTrimmed}/main.tf`,
-        `${resourceLocationTrimmed}/outputs.tf`,
-        `${resourceLocationTrimmed}/variables.tf`
-    ];
+    const acceptableFilePaths = getTerraformFilePaths(resourceLocationTrimmed);
 
     const files = await decompress(zipBuffer);
 


### PR DESCRIPTION
<!--- Provide JIRA issue ID and a general summary of your changes in the Title above -->
<!--- e.g. "RD-1234 Improve styling in SuperComponent" -->
<!--- Note that the title is used as a commit message after merging the PR -->

## Description
<!--- Describe your changes to help reviewers understand the details. -->
Issue was caused by not scanning `main.tf` file via processing mechanism for `.git` files
Solution for getting all the necessary file paths to scan has been unified across mechanisms responsible for processing `.git` and `.zip` files, to make it more robust and bulletproof 🎸 

## Screenshots / Videos
<!--- If applicable, add screenshot(s) or video(s) describing the changes you made. -->
<!--- Consider adding comparison screenshot(s) - before and after the change. -->
<!--- If not applicable, just write “N/A” in this section. -->


https://user-images.githubusercontent.com/89005877/179215616-de009811-7f7e-44b3-adad-1afb56a467d8.mp4


https://user-images.githubusercontent.com/89005877/179215646-f254b665-773e-493e-9be0-3b913215b44a.mp4



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [x] I verified that all tests and checks have passed.
- [x] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [x] I added proper labels to this PR.

## Tests
<!--- If applicable, describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If applicable, provide a link to system tests, e.g: -->
<!--- [#1039](https://jenkins.cloudify.co/.../1039) (2021-08-06 07:05:50) --> 
<!--- If not applicable, just write “N/A” in this section. -->

[![Build Status](https://jenkins.cloudify.co/buildStatus/icon?job=Stage-UI-System-Test&build=3158)](https://jenkins.cloudify.co/view/UI%20Health%20View/job/Stage-UI-System-Test/3158/)
2 case scenario had failed, but not due to the introduced modifications
From analyzing the video from [artefacts](https://jenkins.cloudify.co/view/UI%20Health%20View/job/Stage-UI-System-Test/3158/artifact/cloudify-stage/test/cypress/videos/widgets/), it seems like the issue is related to appearing `GettingStartedModal`, which is blocking the UI and therefor some click commands are failing.
The issue is appearing on 2 last test scenarios, so it may be related to the [before method](https://github.com/cloudify-cosmo/cloudify-stage/blob/dad9ec133fd5beef06bb1cc75c16bb63f8c8ad17/test/cypress/integration/widgets/blueprints_spec.ts#L812-L815) of one of the last `describe` blocks

### Image with `GettingStartedModal` blocking the view
![image](https://user-images.githubusercontent.com/89005877/179467780-e829ba77-686b-45e6-988b-c54cc7960277.png)

As the issue is not related to my modifications, I consider this test execution a success 🚀 

## Documentation
<!--- If applicable, describe how you documented or plan to document your changes. -->
<!--- Check UI documentation guidelines - https://cloudifysource.atlassian.net/l/c/EYWJ0XfB - for details. -->
<!--- Provide links to JIRA issues, other PRs or related documentation pages. -->
<!--- If not applicable, just write “N/A” in this section. -->

N/A