### PR TITLE
RD-5371 Fix support for `placeHolder` widget configuration parameter

### DIFF
--- a/app/components/EditWidget.tsx
+++ b/app/components/EditWidget.tsx
@@ -1,12 +1,18 @@
-// @ts-nocheck File not migrated fully to TS
-
-import PropTypes from 'prop-types';
-
 import React, { useState } from 'react';
+import type { FunctionComponent } from 'react';
 import EditWidgetIcon from './EditWidgetIcon';
+import type { EditWidgetIconProps } from './EditWidgetIcon';
 import EditWidgetModal from './EditWidgetModal';
+import type { Widget } from '../utils/StageAPI';
+import type { WidgetOwnProps } from './shared/widgets/Widget';
 
-function EditWidget({ iconSize, onWidgetEdited, widget }) {
+interface EditWidgetProps {
+    widget: Widget;
+    onWidgetEdited: NonNullable<WidgetOwnProps<any>['onWidgetUpdated']>;
+    iconSize: EditWidgetIconProps['size'];
+}
+
+const EditWidget: FunctionComponent<EditWidgetProps> = ({ iconSize, onWidgetEdited, widget }) => {
     const [configShown, setShowConfig] = useState(false);
     const configuration = widget.configuration || {};
     const configDef = widget.definition.initialConfiguration || [];
@@ -24,19 +30,5 @@ function EditWidget({ iconSize, onWidgetEdited, widget }) {
             />
         </span>
     );
-}
-
-EditWidget.propTypes = {
-    widget: PropTypes.shape({
-        configuration: PropTypes.shape({}),
-        definition: PropTypes.shape({
-            initialConfiguration: PropTypes.arrayOf(PropTypes.shape({}))
-        }).isRequired
-    }).isRequired,
-    onWidgetEdited: PropTypes.func.isRequired,
-    // iconSize is an optional forwarded prop
-    // eslint-disable-next-line react/require-default-props
-    iconSize: PropTypes.string
 };
-
 export default EditWidget;

--- a/app/components/EditWidgetIcon.tsx
+++ b/app/components/EditWidgetIcon.tsx
@@ -1,29 +1,23 @@
-// @ts-nocheck File not migrated fully to TS
-import PropTypes from 'prop-types';
 import React from 'react';
+import type { FunctionComponent } from 'react';
+import type { IconProps } from 'semantic-ui-react';
 import { Icon } from './basic/index';
 
-export default function EditWidgetIcon({ onShowConfig, size }) {
-    return (
-        <Icon
-            name="setting"
-            link
-            size={size}
-            className="editWidgetIcon"
-            onClick={event => {
-                event.stopPropagation();
-                onShowConfig();
-            }}
-        />
-    );
+export interface EditWidgetIconProps {
+    onShowConfig: () => void;
+    size?: IconProps['size'];
 }
 
-EditWidgetIcon.propTypes = {
-    onShowConfig: PropTypes.func.isRequired,
-    size: PropTypes.string
-};
-
-EditWidgetIcon.defaultProps = {
-    // Use the default icon size
-    size: undefined
-};
+const EditWidgetIcon: FunctionComponent<EditWidgetIconProps> = ({ onShowConfig, size }) => (
+    <Icon
+        name="setting"
+        link
+        size={size}
+        className="editWidgetIcon"
+        onClick={(event: Event) => {
+            event.stopPropagation();
+            onShowConfig();
+        }}
+    />
+);
+export default EditWidgetIcon;

--- a/app/components/EditWidgetModal.tsx
+++ b/app/components/EditWidgetModal.tsx
@@ -1,35 +1,67 @@
-// @ts-nocheck File not migrated fully to TS
 import i18n from 'i18next';
-import _ from 'lodash';
-import PropTypes from 'prop-types';
+import { get, isEmpty, noop } from 'lodash';
+import type { FunctionComponent } from 'react';
 import React, { useCallback, useEffect, useState } from 'react';
+import type { GenericFieldProps } from 'cloudify-ui-components';
 import { getToolbox } from '../utils/Toolbox';
 
 import { ApproveButton, CancelButton, Form, GenericField, Message, Modal } from './basic';
+import type { WidgetConfigurationDefinition, Widget } from '../utils/StageAPI';
+import type { WidgetOwnProps } from './shared/widgets/Widget';
 
-const getInitialFields = (configDef, configuration) =>
+type Fields = Record<string, any>;
+type Configuration = Record<string, unknown>;
+
+const getInitialFields: (configDef: WidgetConfigurationDefinition[], configuration: Configuration) => Fields = (
+    configDef,
+    configuration
+) =>
     configDef
         .filter(config => !config.hidden)
-        .reduce((fields, config) => {
-            fields[config.id] = _.get(configuration, `[${config.id}]`, config.value || config.default);
+        .reduce((fields: Record<string, any>, config) => {
+            fields[config.id] = get(configuration, `[${config.id}]`, config.value || config.default);
             return fields;
         }, {});
 
-function EditWidgetGenericField({ fields, setFields, ...restProps }) {
-    const handleInputChange = (proxy, field) => {
+interface EditWidgetGenericFieldProps extends GenericFieldProps {
+    fields: Fields;
+    setFields: (fields: Fields) => void;
+}
+const EditWidgetGenericField: FunctionComponent<EditWidgetGenericFieldProps> = ({
+    fields,
+    setFields,
+    ...restProps
+}) => {
+    const handleInputChange: GenericFieldProps['onChange'] = (_proxy, field) => {
         const { name } = field;
         const value = GenericField.formatValue(
             restProps.type,
             restProps.type === GenericField.BOOLEAN_TYPE ? field.checked : field.value
         );
 
-        setFields({ ...fields, [name]: value });
+        if (name) setFields({ ...fields, [name]: value });
     };
     return <GenericField onChange={handleInputChange} {...restProps} />;
+};
+
+interface EditWidgetModalProps {
+    configuration: Configuration;
+    configDef: WidgetConfigurationDefinition[];
+    widget: Widget;
+    show: boolean;
+    onWidgetEdited: NonNullable<WidgetOwnProps<any>['onWidgetUpdated']>;
+    onHideConfig: () => void;
 }
 
-export default function EditWidgetModal({ configDef, configuration, show, onHideConfig, onWidgetEdited, widget }) {
-    const [fields, setFields] = useState(getInitialFields(configDef, configuration));
+const EditWidgetModal: FunctionComponent<EditWidgetModalProps> = ({
+    configDef,
+    configuration,
+    show,
+    onHideConfig,
+    onWidgetEdited,
+    widget
+}) => {
+    const [fields, setFields] = useState<Fields>(getInitialFields(configDef, configuration));
 
     useEffect(() => {
         if (show) setFields(getInitialFields(configDef, configuration));
@@ -70,15 +102,15 @@ export default function EditWidgetModal({ configDef, configuration, show, onHide
                                 type={config.type}
                                 key={config.id}
                                 name={config.id}
-                                label={config.name}
+                                label={config.name || ''}
                                 value={fields[config.id]}
                                 columns={config.columns}
                                 placeholder={config.placeHolder}
-                                widgetlessToolbox={getToolbox(undefined, undefined, undefined)}
+                                widgetlessToolbox={getToolbox(noop, noop)}
                             />
                         ))}
 
-                    {_.isEmpty(configDef) && (
+                    {isEmpty(configDef) && (
                         <Message>
                             {i18n.t(
                                 'editMode.editWidget.noConfiguration',
@@ -95,25 +127,5 @@ export default function EditWidgetModal({ configDef, configuration, show, onHide
             </Modal.Actions>
         </Modal>
     );
-}
-
-EditWidgetModal.propTypes = {
-    configuration: PropTypes.shape({}).isRequired,
-    configDef: PropTypes.arrayOf(
-        PropTypes.shape({
-            // eslint-disable-next-line react/forbid-prop-types
-            default: PropTypes.any,
-            id: PropTypes.string,
-            name: PropTypes.string,
-            hidden: PropTypes.bool,
-            // eslint-disable-next-line react/forbid-prop-types
-            columns: PropTypes.array,
-            // eslint-disable-next-line react/forbid-prop-types
-            value: PropTypes.any
-        })
-    ).isRequired,
-    widget: PropTypes.shape({ id: PropTypes.string }).isRequired,
-    show: PropTypes.bool.isRequired,
-    onWidgetEdited: PropTypes.func.isRequired,
-    onHideConfig: PropTypes.func.isRequired
 };
+export default EditWidgetModal;

--- a/app/components/EditWidgetModal.tsx
+++ b/app/components/EditWidgetModal.tsx
@@ -73,6 +73,7 @@ export default function EditWidgetModal({ configDef, configuration, show, onHide
                                 label={config.name}
                                 value={fields[config.id]}
                                 columns={config.columns}
+                                placeholder={config.placeHolder}
                                 widgetlessToolbox={getToolbox(undefined, undefined, undefined)}
                             />
                         ))}

--- a/app/components/shared/DynamicTable.tsx
+++ b/app/components/shared/DynamicTable.tsx
@@ -52,7 +52,7 @@ const DynamicTable: FunctionComponent<DynamicTableProps> = ({ name, value = [], 
                     <Table.Row key={index}>
                         {columns
                             .filter(column => !column.hidden)
-                            .map(({ id, label, width, ...columnRest }) => (
+                            .map(({ id, label, width, placeHolder, ...columnRest }) => (
                                 <Table.Cell key={id} width={width}>
                                     <GenericField
                                         label=""
@@ -62,6 +62,7 @@ const DynamicTable: FunctionComponent<DynamicTableProps> = ({ name, value = [], 
                                         value={val[id]}
                                         rowValues={val}
                                         onChange={handleEditRow(id, index)}
+                                        placeholder={placeHolder}
                                         {...rest}
                                         {...columnRest}
                                     />

--- a/app/utils/Toolbox.ts
+++ b/app/utils/Toolbox.ts
@@ -129,7 +129,7 @@ const createToolbox = (store: Store<ReduxState>) => {
 const getToolbox = (
     onRefresh: Stage.Types.Toolbox['refresh'],
     onLoading: Stage.Types.Toolbox['loading'],
-    widget: ReturnType<Stage.Types.Toolbox['getWidget']>
+    widget?: ReturnType<Stage.Types.Toolbox['getWidget']>
 ) => {
     // NOTE: assumes the toolbox is already created
     return new Proxy(toolbox!, {


### PR DESCRIPTION
## Description
Fixes RD-5371 by passing `placeHolder` configuration parameter to `GenericField` component (b62517b781ba9f6fbb312d7c1676ef8dde5fd927).
In addition migrated few components from `EditWidget*` family to TypeScript (f4e0ae30121a2c37745b6a227f4710fc1bcf070d).

## Screenshots / Videos

![image](https://user-images.githubusercontent.com/5202105/179301961-aedae384-f7b7-4ed3-9e86-f16fbdccd9dd.png)


## Checklist
- [x] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [x] I verified that all tests and checks have passed.
- [x] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [x] I added proper labels to this PR.

## Tests
[![Build Status](https://jenkins.cloudify.co/buildStatus/icon?job=Stage-UI-System-Test&build=3149)](https://jenkins.cloudify.co/view/UI%20Health%20View/job/Stage-UI-System-Test/3149/) (15.07.2022) - all PASSED

## Documentation
N/A