### PR TITLE
RD-6089 Bump `elkjs` package version

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -23,7 +23,7 @@
                 "decompress": "^4.2.1",
                 "directory-tree": "^3.2.2",
                 "ejs": "^3.1.7",
-                "elkjs": "^0.4.1",
+                "elkjs": "^0.8.2",
                 "express": "^4.14.0",
                 "express-static-gzip": "^2.1.7",
                 "flat": "^4.1.1",
@@ -6844,9 +6844,9 @@
             "integrity": "sha512-R3RV3rU1xWwFJlSClVWDvARaOk6VUO/FubHLodIASDB3Mc2dzuWvNdfOgH9bwHUTqT79u92qw60NWfwUdzAqdg=="
         },
         "node_modules/elkjs": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.4.1.tgz",
-            "integrity": "sha512-fiVIfjlVptEaFw6QydlZWKEV80MnlNDtfiFeHcbL65i2+UaknKVhFW0VVB8YmHbaMYKNUJ/9CKlOqPmarGuZBQ=="
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.8.2.tgz",
+            "integrity": "sha512-L6uRgvZTH+4OF5NE/MBbzQx/WYpru1xCBE9respNj6qznEewGUIfhzmm7horWWxbNO2M0WckQypGctR8lH79xQ=="
         },
         "node_modules/emittery": {
             "version": "0.10.2",
@@ -25252,9 +25252,9 @@
             "integrity": "sha512-R3RV3rU1xWwFJlSClVWDvARaOk6VUO/FubHLodIASDB3Mc2dzuWvNdfOgH9bwHUTqT79u92qw60NWfwUdzAqdg=="
         },
         "elkjs": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.4.1.tgz",
-            "integrity": "sha512-fiVIfjlVptEaFw6QydlZWKEV80MnlNDtfiFeHcbL65i2+UaknKVhFW0VVB8YmHbaMYKNUJ/9CKlOqPmarGuZBQ=="
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.8.2.tgz",
+            "integrity": "sha512-L6uRgvZTH+4OF5NE/MBbzQx/WYpru1xCBE9respNj6qznEewGUIfhzmm7horWWxbNO2M0WckQypGctR8lH79xQ=="
         },
         "emittery": {
             "version": "0.10.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -42,7 +42,7 @@
         "decompress": "^4.2.1",
         "directory-tree": "^3.2.2",
         "ejs": "^3.1.7",
-        "elkjs": "^0.4.1",
+        "elkjs": "^0.8.2",
         "express": "^4.14.0",
         "express-static-gzip": "^2.1.7",
         "flat": "^4.1.1",

--- a/backend/test/widgets/executions/references/root-level-task_elk-graph.json
+++ b/backend/test/widgets/executions/references/root-level-task_elk-graph.json
@@ -1,8 +1,8 @@
 {
-    "$H": 12,
+    "$H": 13,
     "children": [
         {
-            "$H": 276,
+            "$H": 277,
             "children": [],
             "edges": [],
             "height": 50,
@@ -29,7 +29,7 @@
             "y": 12
         },
         {
-            "$H": 280,
+            "$H": 281,
             "children": [],
             "edges": [],
             "height": 50,
@@ -58,11 +58,14 @@
     ],
     "edges": [
         {
+            "container": "tasksGraph",
             "id": "615c9095-8a76-455f-99a1-fc1936658998_55c9a5f6-48c3-45fb-b238-026bcbf3812a",
             "sections": [
                 {
                     "endPoint": { "x": 332, "y": 37 },
                     "id": "615c9095-8a76-455f-99a1-fc1936658998_55c9a5f6-48c3-45fb-b238-026bcbf3812a_s0",
+                    "incomingShape": "615c9095-8a76-455f-99a1-fc1936658998",
+                    "outgoingShape": "55c9a5f6-48c3-45fb-b238-026bcbf3812a",
                     "startPoint": { "x": 282, "y": 37 }
                 }
             ],


### PR DESCRIPTION
## Description

Bumped `elkjs` package version to satisfy Snyk license audit (unfortunately it doesn't say what actually is the problem). 
One thing I spotted is that newer `elkjs` uses EPL-2.0 and not deprecated EPL-1.0.

I did quick investigation and I'm not sure it still is copyleft license and I'm not sure it solves copyleft-license-related concerns.
More: https://snyk.io/learn/open-source-licenses/

We use `elkjs` package only in Executions widget backend.

## Screenshots / Videos
N/A

## Checklist
- [x] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [x] I followed the [UI Testing Guidelines](https://cloudifysource.atlassian.net/l/cp/udCVfvrx) and verified that all tests/checks have passed.
- [x] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [x] I added proper labels to this PR.

## Tests

[![Build Status](https://jenkins.cloudify.co/buildStatus/icon?job=Stage-UI-System-Test&build=3668)](https://jenkins.cloudify.co/view/UI%20Health%20View/job/Stage-UI-System-Test/3668/) - only Executions widget test - PASSED

## Documentation
N/A
