### PR TITLE
RD-5423 Fix support for Deploy action in Deploy On modal

### DIFF
--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -1148,7 +1148,12 @@
                                     "help": "Specify a text which will be appended to each deployment name"
                                 }
                             },
-                            "steps": {
+                            "deploySteps": {
+                                "validatingData": "1/3: Validating data...",
+                                "fetchingEnvironments": "2/3: Fetching environments list...",
+                                "creatingDeployments": "3/3: Creating deployments..."
+                            },
+                            "deployAndInstallSteps": {
                                 "validatingData": "1/4: Validating data...",
                                 "fetchingEnvironments": "2/4: Fetching environments list...",
                                 "creatingDeployments": "3/4: Creating deployments...",

--- a/widgets/common/src/deployModal/DeployModalActions.tsx
+++ b/widgets/common/src/deployModal/DeployModalActions.tsx
@@ -27,13 +27,15 @@ const ApproveButtons: FunctionComponent<ApproveButtonsProps> = ({
     const { ApproveButton, Button, Dropdown } = Stage.Basic;
 
     if (!showDeployButton) {
-        <ApproveButton
-            onClick={onInstall}
-            disabled={loading}
-            content={t('buttons.deployAndInstall')}
-            icon="cogs"
-            className="green"
-        />;
+        return (
+            <ApproveButton
+                onClick={onInstall}
+                disabled={loading}
+                content={t('buttons.deployAndInstall')}
+                icon="cogs"
+                className="green"
+            />
+        );
     }
     return (
         <Button.Group color="green">

--- a/widgets/common/src/deployModal/GenericDeployModal.tsx
+++ b/widgets/common/src/deployModal/GenericDeployModal.tsx
@@ -1,6 +1,7 @@
 import type { AccordionTitleProps, CheckboxProps } from 'semantic-ui-react';
 import type { ChangeEvent, SyntheticEvent } from 'react';
 import type { DateInputProps } from 'cloudify-ui-components/typings/components/form/DateInput/DateInput';
+import { isEmpty } from 'lodash';
 import FileActions from '../actions/FileActions';
 import BlueprintActions from '../blueprints/BlueprintActions';
 import DynamicDropdown from '../components/DynamicDropdown';
@@ -601,6 +602,7 @@ class GenericDeployModal extends React.Component<GenericDeployModalProps, Generi
             showDeploymentNameInput,
             showDeployButton,
             showSitesInput,
+            deploySteps,
             deploymentNameLabel,
             deploymentNameHelp,
             blueprintFilterRules
@@ -844,7 +846,7 @@ class GenericDeployModal extends React.Component<GenericDeployModalProps, Generi
 
                 <DeployModalActions
                     loading={loading}
-                    showDeployButton={showDeployButton}
+                    showDeployButton={showDeployButton && !isEmpty(deploySteps)}
                     onCancel={this.onCancel}
                     onInstall={this.onDeployAndInstall}
                     onDeploy={this.onDeploy}

--- a/widgets/common/src/deploymentsView/header/DeployOnModal.tsx
+++ b/widgets/common/src/deploymentsView/header/DeployOnModal.tsx
@@ -18,7 +18,7 @@ interface DeployOnModalProps {
     onHide: () => void;
 }
 
-const t = Stage.Utils.getT(`${i18nPrefix}.header`);
+const tModal = Stage.Utils.getT(`${i18nPrefix}.header.bulkActions.deployOn.modal`);
 
 const DeployOnModal: FunctionComponent<DeployOnModalProps> = ({ filterRules, toolbox, onHide }) => {
     const [executionStarted, setExecutionStarted] = Stage.Hooks.useBoolean();
@@ -69,25 +69,38 @@ const DeployOnModal: FunctionComponent<DeployOnModalProps> = ({ filterRules, too
             open
             onHide={onHide}
             i18nHeaderKey={`${i18nPrefix}.header.bulkActions.deployOn.modal.header`}
-            deployValidationMessage={t('bulkActions.deployOn.modal.steps.validatingData')}
-            deployAndInstallSteps={[
+            showDeployButton
+            deployValidationMessage={tModal('deploySteps.validatingData')}
+            deploySteps={[
                 {
-                    message: t('bulkActions.deployOn.modal.steps.fetchingEnvironments'),
+                    message: tModal('deploySteps.fetchingEnvironments'),
                     executeStep: fetchEnvironments
                 },
                 {
-                    message: t('bulkActions.deployOn.modal.steps.creatingDeployments'),
+                    message: tModal('deploySteps.creatingDeployments'),
+                    executeStep: createDeploymentGroup
+                },
+                { executeStep: closeModal }
+            ]}
+            deployAndInstallValidationMessage={tModal('deployAndInstallSteps.validatingData')}
+            deployAndInstallSteps={[
+                {
+                    message: tModal('deployAndInstallSteps.fetchingEnvironments'),
+                    executeStep: fetchEnvironments
+                },
+                {
+                    message: tModal('deployAndInstallSteps.creatingDeployments'),
                     executeStep: createDeploymentGroup
                 },
                 {
-                    message: t('bulkActions.deployOn.modal.steps.installingDeployments'),
+                    message: tModal('deployAndInstallSteps.installingDeployments'),
                     executeStep: startInstallWorkflow
                 },
                 { executeStep: setExecutionStarted }
             ]}
             showDeploymentNameInput
-            deploymentNameLabel={t('bulkActions.deployOn.modal.inputs.name.label')}
-            deploymentNameHelp={t('bulkActions.deployOn.modal.inputs.name.help')}
+            deploymentNameLabel={tModal('inputs.name.label')}
+            deploymentNameHelp={tModal('inputs.name.help')}
         />
     );
 };


### PR DESCRIPTION
## Description

The reason for the problem described within RD-5423 was that there was no `deploySteps` defined for `GenericDeployModal` used in `DeployOnModal` component. That was fixed withing this PR as well as some other places were updated, so that user won't see Deploy option when deploy steps are not defined.

## Screenshots / Videos

https://user-images.githubusercontent.com/5202105/202669852-44cfb9d5-77dd-4452-b942-db1927152f0f.mp4


## Checklist
- [x] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [x] I followed the [UI Testing Guidelines](https://cloudifysource.atlassian.net/l/cp/udCVfvrx) and verified that all tests/checks have passed.
- [x] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [x] I added proper labels to this PR.

## Tests
Added Cypress test.

[![Build Status](https://jenkins.cloudify.co/buildStatus/icon?job=Stage-UI-System-Test&build=3875)](https://jenkins.cloudify.co/view/UI%20Health%20View/job/Stage-UI-System-Test/3875/) - only `deployments_view_spec`

## Documentation
N/A
