### PR TITLE
RD-6337 Fix `build:widget` NPM script

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -86,6 +86,9 @@ pipeline {
                 echo "Install dependencies"
                 sh 'npm run beforebuild'
                 archiveFolder('~/.npm', "${WORKSPACE}/${STAGE_DIR}/package-lock.json ${WORKSPACE}/${STAGE_DIR}/backend/package-lock.json", 'stage-mb', 'npm_dir', '/mnt/data')
+                echo "Build single widget"
+                sh 'npm run build:widget executions'
+                sh 'test ${WORKSPACE}/${STAGE_DIR}/dist/executions.zip'
                 echo "Build application"
                 sh 'npm run build'
               }

--- a/scripts/buildWidget.sh
+++ b/scripts/buildWidget.sh
@@ -2,4 +2,4 @@
 
 WIDGET_NAME=$1
 bestzip --version > /dev/null || npm install -g bestzip
-npm run build -- --widget=$WIDGET_NAME && cd dist/widgets && bestzip ../$WIDGET_NAME.zip $WIDGET_NAME
+npm run build -- --env widget=$WIDGET_NAME && cd dist/widgets && bestzip ../$WIDGET_NAME.zip $WIDGET_NAME

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,8 +17,8 @@ const CONTEXT_PATH = '/console';
 module.exports = (env, argv) => {
     const isProduction = argv.mode === 'production';
     const isDevelopment = argv.mode === 'development';
-    const isSingleWidgetBuild = !!argv.widget;
-    const widgetName = argv.widget;
+    const isSingleWidgetBuild = !!env.widget;
+    const widgetName = env.widget;
     const mode = isProduction ? 'production' : 'development';
     const context = path.join(__dirname);
     const devtool = isProduction ? undefined : 'eval-source-map';


### PR DESCRIPTION
## Description
After migration to Webpack 5 (RD-2853) `build:widget` NPM script in Stage stopped working.
This PR brings it back to live and adds CI check to avoid such issues in the future.

## Screenshots / Videos
N/A

## Checklist
- [x] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [x] I followed the [UI Testing Guidelines](https://cloudifysource.atlassian.net/l/cp/udCVfvrx) and verified that all tests/checks have passed.
- [x] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [x] I added proper labels to this PR.

## Tests
Manual tests + Jenkins CI pipeline.

## Documentation
Widget building already described in [widgets/README.md](https://github.com/cloudify-cosmo/cloudify-stage/blob/94665179a08b63f37df0836c9a0cbcb8ccc44836/widgets/README.md).