### PR TITLE
RD-5382 Remove setting blueprint ID in `className` prop

### DIFF
--- a/test/cypress/integration/widgets/blueprints_spec.ts
+++ b/test/cypress/integration/widgets/blueprints_spec.ts
@@ -212,6 +212,10 @@ describe('Blueprints widget', () => {
         });
 
         it('as a catalog', () => {
+            function getBlueprintSegment(blueprintName: string) {
+                return cy.getByTestId(blueprintName);
+            }
+
             cy.editWidgetConfiguration('blueprints', () =>
                 cy.get('.dropdown').contains('Catalog').click({ force: true })
             );
@@ -219,100 +223,82 @@ describe('Blueprints widget', () => {
             cy.get('div.blueprintsWidget table.blueprintsTable').should('not.exist');
             cy.get('div.blueprintsWidget .segmentList').should('exist');
 
-            cy.get('.pending')
-                .parent()
-                .within(() => {
-                    cy.contains('Pending');
-                    cy.get('.actionButtons').should('not.exist');
-                    cy.get('.warning').should('not.exist');
-                    cy.get('a').click({ force: true });
-                });
+            getBlueprintSegment('pending').within(() => {
+                cy.contains('Pending');
+                cy.get('.actionButtons').should('not.exist');
+                cy.get('.warning').should('not.exist');
+                cy.get('a').click({ force: true });
+            });
 
-            cy.get('.uploading')
-                .parent()
-                .within(() => {
-                    cy.contains('Uploading');
-                    cy.get('.actionButtons').should('not.exist');
-                    cy.get('.warning').should('not.exist');
-                    cy.get('a').click({ force: true });
-                });
+            getBlueprintSegment('uploading').within(() => {
+                cy.contains('Uploading');
+                cy.get('.actionButtons').should('not.exist');
+                cy.get('.warning').should('not.exist');
+                cy.get('a').click({ force: true });
+            });
 
-            cy.get('.extracting')
-                .parent()
-                .within(() => {
-                    cy.contains('Extracting');
-                    cy.get('.actionButtons').should('not.exist');
-                    cy.get('.warning').should('not.exist');
-                    cy.get('a').click({ force: true });
-                });
+            getBlueprintSegment('extracting').within(() => {
+                cy.contains('Extracting');
+                cy.get('.actionButtons').should('not.exist');
+                cy.get('.warning').should('not.exist');
+                cy.get('a').click({ force: true });
+            });
 
-            cy.get('.parsing')
-                .parent()
-                .within(() => {
-                    cy.contains('Parsing');
-                    cy.get('.actionButtons').should('not.exist');
-                    cy.get('.warning').should('not.exist');
-                    cy.get('a').click({ force: true });
-                });
+            getBlueprintSegment('parsing').within(() => {
+                cy.contains('Parsing');
+                cy.get('.actionButtons').should('not.exist');
+                cy.get('.warning').should('not.exist');
+                cy.get('a').click({ force: true });
+            });
 
-            cy.get('.failed_uploading')
-                .parent()
-                .within(() => {
-                    cy.contains('Failed');
-                    cy.get('.actionButtons').children().should('have.length', 1);
-                    cy.get('.trash');
-                    cy.get('a').click({ force: true });
-                    cy.get('.warning').trigger('mouseover');
-                });
+            getBlueprintSegment('failed_uploading').within(() => {
+                cy.contains('Failed');
+                cy.get('.actionButtons').children().should('have.length', 1);
+                cy.get('.trash');
+                cy.get('a').click({ force: true });
+                cy.get('.warning').trigger('mouseover');
+            });
             cy.contains('upload error');
             cy.contains('Failed uploading');
 
-            cy.get('.failed_extracting')
-                .parent()
-                .within(() => {
-                    cy.contains('Failed');
-                    cy.get('.actionButtons').children().should('have.length', 1);
-                    cy.get('.trash').should('exist');
-                    cy.get('a').click({ force: true });
-                    cy.get('.warning').trigger('mouseover');
-                });
+            getBlueprintSegment('failed_extracting').within(() => {
+                cy.contains('Failed');
+                cy.get('.actionButtons').children().should('have.length', 1);
+                cy.get('.trash').should('exist');
+                cy.get('a').click({ force: true });
+                cy.get('.warning').trigger('mouseover');
+            });
             cy.contains('extract error');
             cy.contains('Failed extracting');
 
-            cy.get('.failed_parsing')
-                .parent()
-                .within(() => {
-                    cy.contains('Failed');
-                    cy.get('.actionButtons').children().should('have.length', 1);
-                    cy.get('.trash').should('exist');
-                    cy.get('a').click({ force: true });
-                    cy.get('.warning').trigger('mouseover');
-                });
+            getBlueprintSegment('failed_parsing').within(() => {
+                cy.contains('Failed');
+                cy.get('.actionButtons').children().should('have.length', 1);
+                cy.get('.trash').should('exist');
+                cy.get('a').click({ force: true });
+                cy.get('.warning').trigger('mouseover');
+            });
             cy.contains('parse error');
             cy.contains('Failed parsing');
 
-            cy.get('.invalid')
-                .parent()
-                .within(() => {
-                    cy.contains('Invalid');
-                    cy.get('.actionButtons').children().should('have.length', 1);
-                    cy.get('.trash').should('exist');
-                    cy.get('a').click({ force: true });
-                    cy.get('.warning').trigger('mouseover');
-                });
+            getBlueprintSegment('invalid').within(() => {
+                cy.contains('Invalid');
+                cy.get('.actionButtons').children().should('have.length', 1);
+                cy.get('.trash').should('exist');
+                cy.get('a').click({ force: true });
+                cy.get('.warning').trigger('mouseover');
+            });
             cy.contains('invalid error');
 
             cy.editWidgetConfiguration('blueprints', () => cy.get('input[name=hideFailedBlueprints]').parent().click());
             cy.wait('@filteredBlueprints');
 
-            cy.get('.uploaded')
-                .parent()
-                .within(() => {
-                    cy.contains('Uploaded');
-                    cy.get('.actionButtons').children().should('have.length', 3);
-                    cy.get('.warning').should('not.exist');
-                    cy.get('a').click({ force: true });
-                });
+            getBlueprintSegment('uploaded').within(() => {
+                cy.contains('Uploaded');
+                cy.get('.actionButtons').children().should('have.length', 3);
+                cy.get('.warning').should('not.exist');
+                cy.get('a').click({ force: true });
+            });
 
             cy.get('div.blueprintsWidget .segmentList').should('not.exist');
             cy.contains('.pageTitle', 'uploaded');

--- a/test/cypress/integration/widgets/filter_spec.ts
+++ b/test/cypress/integration/widgets/filter_spec.ts
@@ -81,6 +81,10 @@ describe('Filter', () => {
     describe('refreshes dropdown data on', () => {
         const blueprintName = 'filter-test';
 
+        function getBlueprintSegment(bpName: string) {
+            return cy.getByTestId(bpName);
+        }
+
         before(() =>
             cy
                 .deleteDeployments(blueprintName)
@@ -94,7 +98,7 @@ describe('Filter', () => {
         it('deployment creation and removal', () => {
             cy.get('.blueprintsWidget').within(() => {
                 cy.getSearchInput().scrollIntoView().clear().type(blueprintName);
-                cy.get(`.${blueprintName}`).parent().find('.rocket').click();
+                getBlueprintSegment(blueprintName).find('.rocket').click();
             });
             const deploymentName = `${blueprintName}-deployment`;
             cy.get('input[name=deploymentName]').type(deploymentName);
@@ -124,7 +128,7 @@ describe('Filter', () => {
         it('blueprint upload and removal', () => {
             cy.get('.blueprintsWidget').within(() => {
                 cy.getSearchInput().scrollIntoView().clear().type(blueprintName);
-                cy.get(`.${blueprintName}`).parent().find('.trash').click();
+                getBlueprintSegment(blueprintName).find('.trash').click();
             });
             cy.contains('Yes').click();
 

--- a/widgets/blueprints/src/BlueprintsCatalog.tsx
+++ b/widgets/blueprints/src/BlueprintsCatalog.tsx
@@ -25,7 +25,7 @@ export default function BlueprintsCatalog({
             <Grid.Column key={item.id}>
                 <DataSegment.Item
                     selected={item.isSelected}
-                    className={`fullHeight ${item.id}`}
+                    className="fullHeight"
                     onClick={event => {
                         event.stopPropagation();
                         onSelectBlueprint(item);

--- a/widgets/blueprints/src/BlueprintsCatalog.tsx
+++ b/widgets/blueprints/src/BlueprintsCatalog.tsx
@@ -22,7 +22,7 @@ export default function BlueprintsCatalog({
 
     const blueprintsItems = data.items.map(item => {
         return (
-            <Grid.Column key={item.id}>
+            <Grid.Column key={item.id} data-testid={item.id}>
                 <DataSegment.Item
                     selected={item.isSelected}
                     className="fullHeight"


### PR DESCRIPTION
## Description
The problem described in RD-5382 comes from the fact that blueprint ID was passed to `className` prop in one of the components in Blueprints widget. Depending on the blueprint ID it could change the styling of the catalog item 🙂 

## Screenshots / Videos
### Before
![image](https://user-images.githubusercontent.com/5202105/180216348-d12561df-92dc-4060-9be9-640ab58caf14.png)

### After
![image](https://user-images.githubusercontent.com/5202105/180216447-e73c5497-6d4f-43c6-9134-8c9bed9df383.png)

## Checklist
- [x] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [x] I verified that all tests and checks have passed.
- [x] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [x] I added proper labels to this PR.

## Tests
1. [![Build Status](https://jenkins.cloudify.co/buildStatus/icon?job=Stage-UI-System-Test&build=3192)](https://jenkins.cloudify.co/view/UI%20Health%20View/job/Stage-UI-System-Test/3192/) - `blueprints_spec` and `filter_spec` failed
2. [![Build Status](https://jenkins.cloudify.co/buildStatus/icon?job=Stage-UI-System-Test&build=3196)](https://jenkins.cloudify.co/view/UI%20Health%20View/job/Stage-UI-System-Test/3196/) - only `blueprints_spec` and `filter_spec`:
  a. `blueprints_spec` - failed due to known issue (RD-5020), so I'm considering it as PASSED
  b. `filter_spec` - PASSED`

## Documentation
N/A
