### PR TITLE
RD-5752 Reuse backend types in frontend package

### DIFF
--- a/app/actions/userApp.ts
+++ b/app/actions/userApp.ts
@@ -8,6 +8,7 @@ import { saveUserAppData } from './userAppCommon';
 import Internal from '../utils/Internal';
 import Consts from '../utils/consts';
 import UserAppDataAutoSaver from '../utils/UserAppDataAutoSaver';
+import type { GetUserAppResponse } from '../../backend/routes/UserApp.types';
 
 function setPages(pages) {
     return {
@@ -50,7 +51,7 @@ export function resetPagesForTenant(tenant) {
             return dispatch(resetPages());
         }
         const internal = new Internal(getState().manager);
-        return internal.doGet('ua/clear-pages', { params: { tenant } });
+        return internal.doGet<GetUserAppResponse>('ua/clear-pages', { params: { tenant } });
     };
 }
 
@@ -59,7 +60,7 @@ export function loadOrCreateUserAppData() {
         const { manager } = getState();
 
         const internal = new Internal(manager);
-        return internal.doGet('/ua').then(userApp => {
+        return internal.doGet<GetUserAppResponse>('/ua').then(userApp => {
             if (
                 userApp &&
                 userApp.appDataVersion === Consts.APP_VERSION &&

--- a/app/actions/userAppCommon.ts
+++ b/app/actions/userAppCommon.ts
@@ -3,6 +3,7 @@ import type { Dispatch, Store } from 'redux';
 import type { ReduxState } from '../reducers';
 import Consts from '../utils/consts';
 import Internal from '../utils/Internal';
+import type { PostUserAppRequestBody, PostUserAppResponse } from '../../backend/routes/UserApp.types';
 
 export function saveUserAppData() {
     return (_dispatch: Dispatch, getState: Store<ReduxState>['getState']) => {
@@ -19,9 +20,9 @@ export function saveUserAppData() {
                 widget.maximized = false;
             });
 
-        const body = { appData, version: Consts.APP_VERSION };
+        const body: PostUserAppRequestBody = { appData, version: Consts.APP_VERSION };
 
         const internal = new Internal(getState().manager);
-        return internal.doPost('/ua', { body });
+        return internal.doPost<PostUserAppResponse, PostUserAppRequestBody>('/ua', { body });
     };
 }

--- a/app/actions/widgets.ts
+++ b/app/actions/widgets.ts
@@ -3,6 +3,7 @@
 import Internal from '../utils/Internal';
 import widgetDefinitionLoader from '../utils/widgetDefinitionsLoader';
 import * as types from './types';
+import type { GetWidgetsUsedResponse } from '../../backend/routes/Widgets.types';
 
 export function storeWidgetDefinitions(widgetDefinitions) {
     return {
@@ -107,6 +108,6 @@ export function replaceWidget(widgetId, widgetFile, widgetUrl) {
 export function checkIfWidgetIsUsed(widgetId) {
     return (dispatch, getState) => {
         const internal = new Internal(getState().manager);
-        return internal.doGet(`/widgets/${widgetId}/used`);
+        return internal.doGet<GetWidgetsUsedResponse>(`/widgets/${widgetId}/used`);
     };
 }

--- a/app/components/ContactDetailsModal/useModalOpenState.ts
+++ b/app/components/ContactDetailsModal/useModalOpenState.ts
@@ -5,10 +5,7 @@ import type { ReduxState } from '../../reducers';
 import consts from '../../utils/consts';
 import Internal from '../../utils/Internal';
 import useManager from '../../utils/hooks/useManager';
-
-interface ContactDetailsResponse {
-    contactDetailsReceived: boolean;
-}
+import type { GetContactDetailsResponse } from '../../../backend/routes/ContactDetails.types';
 
 const useModalOpenState = () => {
     // Modal is opened ONLY if currently the user is using the Community version and has not submitted contact details yet
@@ -21,7 +18,7 @@ const useModalOpenState = () => {
 
     useEffect(() => {
         if (userIsUsingCommunity) {
-            internal.doGet('contactDetails/').then((response: ContactDetailsResponse) => {
+            internal.doGet<GetContactDetailsResponse>('contactDetails/').then(response => {
                 if (!response.contactDetailsReceived) {
                     openModal();
                 }

--- a/app/components/GettingStartedModal/installation/process.ts
+++ b/app/components/GettingStartedModal/installation/process.ts
@@ -4,6 +4,7 @@ import StageUtils from '../../../utils/stageUtils';
 import type Internal from '../../../utils/Internal';
 import type Manager from '../../../utils/Manager';
 import type { BlueprintInstallationTask, PluginInstallationTask, SecretInstallationTask } from './tasks';
+import type { PostPluginsUploadQueryParams } from '../../../../backend/routes/Plugins.types';
 
 export enum TaskType {
     Plugin = 'plugin',
@@ -39,7 +40,7 @@ export const installPlugin = async (internal: Internal, plugin: PluginInstallati
         wagonUrl: plugin.wagonUrl
     };
     try {
-        await internal.doUpload('/plugins/upload', { params, method: 'post' });
+        await internal.doUpload<any, PostPluginsUploadQueryParams>('/plugins/upload', { params, method: 'post' });
         return true;
     } catch (e) {
         log.error(e);

--- a/app/components/templateManagement/TemplateManagement.tsx
+++ b/app/components/templateManagement/TemplateManagement.tsx
@@ -18,6 +18,11 @@ import { addPage, removePage } from '../../actions/templateManagement/pages';
 import PageGroups from './pageGroups/PageGroups';
 import type { ReduxState } from '../../reducers';
 import useCreatePageId from './pages/useCreatePageId';
+import type {
+    GetPageGroupsResponse,
+    GetPagesResponse,
+    GetTemplatesResponse
+} from '../../../backend/routes/Templates.types';
 
 export default function TemplateManagement() {
     const dispatch = useDispatch();
@@ -44,9 +49,9 @@ export default function TemplateManagement() {
     function fetchData() {
         startLoading();
         return Promise.all([
-            internal.doGet('/templates'),
-            internal.doGet('/templates/pages'),
-            internal.doGet('/templates/page-groups')
+            internal.doGet<GetTemplatesResponse>('/templates'),
+            internal.doGet<GetPagesResponse>('/templates/pages'),
+            internal.doGet<GetPageGroupsResponse>('/templates/page-groups')
         ])
             .then(data => {
                 const selectedTemplate = _.find(templates, { selected: true });

--- a/app/utils/External.ts
+++ b/app/utils/External.ts
@@ -18,14 +18,16 @@ Text form of class hierarchy diagram to be used at: https://yuml.me/diagram/nofu
 
 */
 
-interface RequestOptions {
-    params?: Record<string, any>;
-    body?: any;
+interface RequestOptions<RequestBody, RequestParams> {
+    params?: RequestParams;
+    body?: RequestBody;
     headers?: Record<string, any>;
     parseResponse?: boolean;
     withCredentials?: boolean;
     validateAuthentication?: boolean;
 }
+
+type QueryParams = Record<string, any>;
 
 function getContentType(type?: string) {
     return { 'content-type': type || 'application/json' };
@@ -50,40 +52,55 @@ function getFilenameFromHeaders(headers: Headers, fallbackFilename: string) {
 export default class External {
     constructor(protected managerData: any) {}
 
-    doGet(url: string, requestOptions?: Omit<RequestOptions, 'body'>) {
-        return this.ajaxCall(url, 'get', requestOptions);
+    doGet<ResponseBody = any, RequestQueryParams = QueryParams>(
+        url: string,
+        requestOptions?: Omit<RequestOptions<never, RequestQueryParams>, 'body'>
+    ) {
+        return this.ajaxCall<ResponseBody, never, RequestQueryParams>(url, 'get', requestOptions);
     }
 
-    doPost(url: string, requestOptions?: RequestOptions) {
-        return this.ajaxCall(url, 'post', requestOptions);
+    doPost<ResponseBody = any, RequestBody = any, RequestQueryParams = QueryParams>(
+        url: string,
+        requestOptions?: RequestOptions<RequestBody, RequestQueryParams>
+    ) {
+        return this.ajaxCall<ResponseBody, RequestBody, RequestQueryParams>(url, 'post', requestOptions);
     }
 
-    doDelete(url: string, requestOptions?: RequestOptions) {
-        return this.ajaxCall(url, 'delete', requestOptions);
+    doDelete<ResponseBody = any, RequestBody = any, RequestQueryParams = QueryParams>(
+        url: string,
+        requestOptions?: RequestOptions<RequestBody, RequestQueryParams>
+    ) {
+        return this.ajaxCall<ResponseBody, RequestBody, RequestQueryParams>(url, 'delete', requestOptions);
     }
 
-    doPut(url: string, requestOptions: RequestOptions) {
-        return this.ajaxCall(url, 'put', requestOptions);
+    doPut<ResponseBody = any, RequestBody = any, RequestQueryParams = QueryParams>(
+        url: string,
+        requestOptions: RequestOptions<RequestBody, RequestQueryParams>
+    ) {
+        return this.ajaxCall<ResponseBody, RequestBody, RequestQueryParams>(url, 'put', requestOptions);
     }
 
-    doPatch(url: string, requestOptions: RequestOptions) {
-        return this.ajaxCall(url, 'PATCH', requestOptions);
+    doPatch<ResponseBody = any, RequestBody = any, RequestQueryParams = QueryParams>(
+        url: string,
+        requestOptions: RequestOptions<RequestBody, RequestQueryParams>
+    ) {
+        return this.ajaxCall<ResponseBody, RequestBody, RequestQueryParams>(url, 'PATCH', requestOptions);
     }
 
-    doDownload(url: string, fileName = '') {
-        return this.ajaxCall(url, 'get', { fileName });
+    doDownload<ResponseBody = any, RequestQueryParams = QueryParams>(url: string, fileName = '') {
+        return this.ajaxCall<ResponseBody, never, RequestQueryParams>(url, 'get', { fileName });
     }
 
-    doUpload(
+    doUpload<ResponseBody = any, RequestQueryParams = QueryParams>(
         url: string,
         {
-            params = {},
+            params,
             files,
             method,
             parseResponse = true,
             compressFile
         }: {
-            params?: Record<string, any>;
+            params?: RequestQueryParams;
             files?: (Blob & { name: string }) | Record<string, any>;
             method?: string;
             parseResponse?: boolean;
@@ -94,7 +111,7 @@ export default class External {
 
         log.debug(`Uploading file for url: ${url}`);
 
-        return new Promise<any>((resolve, reject) => {
+        return new Promise<ResponseBody>((resolve, reject) => {
             // Call upload method
             const xhr = new XMLHttpRequest();
             xhr.addEventListener('error', e => {
@@ -195,7 +212,7 @@ export default class External {
         });
     }
 
-    private ajaxCall(
+    ajaxCall<ResponseBody, RequestBody, RequestQueryParams>(
         url: string,
         method: string,
         {
@@ -206,8 +223,8 @@ export default class External {
             fileName,
             withCredentials,
             validateAuthentication = true
-        }: RequestOptions & { fileName?: string } = {}
-    ) {
+        }: RequestOptions<RequestBody, RequestQueryParams> & { fileName?: string } = {}
+    ): Promise<ResponseBody> {
         const actualUrl = this.buildActualUrl(url, params);
         log.debug(`${method} data. URL: ${url}`);
 

--- a/app/utils/External.ts
+++ b/app/utils/External.ts
@@ -18,7 +18,9 @@ Text form of class hierarchy diagram to be used at: https://yuml.me/diagram/nofu
 
 */
 
-interface RequestOptions<RequestBody, RequestParams> {
+type QueryParams = Record<string, any>;
+
+interface RequestOptions<RequestBody, RequestParams extends QueryParams> {
     params?: RequestParams;
     body?: RequestBody;
     headers?: Record<string, any>;
@@ -26,8 +28,6 @@ interface RequestOptions<RequestBody, RequestParams> {
     withCredentials?: boolean;
     validateAuthentication?: boolean;
 }
-
-type QueryParams = Record<string, any>;
 
 function getContentType(type?: string) {
     return { 'content-type': type || 'application/json' };
@@ -52,46 +52,46 @@ function getFilenameFromHeaders(headers: Headers, fallbackFilename: string) {
 export default class External {
     constructor(protected managerData: any) {}
 
-    doGet<ResponseBody = any, RequestQueryParams = QueryParams>(
+    doGet<ResponseBody = any, RequestQueryParams extends QueryParams = QueryParams>(
         url: string,
         requestOptions?: Omit<RequestOptions<never, RequestQueryParams>, 'body'>
     ) {
         return this.ajaxCall<ResponseBody, never, RequestQueryParams>(url, 'get', requestOptions);
     }
 
-    doPost<ResponseBody = any, RequestBody = any, RequestQueryParams = QueryParams>(
+    doPost<ResponseBody = any, RequestBody = any, RequestQueryParams extends QueryParams = QueryParams>(
         url: string,
         requestOptions?: RequestOptions<RequestBody, RequestQueryParams>
     ) {
         return this.ajaxCall<ResponseBody, RequestBody, RequestQueryParams>(url, 'post', requestOptions);
     }
 
-    doDelete<ResponseBody = any, RequestBody = any, RequestQueryParams = QueryParams>(
+    doDelete<ResponseBody = any, RequestBody = any, RequestQueryParams extends QueryParams = QueryParams>(
         url: string,
         requestOptions?: RequestOptions<RequestBody, RequestQueryParams>
     ) {
         return this.ajaxCall<ResponseBody, RequestBody, RequestQueryParams>(url, 'delete', requestOptions);
     }
 
-    doPut<ResponseBody = any, RequestBody = any, RequestQueryParams = QueryParams>(
+    doPut<ResponseBody = any, RequestBody = any, RequestQueryParams extends QueryParams = QueryParams>(
         url: string,
         requestOptions: RequestOptions<RequestBody, RequestQueryParams>
     ) {
         return this.ajaxCall<ResponseBody, RequestBody, RequestQueryParams>(url, 'put', requestOptions);
     }
 
-    doPatch<ResponseBody = any, RequestBody = any, RequestQueryParams = QueryParams>(
+    doPatch<ResponseBody = any, RequestBody = any, RequestQueryParams extends QueryParams = QueryParams>(
         url: string,
         requestOptions: RequestOptions<RequestBody, RequestQueryParams>
     ) {
         return this.ajaxCall<ResponseBody, RequestBody, RequestQueryParams>(url, 'PATCH', requestOptions);
     }
 
-    doDownload<ResponseBody = any, RequestQueryParams = QueryParams>(url: string, fileName = '') {
+    doDownload<ResponseBody = any, RequestQueryParams extends QueryParams = QueryParams>(url: string, fileName = '') {
         return this.ajaxCall<ResponseBody, never, RequestQueryParams>(url, 'get', { fileName });
     }
 
-    doUpload<ResponseBody = any, RequestQueryParams = QueryParams>(
+    doUpload<ResponseBody = any, RequestQueryParams extends QueryParams = QueryParams>(
         url: string,
         {
             params,
@@ -212,7 +212,7 @@ export default class External {
         });
     }
 
-    private ajaxCall<ResponseBody, RequestBody, RequestQueryParams>(
+    private ajaxCall<ResponseBody, RequestBody, RequestQueryParams extends QueryParams>(
         url: string,
         method: string,
         {
@@ -316,7 +316,7 @@ export default class External {
     }
 
     // eslint-disable-next-line class-methods-use-this
-    protected buildActualUrl(url: string, data?: Record<string, any>) {
+    protected buildActualUrl(url: string, data?: QueryParams) {
         return getUrlWithQueryString(url, data);
     }
 

--- a/app/utils/External.ts
+++ b/app/utils/External.ts
@@ -212,7 +212,7 @@ export default class External {
         });
     }
 
-    ajaxCall<ResponseBody, RequestBody, RequestQueryParams>(
+    private ajaxCall<ResponseBody, RequestBody, RequestQueryParams>(
         url: string,
         method: string,
         {

--- a/app/utils/auth.ts
+++ b/app/utils/auth.ts
@@ -6,7 +6,7 @@ import External from './External';
 import Internal from './Internal';
 import encodeTextToBase64 from './encodeTextToBase64';
 import type { ManagerData, LicenseData, LicenseStatus } from '../reducers/managerReducer';
-import type { GetAuthUserResponse } from '../../backend/routes/Auth.types';
+import type { GetAuthManagerResponse, GetAuthUserResponse } from '../../backend/routes/Auth.types';
 import type { LicenseResponse } from '../../backend/handler/AuthHandler.types';
 
 export default class Auth {
@@ -17,12 +17,12 @@ export default class Auth {
 
     static getManagerData(managerData: ManagerData) {
         const internal = new Internal(managerData);
-        return internal.doGet('/auth/manager');
+        return internal.doGet<GetAuthManagerResponse>('/auth/manager');
     }
 
     static getUserData(managerData: ManagerData) {
         const internal = new Internal(managerData);
-        return internal.doGet('/auth/user') as Promise<GetAuthUserResponse>;
+        return internal.doGet<GetAuthUserResponse>('/auth/user');
     }
 
     static logout(managerData: ManagerData) {

--- a/app/utils/templatesLoader.ts
+++ b/app/utils/templatesLoader.ts
@@ -9,6 +9,7 @@ import type {
     GetTemplatesResponse
 } from '../../backend/routes/Templates.types';
 
+// NOTE: Solution based on https://stackoverflow.com/questions/41253310/typescript-retrieve-element-type-information-from-array-type
 type ArrayElement<ArrayType extends readonly unknown[]> = ArrayType extends readonly (infer ElementType)[]
     ? ElementType
     : never;

--- a/app/utils/templatesLoader.ts
+++ b/app/utils/templatesLoader.ts
@@ -2,21 +2,38 @@ import { keyBy, mapValues } from 'lodash';
 import log from 'loglevel';
 import type { ManagerData } from '../reducers/managerReducer';
 import Internal from './Internal';
+import type { Page, PageGroup, Template } from '../../backend/handler/templates/types';
+import type {
+    GetPageGroupsResponse,
+    GetPagesResponse,
+    GetTemplatesResponse
+} from '../../backend/routes/Templates.types';
 
-function fetchResource(manager: ManagerData, resourceUrl = '') {
-    return new Internal(manager).doGet(`/templates${resourceUrl}`).then(resources => keyBy(resources, 'id'));
+type ArrayElement<ArrayType extends readonly unknown[]> = ArrayType extends readonly (infer ElementType)[]
+    ? ElementType
+    : never;
+
+function fetchResource<Resource extends ArrayElement<GetTemplatesResponse | GetPagesResponse | GetPageGroupsResponse>>(
+    manager: ManagerData,
+    resourceUrl = ''
+): Promise<Record<string, Resource>> {
+    return new Internal(manager)
+        .doGet<Resource[]>(`/templates${resourceUrl}`)
+        .then(resources => keyBy(resources, 'id'));
 }
 
 export default function load(manager: ManagerData) {
     return Promise.all([
-        fetchResource(manager),
-        fetchResource(manager, '/pages'),
-        fetchResource(manager, '/page-groups')
+        fetchResource<Template>(manager),
+        fetchResource<Page>(manager, '/pages'),
+        fetchResource<PageGroup>(manager, '/page-groups')
     ])
-        .then(results => ({
-            templatesDef: mapValues(results[0], 'data'),
-            pagesDef: mapValues(results[1], ({ name, data }) => ({ name, ...data })),
-            pageGroupsDef: mapValues(results[2], ({ name, icon, pages }) => ({ name, icon, pages }))
-        }))
+        .then(results => {
+            return {
+                templatesDef: mapValues(results[0], 'data'),
+                pagesDef: mapValues(results[1], ({ name, data }) => ({ name, ...data })),
+                pageGroupsDef: mapValues(results[2], ({ name, icon, pages }) => ({ name, icon, pages }))
+            };
+        })
         .catch(e => log.error(e));
 }

--- a/app/utils/widgetDefinitionsLoader.ts
+++ b/app/utils/widgetDefinitionsLoader.ts
@@ -17,6 +17,14 @@ import ScriptLoader from './scriptLoader';
 import type { WidgetDefinition } from './StageAPI';
 import StageUtils from './stageUtils';
 import StyleLoader from './StyleLoader';
+import type {
+    GetWidgetsResponse,
+    PostWidgetsQueryParams,
+    PostWidgetsResponse,
+    PutWidgetsQueryParams,
+    PutWidgetsResponse
+} from '../../backend/routes/Widgets.types';
+import type { WidgetData } from '../../backend/handler/WidgetsHandler.types';
 
 let bundleLoadedWidgets: WidgetDefinition<any, any, any>[] = [];
 
@@ -113,12 +121,12 @@ export default class WidgetDefinitionsLoader {
         return widgetDefinition;
     }
 
-    public static load(manager: any): Promise<WidgetDefinition<any, any, any>[]> {
+    public static load(manager: any): Promise<(WidgetData & { loaded: boolean })[]> {
         const internal = new Internal(manager);
         return Promise.all([
             new ScriptLoader(LoaderUtils.getResourceUrl('widgets/common/common.js', false)).load(), // Commons has to load before the widgets
-            internal.doGet('/widgets') // We can load the list of widgets in the meanwhile
-        ]).then(results => results[1].map((widget: WidgetListItem) => ({ ...widget, loaded: false })));
+            internal.doGet<GetWidgetsResponse>('/widgets') // We can load the list of widgets in the meanwhile
+        ]).then(results => results[1].map(widget => ({ ...widget, loaded: false })));
     }
 
     private static installWidget(widgetFile: any, widgetUrl: any, manager: any) {
@@ -126,14 +134,17 @@ export default class WidgetDefinitionsLoader {
 
         if (widgetUrl) {
             log.debug('Install widget from url', widgetUrl);
-            return internal.doPost('/widgets', {
+            return internal.doPost<PostWidgetsResponse, any, PostWidgetsQueryParams>('/widgets', {
                 params: {
                     url: widgetUrl
                 }
             });
         }
         log.debug('Install widget from file');
-        return internal.doUpload('/widgets', { method: 'post', files: { widget: widgetFile } });
+        return internal.doUpload<PostWidgetsResponse, PostWidgetsQueryParams>('/widgets', {
+            method: 'post',
+            files: { widget: widgetFile }
+        });
     }
 
     private static updateWidget(widgetId: any, widgetFile: any, widgetUrl: any, manager: any): Promise<WidgetListItem> {
@@ -141,10 +152,15 @@ export default class WidgetDefinitionsLoader {
 
         if (widgetUrl) {
             log.debug(`Update widget ${widgetId} from url`, widgetUrl);
-            return internal.doPut('/widgets', { params: { url: widgetUrl, id: widgetId } });
+            return internal.doPut<PutWidgetsResponse, any, PutWidgetsQueryParams>('/widgets', {
+                params: { url: widgetUrl, id: widgetId }
+            });
         }
         log.debug(`Update widget ${widgetId} from file`);
-        return internal.doUpload('/widgets', { params: { id: widgetId }, files: { widget: widgetFile } });
+        return internal.doUpload<PutWidgetsResponse, PutWidgetsQueryParams>('/widgets', {
+            params: { id: widgetId },
+            files: { widget: widgetFile }
+        });
     }
 
     private static validateWidget(widgetId: any, manager: any) {

--- a/backend/db/models/UserAppsModel.types.ts
+++ b/backend/db/models/UserAppsModel.types.ts
@@ -11,12 +11,20 @@ export interface AppDataPage {
     layout: LayoutSection[];
 }
 
+export interface AppDataPageGroup {
+    id: string;
+    name: string;
+    type: 'pageGroup';
+    icon?: string;
+    pages: AppDataPage[];
+}
+
 export interface UserAppsData {
     username: string;
     appDataVersion: number;
     mode: Mode;
     tenant: string;
-    appData: { pages: AppDataPage[] };
+    appData: { pages: (AppDataPage | AppDataPageGroup)[] };
 }
 
 export type UserAppsAttributes = CommonAttributes & UserAppsData;

--- a/backend/routes/GitHub.types.ts
+++ b/backend/routes/GitHub.types.ts
@@ -1,6 +1,11 @@
-// eslint-disable-next-line node/no-unpublished-import
+/* eslint-disable import/no-extraneous-dependencies,node/no-unpublished-import */
 import type { Endpoints } from '@octokit/types';
 
-export type GetGitHubSearchRepositoriesResponse = Endpoints['GET /search/repositories'];
+export type { Endpoints } from '@octokit/types';
 
-export type GetGitHubReposTreesResponse = Endpoints['GET /repos/{owner}/{repo}/git/trees/{tree_sha}'];
+export type GetGitHubSearchRepositoriesResponse = Endpoints['GET /search/repositories']['response']['data'] & {
+    isAuth: boolean;
+};
+
+export type GetGitHubReposTreesResponse =
+    Endpoints['GET /repos/{owner}/{repo}/git/trees/{tree_sha}']['response']['data'];

--- a/backend/routes/Plugins.ts
+++ b/backend/routes/Plugins.ts
@@ -11,13 +11,17 @@ import { getLogger } from '../handler/LoggerHandler';
 import * as ManagerHandler from '../handler/ManagerHandler';
 import { forward, getResponseForwarder, requestAndForwardResponse } from '../handler/RequestHandler';
 import { getHeadersWithAuthenticationTokenFromRequest } from '../utils';
-import type { PostPluginsUploadQueryParams, PutPluginsTitleResponse } from './Plugins.types';
+import type {
+    PostPluginsUploadQueryParams,
+    PutPluginsTitleRequestQueryParams,
+    PutPluginsTitleResponse
+} from './Plugins.types';
 import type { GenericErrorResponse } from '../types';
 
 const router = express.Router();
 const upload = multer();
 const logger = getLogger('Plugins');
-const getFiles = (req: Request) => req.files as { [fieldname: string]: Express.Multer.File[] };
+const getFiles = (req: Request<any, any, any, any, any>) => req.files as { [fieldname: string]: Express.Multer.File[] };
 
 function checkParams(req: Request, res: Response, next: NextFunction) {
     const files = getFiles(req);
@@ -93,8 +97,12 @@ router.get('/icons/:pluginId', (req, res) => {
 router.put(
     '/title',
     upload.fields(_.map(['yaml_file'], name => ({ name, maxCount: 1 }))),
-    (req, res: Response<PutPluginsTitleResponse>) => {
+    (
+        req: Request<never, PutPluginsTitleResponse, any, PutPluginsTitleRequestQueryParams>,
+        res: Response<PutPluginsTitleResponse>
+    ) => {
         let getPluginYaml: Promise<any>;
+
         if (typeof req.query.yamlUrl === 'string') {
             getPluginYaml = downloadFile(req.query.yamlUrl);
         } else {

--- a/backend/routes/Plugins.types.ts
+++ b/backend/routes/Plugins.types.ts
@@ -33,6 +33,10 @@ export interface PutPluginsTitleResponse {
     title: string;
 }
 
+export interface PutPluginsTitleRequestQueryParams {
+    yamlUrl?: string;
+}
+
 export interface PostPluginsUploadQueryParams {
     iconUrl?: string;
     title: string;

--- a/backend/routes/Widgets.ts
+++ b/backend/routes/Widgets.ts
@@ -4,7 +4,7 @@ import * as WidgetsHandler from '../handler/WidgetsHandler';
 import { getRBAC, isAuthorized } from '../handler/AuthHandler';
 import { getTokenFromCookies } from '../utils';
 import type {
-    GetWidgetsListResponse,
+    GetWidgetsResponse,
     GetWidgetsUsedResponse,
     PostWidgetsQueryParams,
     PostWidgetsResponse,
@@ -16,7 +16,7 @@ const router = express.Router();
 
 router.use(express.json());
 
-router.get('/', (_req, res: Response<GetWidgetsListResponse>, next) => {
+router.get('/', (_req, res: Response<GetWidgetsResponse>, next) => {
     WidgetsHandler.listWidgets()
         .then(widgets => res.send(widgets))
         .catch(next);

--- a/backend/routes/Widgets.types.ts
+++ b/backend/routes/Widgets.types.ts
@@ -2,7 +2,7 @@
 import type { Query } from 'express-serve-static-core';
 import type { WidgetData, WidgetUsage } from '../handler/WidgetsHandler.types';
 
-export type GetWidgetsListResponse = WidgetData[];
+export type GetWidgetsResponse = WidgetData[];
 
 export type GetWidgetsUsedResponse = WidgetUsage[];
 

--- a/widgets/blueprintCatalog/src/actions.ts
+++ b/widgets/blueprintCatalog/src/actions.ts
@@ -1,5 +1,6 @@
 import Consts from './consts';
 import type { WidgetParameters } from './types';
+import type { GetExternalContentQueryParams } from '../../../backend/routes/External.types';
 
 export default class Actions {
     private toolbox: Stage.Types.WidgetlessToolbox;
@@ -22,11 +23,14 @@ export default class Actions {
     }
 
     doGetRepos(params: WidgetParameters) {
-        if (!_.isEmpty(this.jsonPath)) {
+        if (this.jsonPath) {
             // JSON URL
             return this.toolbox
                 .getInternal()
-                .doGet('/external/content', { params: { url: this.jsonPath }, parseResponse: false })
+                .doGet<any, GetExternalContentQueryParams>('/external/content', {
+                    params: { url: this.jsonPath },
+                    parseResponse: false
+                })
                 .then(response => response.json())
                 .then(data =>
                     Promise.resolve({
@@ -47,8 +51,8 @@ export default class Actions {
             .then(data => Promise.resolve({ ...data, source: Consts.GITHUB_DATA_SOURCE }));
     }
 
-    doGetReadme(readmeUrl: string): Promise<string> {
-        return this.toolbox.getInternal().doGet(readmeUrl);
+    doGetReadme(readmeUrl: string) {
+        return this.toolbox.getInternal().doGet<string>(readmeUrl);
     }
 
     doGetRepoTree(repositoryName: string) {

--- a/widgets/blueprintCatalog/src/actions.ts
+++ b/widgets/blueprintCatalog/src/actions.ts
@@ -27,7 +27,7 @@ export default class Actions {
             // JSON URL
             return this.toolbox
                 .getInternal()
-                .doGet<any, GetExternalContentQueryParams>('/external/content', {
+                .doGet<Response, GetExternalContentQueryParams>('/external/content', {
                     params: { url: this.jsonPath },
                     parseResponse: false
                 })

--- a/widgets/blueprintCatalog/src/actions.ts
+++ b/widgets/blueprintCatalog/src/actions.ts
@@ -1,6 +1,10 @@
 import Consts from './consts';
 import type { WidgetParameters } from './types';
 import type { GetExternalContentQueryParams } from '../../../backend/routes/External.types';
+import type {
+    GetGitHubReposTreesResponse,
+    GetGitHubSearchRepositoriesResponse
+} from '../../../backend/routes/GitHub.types';
 
 export default class Actions {
     private toolbox: Stage.Types.WidgetlessToolbox;
@@ -47,7 +51,7 @@ export default class Actions {
                 params,
                 parseResponse: false
             })
-            .then(response => Promise.resolve(response.json()))
+            .then(response => Promise.resolve(response.json() as GetGitHubSearchRepositoriesResponse))
             .then(data => Promise.resolve({ ...data, source: Consts.GITHUB_DATA_SOURCE }));
     }
 
@@ -56,7 +60,9 @@ export default class Actions {
     }
 
     doGetRepoTree(repositoryName: string) {
-        return this.toolbox.getInternal().doGet(`/github/repos/${this.username}/${repositoryName}/git/trees/master`);
+        return this.toolbox
+            .getInternal()
+            .doGet<GetGitHubReposTreesResponse>(`/github/repos/${this.username}/${repositoryName}/git/trees/master`);
     }
 
     doFindImage(repositoryName: string): Promise<string> {

--- a/widgets/blueprintCatalog/src/widget.tsx
+++ b/widgets/blueprintCatalog/src/widget.tsx
@@ -107,9 +107,10 @@ Stage.defineWidget<WidgetParameters, BlueprintCatalogPayload | Error, BlueprintC
             .then(([data, uploadedBlueprintsResp]) => {
                 const uploadedBlueprints = uploadedBlueprintsResp.items.map(({ id }: Partial<Blueprint>) => id);
                 let repos: Blueprint[] = data.items;
-                const { source } = data.source;
+                const { source } = data;
                 const total = data.total_count;
-                if (data.source === Consts.GITHUB_DATA_SOURCE) {
+                if (source === Consts.GITHUB_DATA_SOURCE) {
+                    // @ts-ignore TODO(RD-5993) Types should be improved once new Blueprint Marketplace API is ready
                     const isAuthenticated = data.isAuth;
 
                     const fetches = _.map(repos, repo =>

--- a/widgets/blueprintSources/src/BlueprintSources.tsx
+++ b/widgets/blueprintSources/src/BlueprintSources.tsx
@@ -143,7 +143,7 @@ export default function BlueprintSources({ data, toolbox, widget }: BlueprintSou
         const actions = new Actions(toolbox);
         actions
             .doGetFileContent(path)
-            .then((responseBody: string) => {
+            .then(responseBody => {
                 if (isImage) {
                     clearContent();
                 } else {

--- a/widgets/blueprintSources/src/actions.ts
+++ b/widgets/blueprintSources/src/actions.ts
@@ -1,19 +1,22 @@
-// @ts-nocheck File not migrated fully to TS
+import type {
+    GetSourceBrowseBlueprintArchiveResponse,
+    GetSourceBrowseBlueprintFileResponse
+} from '../../../backend/routes/SourceBrowser.types';
 
 export default class {
-    constructor(toolbox) {
-        this.toolbox = toolbox;
-    }
+    constructor(private readonly toolbox: Stage.Types.Toolbox) {}
 
-    doGetBlueprintId(deploymentId) {
+    doGetBlueprintId(deploymentId: string) {
         return this.toolbox.getManager().doGet(`/deployments/${deploymentId}?_include=id,blueprint_id`);
     }
 
-    doGetFilesTree(blueprintId) {
-        return this.toolbox.getInternal().doGet(`/source/browse/${blueprintId}/archive`);
+    doGetFilesTree(blueprintId: string) {
+        return this.toolbox
+            .getInternal()
+            .doGet<GetSourceBrowseBlueprintArchiveResponse>(`/source/browse/${blueprintId}/archive`);
     }
 
-    doGetBlueprintDetails(blueprintId) {
+    doGetBlueprintDetails(blueprintId: string) {
         return this.toolbox
             .getManager()
             .doGet(`/blueprints?id=${blueprintId}&_include=plan,main_file_name`)
@@ -23,7 +26,7 @@ export default class {
             }));
     }
 
-    doGetFileContent(path) {
-        return this.toolbox.getInternal().doGet(`/source/browse/${path}`);
+    doGetFileContent(path: string) {
+        return this.toolbox.getInternal().doGet<GetSourceBrowseBlueprintFileResponse>(`/source/browse/${path}`);
     }
 }

--- a/widgets/common/src/actions/FileActions.ts
+++ b/widgets/common/src/actions/FileActions.ts
@@ -1,15 +1,15 @@
+import type { PostFileTextResponse, PostFileYamlResponse } from '../../../../backend/routes/File.types';
+
 export default class FileActions {
     constructor(private toolbox: Stage.Types.WidgetlessToolbox) {}
 
     doGetTextFileContent(file: File) {
         return this.toolbox
             .getInternal()
-            .doUpload('/file/text', { files: { file }, method: 'post', parseResponse: false });
+            .doUpload<PostFileTextResponse>('/file/text', { files: { file }, method: 'post', parseResponse: false });
     }
 
-    doGetYamlFileContent(file: File): Promise<Record<string, any>> {
-        return this.toolbox.getInternal().doUpload('/file/yaml', { files: { file }, method: 'post' }) as Promise<
-            Record<string, any>
-        >;
+    doGetYamlFileContent<YamlResponse extends PostFileYamlResponse>(file: File) {
+        return this.toolbox.getInternal().doUpload<YamlResponse>('/file/yaml', { files: { file }, method: 'post' });
     }
 }

--- a/widgets/common/src/blueprints/BlueprintActions.ts
+++ b/widgets/common/src/blueprints/BlueprintActions.ts
@@ -3,6 +3,11 @@ import Consts from '../Consts';
 import DeploymentActions from '../deployments/DeploymentActions';
 import type { Label } from '../labels/types';
 import PollHelper from '../utils/PollHelper';
+import type { GetExternalContentQueryParams } from '../../../../backend/routes/External.types';
+import type {
+    PutSourceListYamlQueryParams,
+    PutSourceListYamlResponse
+} from '../../../../backend/routes/SourceBrowser.types';
 
 class BlueprintUploadError extends Error {
     constructor(message: string | null, public state: string) {
@@ -249,7 +254,10 @@ export default class BlueprintActions {
                 imageFile = await (
                     await this.toolbox
                         .getInternal()
-                        .doGet('/external/content', { params: { url: imageUrl }, parseResponse: false })
+                        .doGet<Response, GetExternalContentQueryParams>('/external/content', {
+                            params: { url: imageUrl },
+                            parseResponse: false
+                        })
                 ).blob();
             } catch (error) {
                 throw new Error(Stage.i18n.t('widgets.common.blueprintUpload.validationErrors.invalidImageUrl'));
@@ -305,11 +313,16 @@ export default class BlueprintActions {
         if (file) {
             return this.toolbox
                 .getInternal()
-                .doUpload('/source/list/yaml', { params: { includeFilename }, files: { archive: file } });
+                .doUpload<PutSourceListYamlResponse, PutSourceListYamlQueryParams>('/source/list/yaml', {
+                    params: { includeFilename: String(includeFilename) },
+                    files: { archive: file }
+                });
         }
         return this.toolbox
             .getInternal()
-            .doPut('/source/list/yaml', { params: { url: blueprintUrl, includeFilename } });
+            .doPut<PutSourceListYamlResponse, any, PutSourceListYamlQueryParams>('/source/list/yaml', {
+                params: { url: blueprintUrl, includeFilename: String(includeFilename) }
+            });
     }
 
     async doUploadImage(blueprintId: string, imageFile?: Blob) {

--- a/widgets/common/src/deployModal/GenericDeployModal.tsx
+++ b/widgets/common/src/deployModal/GenericDeployModal.tsx
@@ -295,8 +295,8 @@ class GenericDeployModal extends React.Component<GenericDeployModalProps, Generi
         this.setState({ fileLoading: true });
 
         actions
-            .doGetYamlFileContent(file)
-            .then((yamlInputs: Blueprint) => {
+            .doGetYamlFileContent<Blueprint>(file)
+            .then(yamlInputs => {
                 const deploymentInputs = getUpdatedInputs(blueprint.plan.inputs, deploymentInputsState, yamlInputs);
                 this.setState({ errors: {}, deploymentInputs, fileLoading: false });
             })

--- a/widgets/common/src/filters/FilterActions.ts
+++ b/widgets/common/src/filters/FilterActions.ts
@@ -1,4 +1,5 @@
-import type { Filter, FilterUsage, FilterRule } from './types';
+import type { Filter, FilterRule } from './types';
+import type { GetFiltersUsageResponse } from '../../../../backend/routes/Filters.types';
 
 export default class FilterActions {
     constructor(private toolbox: Stage.Types.Toolbox) {}
@@ -11,8 +12,8 @@ export default class FilterActions {
         return this.toolbox.getManager().doDelete(`/filters/deployments/${filterId}`);
     }
 
-    doGetFilterUsage(filterId: string): Promise<FilterUsage[]> {
-        return this.toolbox.getInternal().doGet(`/filters/usage/${filterId}`);
+    doGetFilterUsage(filterId: string) {
+        return this.toolbox.getInternal().doGet<GetFiltersUsageResponse>(`/filters/usage/${filterId}`);
     }
 
     doCreate(filterId: string, filterRules: FilterRule[]) {

--- a/widgets/common/src/plugins/PluginActions.ts
+++ b/widgets/common/src/plugins/PluginActions.ts
@@ -1,3 +1,5 @@
+import type { PostPluginsUploadQueryParams } from '../../../../backend/routes/Plugins.types';
+
 class PluginActions {
     constructor(private readonly toolbox: Stage.Types.Toolbox) {}
 
@@ -5,22 +7,29 @@ class PluginActions {
         return this.toolbox.getManager().doDelete(`/plugins/${plugin.id}`, { body: { force } });
     }
 
-    doUpload(visibility: string, title: string, resources: Record<string, { url: string; file: unknown }>) {
-        const params: Record<string, unknown> = { visibility, title };
+    doUpload(
+        visibility: string,
+        title: string,
+        resources: Record<'wagon' | 'yaml' | 'icon', { url: string; file: unknown }>
+    ) {
+        const params: PostPluginsUploadQueryParams = { visibility, title };
         const files: Record<string, unknown> = {};
 
         _.each(resources, ({ url, file }, name) => {
+            const paramName = `${name}Url` as keyof PostPluginsUploadQueryParams;
             if (file) {
-                params[`${name}Url`] = '';
+                params[paramName] = '';
                 files[`${name}_file`] = file;
             } else if (!_.isEmpty(url)) {
-                params[`${name}Url`] = url;
+                params[paramName] = url;
             }
         });
 
-        return this.toolbox
-            .getInternal()
-            .doUpload('/plugins/upload', { params, files: !_.isEmpty(files) ? files : undefined, method: 'post' });
+        return this.toolbox.getInternal().doUpload<any, PostPluginsUploadQueryParams>('/plugins/upload', {
+            params,
+            files: !_.isEmpty(files) ? files : undefined,
+            method: 'post'
+        });
     }
 
     // eslint-disable-next-line camelcase

--- a/widgets/common/src/plugins/UploadPluginForm.tsx
+++ b/widgets/common/src/plugins/UploadPluginForm.tsx
@@ -1,5 +1,10 @@
 // @ts-nocheck File not migrated fully to TS
 
+import type {
+    PutPluginsTitleResponse,
+    PutPluginsTitleRequestQueryParams
+} from '../../../../backend/routes/Plugins.types';
+
 const placeholders = {
     wagon: "Provide the plugin's wagon file URL or click browse to select a file",
     yaml: "Provide the plugin's YAML file URL or click browse to select a file",
@@ -79,7 +84,9 @@ class UploadPluginForm extends React.Component {
                         this.setState({ loading: true });
                         toolbox
                             .getInternal()
-                            .doUpload('/plugins/title', { files: { yaml_file: pluginYamlFile } })
+                            .doUpload<PutPluginsTitleResponse>('/plugins/title', {
+                                files: { yaml_file: pluginYamlFile }
+                            })
                             .then(onTitleChange)
                             .finally(() => this.setState({ loading: false }));
                     }
@@ -90,7 +97,10 @@ class UploadPluginForm extends React.Component {
                         this.setState({ loading: true });
                         toolbox
                             .getInternal()
-                            .doPut('/plugins/title', { params: { yamlUrl: pluginYamlUrl } })
+                            .doPut<PutPluginsTitleResponse, never, PutPluginsTitleRequestQueryParams>(
+                                '/plugins/title',
+                                { params: { yamlUrl: pluginYamlUrl } }
+                            )
                             .then(onTitleChange)
                             .finally(() => this.setState({ loading: false }));
                     }

--- a/widgets/common/src/terraformModal/TerraformActions.ts
+++ b/widgets/common/src/terraformModal/TerraformActions.ts
@@ -1,30 +1,48 @@
 import type {
     PostTerraformBlueprintArchiveRequestBody,
-    PostTerraformBlueprintRequestBody
+    PostTerraformBlueprintRequestBody,
+    PostTerraformBlueprintResponse,
+    PostTerraformFetchDataFileResponse,
+    PostTerraformFetchDataRequestBody,
+    PostTerraformFetchDataResponse,
+    PostTerraformResourcesFileResponse,
+    PostTerraformResourcesQueryParams,
+    PostTerraformResourcesResponse
 } from '../../../../backend/routes/Terraform.types';
 
 export default class TerraformActions {
     constructor(private toolbox: Stage.Types.WidgetlessToolbox) {}
 
     doGenerateBlueprint(body: PostTerraformBlueprintRequestBody) {
-        return this.toolbox.getInternal().doPost('/terraform/blueprint', { body });
+        return this.toolbox
+            .getInternal()
+            .doPost<PostTerraformBlueprintResponse, PostTerraformBlueprintRequestBody>('/terraform/blueprint', {
+                body
+            });
     }
 
     doGenerateBlueprintArchive(body: PostTerraformBlueprintArchiveRequestBody) {
-        return this.toolbox.getInternal().doPost('/terraform/blueprint/archive', { body, parseResponse: false });
+        return this.toolbox
+            .getInternal()
+            .doPost<Response, PostTerraformBlueprintArchiveRequestBody>('/terraform/blueprint/archive', {
+                body,
+                parseResponse: false
+            });
     }
 
     doGetTemplateModulesByUrl(templateUrl: string, username?: string, password?: string) {
         const headers = username ? { Authorization: `Basic ${btoa(`${username}:${password}`)}` } : undefined;
-        return this.toolbox.getInternal().doPost('/terraform/resources', {
-            params: { templateUrl },
-            headers,
-            validateAuthentication: false
-        });
+        return this.toolbox
+            .getInternal()
+            .doPost<PostTerraformResourcesResponse, never, PostTerraformResourcesQueryParams>('/terraform/resources', {
+                params: { templateUrl },
+                headers,
+                validateAuthentication: false
+            });
     }
 
     doGetTemplateModulesByFile(file: File) {
-        return this.toolbox.getInternal().doUpload('/terraform/resources/file', {
+        return this.toolbox.getInternal().doUpload<PostTerraformResourcesFileResponse>('/terraform/resources/file', {
             method: 'POST',
             files: {
                 file
@@ -35,17 +53,19 @@ export default class TerraformActions {
     doGetOutputsAndVariablesByURL(templateUrl: string, resourceLocation: string, username?: string, password?: string) {
         const headers = username ? { Authorization: `Basic ${btoa(`${username}:${password}`)}` } : undefined;
 
-        return this.toolbox.getInternal().doPost('/terraform/fetch-data', {
-            body: {
-                templateUrl,
-                resourceLocation
-            },
-            headers
-        });
+        return this.toolbox
+            .getInternal()
+            .doPost<PostTerraformFetchDataResponse, PostTerraformFetchDataRequestBody>('/terraform/fetch-data', {
+                body: {
+                    templateUrl,
+                    resourceLocation
+                },
+                headers
+            });
     }
 
     doGetOutputsAndVariablesByFile(file: string, resourceLocation: string) {
-        return this.toolbox.getInternal().doPost('/terraform/fetch-data/file', {
+        return this.toolbox.getInternal().doPost<PostTerraformFetchDataFileResponse>('/terraform/fetch-data/file', {
             body: {
                 file,
                 resourceLocation

--- a/widgets/plugins/src/widget.tsx
+++ b/widgets/plugins/src/widget.tsx
@@ -32,7 +32,7 @@ Stage.defineWidget({
                     _.map(data.items, item =>
                         toolbox
                             .getInternal()
-                            .doGet(`/plugins/icons/${item.id}`, { parseResponse: false })
+                            .doGet<Response>(`/plugins/icons/${item.id}`, { parseResponse: false })
                             .then(response => response.blob())
                             .then(
                                 blob =>

--- a/widgets/pluginsCatalog/src/Actions.ts
+++ b/widgets/pluginsCatalog/src/Actions.ts
@@ -43,7 +43,7 @@ export default class Actions {
     private doGetPluginsCatalogList(): Promise<PluginDescription[]> {
         return this.toolbox
             .getInternal()
-            .doGet<any, GetExternalContentQueryParams>('/external/content', {
+            .doGet<Response, GetExternalContentQueryParams>('/external/content', {
                 params: { url: this.jsonPath },
                 parseResponse: false
             })

--- a/widgets/pluginsCatalog/src/Actions.ts
+++ b/widgets/pluginsCatalog/src/Actions.ts
@@ -1,4 +1,6 @@
 import type { PluginDescription, PluginDescriptionWithVersion, PluginUploadData } from './types';
+import type { GetExternalContentQueryParams } from '../../../backend/routes/External.types';
+import type { PostPluginsUploadQueryParams } from '../../../backend/routes/Plugins.types';
 
 interface UploadedPlugin {
     // NOTE: property names match from the backend ones
@@ -41,7 +43,10 @@ export default class Actions {
     private doGetPluginsCatalogList(): Promise<PluginDescription[]> {
         return this.toolbox
             .getInternal()
-            .doGet('/external/content', { params: { url: this.jsonPath }, parseResponse: false })
+            .doGet<any, GetExternalContentQueryParams>('/external/content', {
+                params: { url: this.jsonPath },
+                parseResponse: false
+            })
             .then(response => response.json());
     }
 
@@ -54,6 +59,8 @@ export default class Actions {
             title
         };
 
-        return this.toolbox.getInternal().doUpload('/plugins/upload', { params, method: 'post' });
+        return this.toolbox
+            .getInternal()
+            .doUpload<any, PostPluginsUploadQueryParams>('/plugins/upload', { params, method: 'post' });
     }
 }

--- a/widgets/topology/src/DataFetcher.ts
+++ b/widgets/topology/src/DataFetcher.ts
@@ -1,5 +1,6 @@
 // @ts-nocheck File not migrated fully to TS
 import _ from 'lodash';
+import type { GetBlueprintUserDataLayoutResponse } from '../../../backend/routes/BlueprintUserData.types';
 
 export default class DataFetcher {
     static fetch(toolbox, blueprintId, deploymentId, fetchLayout) {
@@ -8,7 +9,10 @@ export default class DataFetcher {
         }
 
         function getLayoutPromise(layoutBlueprintId) {
-            return toolbox.getInternal().doGet(`/bud/layout/${layoutBlueprintId}`).catch(_.constant(null));
+            return toolbox
+                .getInternal()
+                .doGet<GetBlueprintUserDataLayoutResponse>(`/bud/layout/${layoutBlueprintId}`)
+                .catch(_.constant(null));
         }
 
         if (deploymentId) {

--- a/widgets/topology/src/Topology.tsx
+++ b/widgets/topology/src/Topology.tsx
@@ -5,6 +5,7 @@ import type { RefObject } from 'react';
 import { createExpandedTopology } from './DataProcessor';
 import ScrollerGlassHandler from './ScrollerGlassHandler';
 import TerraformDetailsModal from './TerraformDetailsModal';
+import type { PutBlueprintUserDataLayoutRequestBody } from '../../../backend/routes/BlueprintUserData.types';
 
 const saveConfirmationTimeout = 2500;
 
@@ -206,7 +207,7 @@ export default class Topology extends React.Component<TopologyProps, TopologySta
             onLayoutSave: body =>
                 toolbox
                     .getInternal()
-                    .doPut(`/bud/layout/${blueprintId}`, { body })
+                    .doPut<any, PutBlueprintUserDataLayoutRequestBody>(`/bud/layout/${blueprintId}`, { body })
                     .then(() => {
                         this.setState({ saveConfirmationOpen: true });
                         setTimeout(() => this.setState({ saveConfirmationOpen: false }), saveConfirmationTimeout);

--- a/widgets/topology/src/widget.tsx
+++ b/widgets/topology/src/widget.tsx
@@ -108,7 +108,7 @@ Stage.defineWidget({
 
                                 return toolbox
                                     .getInternal()
-                                    .doGet(`/plugins/icons/${pluginId}`, { parseResponse: false })
+                                    .doGet<Response>(`/plugins/icons/${pluginId}`, { parseResponse: false })
                                     .then(response => response.blob())
                                     .then(
                                         blob =>


### PR DESCRIPTION
## Description

Main change introduced in this PR is backend types reuse in frontend package. I search for all calls to HTTP client methods exposed by `Internal` class (e.g. `toolbox.getInternal().doGet`).

Additional changes:

* Minor improvements in backend types
* Fixed `getFilterUsage` function (did not take into account that `appData.pages` is an array of either pages or page-groups

## Screenshots / Videos
N/A

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [x] I followed the [UI Testing Guidelines](https://cloudifysource.atlassian.net/l/cp/udCVfvrx) and verified that all tests/checks have passed.
- [x] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [x] I added proper labels to this PR.

## Tests
Type changes only, so I believe passing CI should be enough and no need for system tests execution.

## Documentation
N/A