### PR TITLE
RD-3910: Blocked passing unnecessary data upon navigating to deployment page

### DIFF
--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -1274,19 +1274,19 @@
                 "fieldsToShow": {
                     "name": "List of fields to show in the table",
                     "placeholder": "Select fields from the list",
-                    "items": [
-                        "Icon",
-                        "Timestamp",
-                        "Type",
-                        "Blueprint",
-                        "Deployment",
-                        "Deployment ID",
-                        "Workflow",
-                        "Operation",
-                        "Node ID",
-                        "Node instance ID",
-                        "Message"
-                    ]
+                    "items": {
+                        "icon": "Icon",
+                        "timestamp": "Timestamp",
+                        "type": "Type",
+                        "blueprint": "Blueprint",
+                        "deployment": "Deployment",
+                        "deploymentId": "Deployment ID",
+                        "workflow": "Workflow",
+                        "operation": "Operation",
+                        "nodeId": "Node ID",
+                        "nodeInstanceId": "Node instance ID",
+                        "message": "Message"
+                    }
                 },
                 "colorLogs": {
                     "name": "Color message based on type"

--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -1286,8 +1286,7 @@
                         "Node ID",
                         "Node instance ID",
                         "Message"
-                    ],
-                    "default": "Icon,Timestamp,Blueprint,Deployment,Workflow,Operation,Node ID,Node instance ID,Message"
+                    ]
                 },
                 "colorLogs": {
                     "name": "Color message based on type"

--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -1264,6 +1264,34 @@
             }
         },
         "events": {
+            "name": "Events/logs",
+            "description": "This widget shows events/logs",
+            "configuration": {
+                "fieldsToShow": {
+                    "name": "List of fields to show in the table",
+                    "placeholder": "Select fields from the list",
+                    "items": [
+                        "Icon",
+                        "Timestamp",
+                        "Type",
+                        "Blueprint",
+                        "Deployment",
+                        "Deployment ID",
+                        "Workflow",
+                        "Operation",
+                        "Node ID",
+                        "Node instance ID",
+                        "Message"
+                    ],
+                    "default": "Icon,Timestamp,Blueprint,Deployment,Workflow,Operation,Node ID,Node instance ID,Message"
+                },
+                "colorLogs": {
+                    "name": "Color message based on type"
+                },
+                "maxMessageLength": {
+                    "name": "Maximum message length before truncation"
+                }
+            },
             "detailsIcon": "Show details",
             "detailsModal": {
                 "header": "Details",

--- a/test/cypress/integration/widgets/topology_spec.ts
+++ b/test/cypress/integration/widgets/topology_spec.ts
@@ -182,7 +182,7 @@ describe('Topology', () => {
 
         beforeEach(() => {
             cy.visitTestPage();
-            cy.setDeploymentContext(appDeploymentId);
+            cy.setDeploymentContext(componentDeploymentId);
             waitForTopologyWidgetToBeReadyAfterFetch();
         });
 

--- a/test/cypress/integration/widgets/topology_spec.ts
+++ b/test/cypress/integration/widgets/topology_spec.ts
@@ -191,7 +191,7 @@ describe('Topology', () => {
 
             cy.verifyLocation(
                 `/console/page/test_page_deployment/${componentDeploymentId}`,
-                { deploymentId: componentDeploymentId },
+                { deploymentId: appDeploymentId },
                 componentDeploymentId
             );
         });

--- a/test/cypress/integration/widgets/topology_spec.ts
+++ b/test/cypress/integration/widgets/topology_spec.ts
@@ -182,7 +182,7 @@ describe('Topology', () => {
 
         beforeEach(() => {
             cy.visitTestPage();
-            cy.setDeploymentContext(componentDeploymentId);
+            cy.setDeploymentContext(appDeploymentId);
             waitForTopologyWidgetToBeReadyAfterFetch();
         });
 
@@ -191,7 +191,7 @@ describe('Topology', () => {
 
             cy.verifyLocation(
                 `/console/page/test_page_deployment/${componentDeploymentId}`,
-                { deploymentId: appDeploymentId },
+                { deploymentId: componentDeploymentId },
                 componentDeploymentId
             );
         });

--- a/widgets/events/src/widget.tsx
+++ b/widgets/events/src/widget.tsx
@@ -31,7 +31,7 @@ Stage.defineWidget({
             items: t('configuration.fieldsToShow.items', {
                 returnObjects: true
             }),
-            default: t('configuration.fieldsToShow.default'),
+            default: 'Icon,Timestamp,Blueprint,Deployment,Workflow,Operation,Node ID,Node instance ID,Message',
             type: Stage.Basic.GenericField.MULTI_SELECT_LIST_TYPE
         },
         {

--- a/widgets/events/src/widget.tsx
+++ b/widgets/events/src/widget.tsx
@@ -5,6 +5,25 @@ import './widget.css';
 
 const widgetId = 'events';
 const t = Stage.Utils.getT(`widgets.${widgetId}`);
+const fieldsToShowItemsTranslationPrefix = 'configuration.fieldsToShow.items';
+
+const fieldsToShowItems = Object.values(
+    t(fieldsToShowTranslationPrefix, {
+        returnObjects: true
+    })
+);
+
+const fieldsToShowDefaultItems = [
+    t(`${fieldsToShowTranslationPrefix}.icon`),
+    t(`${fieldsToShowTranslationPrefix}.timestamp`),
+    t(`${fieldsToShowTranslationPrefix}.blueprint`),
+    t(`${fieldsToShowTranslationPrefix}.deployment`),
+    t(`${fieldsToShowTranslationPrefix}.workflow`),
+    t(`${fieldsToShowTranslationPrefix}.operation`),
+    t(`${fieldsToShowTranslationPrefix}.nodeId`),
+    t(`${fieldsToShowTranslationPrefix}.nodeInstanceId`),
+    t(`${fieldsToShowTranslationPrefix}.message`)
+];
 
 Stage.defineWidget({
     id: widgetId,
@@ -28,10 +47,8 @@ Stage.defineWidget({
             id: 'fieldsToShow',
             name: t('configuration.fieldsToShow.name'),
             placeHolder: t('configuration.fieldsToShow.placeholder'),
-            items: t('configuration.fieldsToShow.items', {
-                returnObjects: true
-            }),
-            default: 'Icon,Timestamp,Blueprint,Deployment,Workflow,Operation,Node ID,Node instance ID,Message',
+            items: fieldsToShowItems,
+            default: fieldsToShowDefaultItems.join(','),
             type: Stage.Basic.GenericField.MULTI_SELECT_LIST_TYPE
         },
         {

--- a/widgets/events/src/widget.tsx
+++ b/widgets/events/src/widget.tsx
@@ -3,17 +3,20 @@
 import EventsTable from './EventsTable';
 import './widget.css';
 
+const widgetId = 'events';
+const t = Stage.Utils.getT(`widgets.${widgetId}`);
+
 Stage.defineWidget({
-    id: 'events',
-    name: 'Events/logs',
-    description: 'This widget shows events/logs',
+    id: widgetId,
+    name: t('name'),
+    description: t('description'),
     initialWidth: 12,
     initialHeight: 18,
     color: 'green',
     fetchUrl: '[manager]/events[params]',
     isReact: true,
     hasReadme: true,
-    permission: Stage.GenericConfig.WIDGET_PERMISSION('events'),
+    permission: Stage.GenericConfig.WIDGET_PERMISSION(widgetId),
     categories: [Stage.GenericConfig.CATEGORY.SYSTEM_RESOURCES],
 
     initialConfiguration: [
@@ -23,33 +26,23 @@ Stage.defineWidget({
         Stage.GenericConfig.SORT_ASCENDING_CONFIG(false),
         {
             id: 'fieldsToShow',
-            name: 'List of fields to show in the table',
-            placeHolder: 'Select fields from the list',
-            items: [
-                'Icon',
-                'Timestamp',
-                'Type',
-                'Blueprint',
-                'Deployment',
-                'Deployment ID',
-                'Workflow',
-                'Operation',
-                'Node ID',
-                'Node instance ID',
-                'Message'
-            ],
-            default: 'Icon,Timestamp,Blueprint,Deployment,Workflow,Operation,Node ID,Node instance ID,Message',
+            name: t('configuration.fieldsToShow.name'),
+            placeHolder: t('configuration.fieldsToShow.placeholder'),
+            items: t('configuration.fieldsToShow.items', {
+                returnObjects: true
+            }),
+            default: t('configuration.fieldsToShow.default'),
             type: Stage.Basic.GenericField.MULTI_SELECT_LIST_TYPE
         },
         {
             id: 'colorLogs',
-            name: 'Color message based on type',
+            name: t('configuration.colorLogs.name'),
             default: true,
             type: Stage.Basic.GenericField.BOOLEAN_TYPE
         },
         {
             id: 'maxMessageLength',
-            name: 'Maximum message length before truncation',
+            name: t('configuration.maxMessageLength.name'),
             default: EventsTable.MAX_MESSAGE_LENGTH,
             type: Stage.Basic.GenericField.NUMBER_TYPE,
             min: 10
@@ -116,9 +109,6 @@ Stage.defineWidget({
         }
 
         params.type = eventFilter.type;
-
-        // eslint-disable-next-line
-        console.log(params);
 
         return params;
     },

--- a/widgets/events/src/widget.tsx
+++ b/widgets/events/src/widget.tsx
@@ -117,6 +117,9 @@ Stage.defineWidget({
 
         params.type = eventFilter.type;
 
+        // eslint-disable-next-line
+        console.log(params);
+
         return params;
     },
 

--- a/widgets/topology/src/Topology.tsx
+++ b/widgets/topology/src/Topology.tsx
@@ -349,7 +349,10 @@ export default class Topology extends React.Component<TopologyProps, TopologySta
 
     goToDeploymentPage(nodeDeploymentId) {
         const { toolbox } = this.props;
-        const deploymentId = toolbox.getContext().getValue('deploymentId');
+        // NOTE: Sometimes context may store deploymentId in a form of array.
+        // That's why head function is used here, to make sure that the deploymentId is being stored as a single value
+        const deploymentId = _.head(toolbox.getContext().getValue('deploymentId'));
+
         toolbox.drillDown(toolbox.getWidget(), 'deployment', { deploymentId }, nodeDeploymentId);
     }
 

--- a/widgets/topology/src/Topology.tsx
+++ b/widgets/topology/src/Topology.tsx
@@ -349,8 +349,8 @@ export default class Topology extends React.Component<TopologyProps, TopologySta
 
     goToDeploymentPage(nodeDeploymentId) {
         const { toolbox } = this.props;
-        toolbox.getContext().setValue('deploymentId', nodeDeploymentId);
-        toolbox.drillDown(toolbox.getWidget(), 'deployment', { deploymentId: nodeDeploymentId }, nodeDeploymentId);
+        const deploymentId = toolbox.getContext().getValue('deploymentId');
+        toolbox.drillDown(toolbox.getWidget(), 'deployment', { deploymentId }, nodeDeploymentId);
     }
 
     render() {

--- a/widgets/topology/src/Topology.tsx
+++ b/widgets/topology/src/Topology.tsx
@@ -34,6 +34,7 @@ interface TopologyState {
     // eslint-disable-next-line camelcase
     expandedTerraformNodes: { deployment_id: string; id: string }[];
     saveConfirmationOpen: boolean;
+    isRedirecting: boolean;
 }
 
 export default class Topology extends React.Component<TopologyProps, TopologyState> {
@@ -60,7 +61,12 @@ export default class Topology extends React.Component<TopologyProps, TopologySta
         this.processedTopologyData = null;
         this.scrollerGlassHandler = new ScrollerGlassHandler(this.glassRef);
 
-        this.state = { saveConfirmationOpen: false, expandedDeployments: [], expandedTerraformNodes: [] };
+        this.state = {
+            saveConfirmationOpen: false,
+            expandedDeployments: [],
+            expandedTerraformNodes: [],
+            isRedirecting: false
+        };
     }
 
     componentDidMount() {
@@ -132,6 +138,12 @@ export default class Topology extends React.Component<TopologyProps, TopologySta
 
     setSelectedNode(selectedNode) {
         const { deploymentId, blueprintId, toolbox } = this.props;
+        const { isRedirecting } = this.state;
+
+        if (isRedirecting) {
+            return;
+        }
+
         if (deploymentId) {
             toolbox.getContext().setValue('depNodeId', selectedNode.name + deploymentId);
             toolbox.getContext().setValue('nodeId', selectedNode.name);
@@ -349,11 +361,16 @@ export default class Topology extends React.Component<TopologyProps, TopologySta
 
     goToDeploymentPage(nodeDeploymentId) {
         const { toolbox } = this.props;
-        // NOTE: Sometimes context may store deploymentId in a form of array.
-        // That's why head function is used here, to make sure that the deploymentId is being stored as a single value
-        const deploymentId = _.head(toolbox.getContext().getValue('deploymentId'));
 
-        toolbox.drillDown(toolbox.getWidget(), 'deployment', { deploymentId }, nodeDeploymentId);
+        /*
+            NOTE: isRedirecting flag is being set to block updating context with data provided by setSelectedNode function.
+            More context: it seems that upon clicking 'Go to deployment page' button we are also triggering (via event bubbling) onNodeSelected event handler, which is executing setSelectedNode function.
+        */
+        this.setState({
+            isRedirecting: true
+        });
+
+        toolbox.drillDown(toolbox.getWidget(), 'deployment', { deploymentId: nodeDeploymentId }, nodeDeploymentId);
     }
 
     render() {


### PR DESCRIPTION
<!--- Provide JIRA issue ID and a general summary of your changes in the Title above -->
<!--- e.g. "RD-1234 Improve styling in SuperComponent" -->
<!--- Note that the title is used as a commit message after merging the PR -->

## Description
<!--- Describe your changes to help reviewers understand the details. -->
[Issue](https://cloudifysource.atlassian.net/browse/RD-3910) is appearing due to unnecessary passing `nodeId` to deployment page.
It is read by `events` widget, making the event list to be incorrectly filtered.

### More context
That behavior seems to be related to the fact, that while clicking on the "Go to deployment page" button (inside `topology` widget) we are not only executing function attached to that button, but also the one responsible for handling selection of a specific node (to which the clicked button is attached 😅)
As handler for node selection is putting some extra data into the application `context`, we are getting into the situation when we are trying to navigate to the deployment page with a data that shouldn't be passed.
It looks like an issue related to the event bubbling - coming from the [topology](https://github.com/cloudify-cosmo/cloudify-blueprint-topology).

## Screenshots / Videos
<!--- If applicable, add screenshot(s) or video(s) describing the changes you made. -->
<!--- Consider adding comparison screenshot(s) - before and after the change. -->
<!--- If not applicable, just write “N/A” in this section. -->

N/A

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [x] I verified that all tests and checks have passed.
- [x] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [x] I added proper labels to this PR.

## Tests
<!--- If applicable, describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If applicable, provide a link to system tests, e.g: -->
<!--- [#1039](https://jenkins.cloudify.co/.../1039) (2021-08-06 07:05:50) --> 
<!--- If not applicable, just write “N/A” in this section. -->

### 1 attempt (on **all** test scenarios)
[![Build Status](https://jenkins.cloudify.co/buildStatus/icon?job=Stage-UI-System-Test&build=3199)](https://jenkins.cloudify.co/view/UI%20Health%20View/job/Stage-UI-System-Test/3199/)
`topology_spec` is failing

### 2 attempt (on `topology_spec`)
[![Build Status](https://jenkins.cloudify.co/buildStatus/icon?job=Stage-UI-System-Test&build=3200)](https://jenkins.cloudify.co/view/UI%20Health%20View/job/Stage-UI-System-Test/3200/)

## Documentation
<!--- If applicable, describe how you documented or plan to document your changes. -->
<!--- Check UI documentation guidelines - https://cloudifysource.atlassian.net/l/c/EYWJ0XfB - for details. -->
<!--- Provide links to JIRA issues, other PRs or related documentation pages. -->
<!--- If not applicable, just write “N/A” in this section. -->

N/A