### PR TITLE
RD-5266 Add check for Deploy blueprint modal existence after successful blueprint upload in blueprint_terraform_spec

### DIFF
--- a/test/cypress/integration/widgets/blueprints_terraform_spec.ts
+++ b/test/cypress/integration/widgets/blueprints_terraform_spec.ts
@@ -257,6 +257,8 @@ describe('Blueprints widget should open upload from Terraform module modal and',
                 expect(response.body.value).to.equal(secret.value);
             });
         });
+
+        cy.contains('.modal', 'Deploy blueprint');
     });
 
     it('handle template URL 401', () => {
@@ -366,6 +368,8 @@ describe('Blueprints widget should open upload from Terraform module modal and',
         cy.getSecret(`${blueprintName}.password`).then(response => {
             expect(response.body.value).to.equal(password);
         });
+
+        cy.contains('.modal', 'Deploy blueprint');
     });
 
     describe.skip('create installable blueprint on submit from', () => {


### PR DESCRIPTION
## Description

`blueprint_spec` was failing from time to time in "handle template URL 401" test case.
Added a check for Deploy blueprint modal existence after successful blueprint upload hoping that it'll reduce test flakiness.

## Screenshots / Videos
N/A

## Checklist
- [x] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [x] I followed the [UI Testing Guidelines](https://cloudifysource.atlassian.net/l/cp/udCVfvrx) and verified that all tests/checks have passed.
- [x] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [x] I added proper labels to this PR.

## Tests
[![Build Status](https://jenkins.cloudify.co/buildStatus/icon?job=Stage-UI-System-Test&build=3666)](https://jenkins.cloudify.co/view/UI%20Health%20View/job/Stage-UI-System-Test/3666/)

## Documentation
N/A