### PR TITLE
RD-5965 Bump `axios` and `follow-redirects` packages in backend to make Stage DB migration more robust

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -13,7 +13,7 @@
                 "@evops/hcl-terraform-parser": "^1.0.0",
                 "@tsconfig/node14": "^1.0.1",
                 "archiver": "^5.3.0",
-                "axios": "^0.26.0",
+                "axios": "^0.27.2",
                 "body": "^5.1.0",
                 "cloudify-ui-common": "^7.3.1",
                 "cookie": "^0.4.2",
@@ -4360,11 +4360,25 @@
             }
         },
         "node_modules/axios": {
-            "version": "0.26.1",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-            "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+            "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
             "dependencies": {
-                "follow-redirects": "^1.14.8"
+                "follow-redirects": "^1.14.9",
+                "form-data": "^4.0.0"
+            }
+        },
+        "node_modules/axios/node_modules/form-data": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+            "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+            "dependencies": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.8",
+                "mime-types": "^2.1.12"
+            },
+            "engines": {
+                "node": ">= 6"
             }
         },
         "node_modules/axobject-query": {
@@ -5335,6 +5349,14 @@
                 "eslint-plugin-react-hooks": "^4.1.2",
                 "eslint-plugin-scanjs-rules": "^0.2.1",
                 "eslint-plugin-security": "^1.4.0"
+            }
+        },
+        "node_modules/cloudify-ui-common/node_modules/axios": {
+            "version": "0.26.1",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+            "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+            "dependencies": {
+                "follow-redirects": "^1.14.8"
             }
         },
         "node_modules/co": {
@@ -8466,9 +8488,9 @@
             "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.1",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
-            "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==",
+            "version": "1.15.2",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+            "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
             "funding": [
                 {
                     "type": "individual",
@@ -23259,11 +23281,24 @@
             "peer": true
         },
         "axios": {
-            "version": "0.26.1",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-            "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+            "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
             "requires": {
-                "follow-redirects": "^1.14.8"
+                "follow-redirects": "^1.15.2",
+                "form-data": "^4.0.0"
+            },
+            "dependencies": {
+                "form-data": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+                    "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+                    "requires": {
+                        "asynckit": "^0.4.0",
+                        "combined-stream": "^1.0.8",
+                        "mime-types": "^2.1.12"
+                    }
+                }
             }
         },
         "axobject-query": {
@@ -23983,6 +24018,16 @@
                 "sequelize": "^6.21.3",
                 "umzug": "^3.0.0",
                 "winston": "^3.3.3"
+            },
+            "dependencies": {
+                "axios": {
+                    "version": "0.26.1",
+                    "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+                    "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+                    "requires": {
+                        "follow-redirects": "^1.15.2"
+                    }
+                }
             }
         },
         "co": {
@@ -26409,9 +26454,9 @@
             "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
         },
         "follow-redirects": {
-            "version": "1.15.1",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
-            "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA=="
+            "version": "1.15.2",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+            "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
         },
         "foreground-child": {
             "version": "2.0.0",
@@ -26916,7 +26961,7 @@
             "peer": true,
             "requires": {
                 "eventemitter3": "^4.0.0",
-                "follow-redirects": "^1.0.0",
+                "follow-redirects": "^1.15.2",
                 "requires-port": "^1.0.0"
             }
         },
@@ -34195,7 +34240,7 @@
                     "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
                     "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
                     "requires": {
-                        "follow-redirects": "^1.14.7"
+                        "follow-redirects": "^1.15.2"
                     }
                 }
             }

--- a/backend/package.json
+++ b/backend/package.json
@@ -97,9 +97,6 @@
         "sequelize": "^6.17.0",
         "sequelize-cli": "^6.4.1"
     },
-    "overrides": {
-        "follow-redirects": "^1.15.2"
-    },
     "engines": {
         "node": "16.x"
     },

--- a/backend/package.json
+++ b/backend/package.json
@@ -32,7 +32,7 @@
         "@evops/hcl-terraform-parser": "^1.0.0",
         "@tsconfig/node14": "^1.0.1",
         "archiver": "^5.3.0",
-        "axios": "^0.26.0",
+        "axios": "^0.27.2",
         "body": "^5.1.0",
         "cloudify-ui-common": "^7.3.1",
         "cookie": "^0.4.2",
@@ -94,6 +94,9 @@
         "nodemon": "^2.0.15",
         "sequelize": "^6.17.0",
         "sequelize-cli": "^6.4.1"
+    },
+    "overrides": {
+        "follow-redirects": "^1.15.2"
     },
     "engines": {
         "node": "16.x"


### PR DESCRIPTION
## Description

A proper fix for app-crashing issue (https://github.com/follow-redirects/follow-redirects/issues/211 and RD-5663) was implemented in `follow-redirects` package and new version was released. Bumped `axios` package to get the latest `follow-redirects`.

Noticed that axios v1 is coming, so created RD-5969.

## Screenshots / Videos
N/A

## Checklist
- [x] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [x] I verified that all tests and checks have passed.
- [x] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [x] I added proper labels to this PR.

## Tests
[![Build Status](https://jenkins.cloudify.co/buildStatus/icon?job=Stage-UI-System-Test&build=3569)](https://jenkins.cloudify.co/view/UI%20Health%20View/job/Stage-UI-System-Test/3569/) - failed due to known issues (RD-5918, RD-5921, RD-5922), so I'm considering it as PASSED

## Documentation
N/A