### PR TITLE
RD-5393 Fix default value of `installMethods` configuration parameter in Agents widget

### DIFF
--- a/widgets/agents/src/widget.tsx
+++ b/widgets/agents/src/widget.tsx
@@ -52,7 +52,7 @@ Stage.defineWidget({
                 'Choose Install Methods to filter Agents. Unset all options to disable this type of filtering.',
             placeHolder: 'Select Install Methods from the list',
             items: Consts.installMethodsOptions,
-            default: '',
+            default: [],
             type: Stage.Basic.GenericField.MULTI_SELECT_LIST_TYPE
         }
     ],


### PR DESCRIPTION
## Description
Invalid default value of `installMethods` configuration parameter resulted in having data `install_methods=null` in query string of Agents widget data URL, e.g.
```
http://127.0.0.1:4000/console/sp/agents?&_sort=id&_size=5&_offset=0&install_methods=null&state=started
```
and that caused empty agents list in the response and no agents displayed in the table.

This PR changes the default value to correspond with the type of the input field (`MULTI_SELECT_LIST_TYPE`) and sets it to empty array.

## Screenshots / Videos
N/A

## Checklist
- [x] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [x] I verified that all tests and checks have passed.
- [x] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [x] I added proper labels to this PR.

## Tests
Did manual tests only.

## Documentation
N/A