### PR TITLE
RD-6430 Improve `killRunningExecutions` cypress custom command

### DIFF
--- a/test/cypress/support/executions.ts
+++ b/test/cypress/support/executions.ts
@@ -26,18 +26,15 @@ const commands = {
         cy.cfyRequest(`/executions/${executionId}`, 'POST', null, { action: 'kill' }),
 
     killRunningExecutions: () => {
-        const activeExecutionsUrl = `/executions?${stringify({
+        const activeStatusesQueryString = stringify({
             status: ['scheduled', 'queued', 'pending', 'started', 'cancelling', 'force_cancelling']
-        })}`;
-
-        const activeAndKillCancellingExecutionsUrl = `${activeExecutionsUrl}&${stringify({
-            status: ['kill_cancelling']
-        })}`;
+        });
+        const activeAndKillCancellingStatusesQueryString = `${activeStatusesQueryString}&status=kill_cancelling`;
 
         return cy
-            .cfyRequest(activeExecutionsUrl, 'GET')
+            .cfyRequest(`/executions?${activeStatusesQueryString}`, 'GET')
             .then(response => response.body.items.forEach(({ id }: { id: string }) => cy.killExecution(id)))
-            .then(() => cy.waitUntilEmpty(activeAndKillCancellingExecutionsUrl));
+            .then(() => cy.waitUntilEmpty(`executions?${activeAndKillCancellingStatusesQueryString}`));
     },
 
     waitForExecutionToEnd: (


### PR DESCRIPTION
## Description

Looks like `cy.killRunningExecutions` is not handled properly in non-SSL environment (introduced recently in AMI CentOS images - RD-6305). It creates the following URL:
```
http://46.137.48.103/console/sp//executions?status...
```
and that double slash seems to be interpreted incorrectly.

## Screenshots / Videos
N/A

## Checklist
- [x] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [ ] I followed the [UI Testing Guidelines](https://cloudifysource.atlassian.net/l/cp/udCVfvrx) and verified that all tests/checks have passed.
- [x] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [x] I added proper labels to this PR.

## Tests
Testing only selected specs: 
* test/cypress/integration/flows/user_spec.ts
* test/cypress/integration/widgets/deployment_num_spec.ts
* test/cypress/integration/widgets/servers_num_spec.ts
* test/cypress/integration/widgets/snapshots_spec.ts
* test/cypress/integration/widgets/maintenance_mode_button_spec.ts

1. [![Build Status](https://jenkins.cloudify.co/buildStatus/icon?job=Stage-UI-System-Test&build=3889)] (https://jenkins.cloudify.co/job/Stage-UI-System-Test/3889/) - InterruptedException (known issue - RD-4319)
2. [![Build Status](https://jenkins.cloudify.co/buildStatus/icon?job=Stage-UI-System-Test&build=3890)](https://jenkins.cloudify.co/job/Stage-UI-System-Test/3890/) - PASSED

## Documentation
N/A