### PR TITLE
RD-5406 Fix refreshing deployment action buttons in Deployments View widget

### DIFF
--- a/widgets/common/src/deploymentsView/detailsPane/header.tsx
+++ b/widgets/common/src/deploymentsView/detailsPane/header.tsx
@@ -37,7 +37,7 @@ const DetailsPaneHeader: FunctionComponent<DetailsPaneHeaderProps> = ({ deployme
             width: 1,
             height: 1,
             definition: 'deploymentActionButtons',
-            configuration: { preventRedirectToParentPageAfterDelete: true },
+            configuration: { pollingTime: 5, preventRedirectToParentPageAfterDelete: true },
             drillDownPages: {},
             maximized: false
         }),


### PR DESCRIPTION
## Description

Since implementation of #2023 the list of workflows may change after workflow execution. Deployment Action Buttons widget used inside Deployments View widget was not using data polling, so it couldn't get updated. This PR fixes this behavior by simply adding `pollingTime` parameter to Deployment Action Buttons widget defined inside Deployments View widget.   

## Screenshots / Videos

https://user-images.githubusercontent.com/5202105/180049981-9d08394d-1972-4962-aa6e-9a3654e7f645.mp4


## Checklist
- [x] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [x] I verified that all tests and checks have passed.
- [x] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [x] I added proper labels to this PR.

## Tests
Don't see a need to run system tests for such a simple fix.

## Documentation
N/A
