### PR TITLE
RD-6431 Add generic parameter type to `interceptWithoutCaching` custom Cypress command

### DIFF
--- a/test/cypress/integration/login_spec.ts
+++ b/test/cypress/integration/login_spec.ts
@@ -36,8 +36,8 @@ describe('Login', () => {
             const currentAppDataVersion = Consts.APP_VERSION;
             const fetchUserAppsTimeout = secondsToMs(20);
 
-            cy.interceptWithoutCaching('/console/ua', (userAppsData: GetUserAppResponse) => ({
-                ...userAppsData,
+            cy.interceptWithoutCaching<GetUserAppResponse>('/console/ua', userAppsData => ({
+                ...userAppsData!,
                 appDataVersion: currentAppDataVersion - 1
             })).as('fetchUserApps');
             cy.intercept('GET', '/console/templates/initial').as('fetchTemplateId');
@@ -86,7 +86,7 @@ describe('Login', () => {
 
         const ssoUrl = '/sso-redirect';
         cy.intercept(ssoUrl).as('ssoRedirect');
-        cy.interceptWithoutCaching('/console/config', (clientConfig: ClientConfig) => {
+        cy.interceptWithoutCaching<ClientConfig>('/console/config', clientConfig => {
             clientConfig.app.saml.enabled = true;
             clientConfig.app.saml.ssoUrl = ssoUrl;
             return clientConfig;

--- a/test/cypress/integration/user_configuration_spec.ts
+++ b/test/cypress/integration/user_configuration_spec.ts
@@ -12,7 +12,7 @@ describe('User configuration', () => {
     };
 
     function mockConfigResponse() {
-        cy.interceptWithoutCaching('/console/config', (clientConfig: ClientConfig) => {
+        cy.interceptWithoutCaching<ClientConfig>('/console/config', clientConfig => {
             clientConfig.app.whiteLabel = userConfig.whiteLabel;
             return clientConfig;
         });

--- a/test/cypress/support/commands.ts
+++ b/test/cypress/support/commands.ts
@@ -48,7 +48,7 @@ const getCommonHeaders = () => ({
 const getAdminAuthorizationHeader = () => ({ Authorization: `Basic ${btoa('admin:admin')}` });
 
 const mockGettingStarted = (modalEnabled: boolean) =>
-    cy.interceptWithoutCaching('/console/auth/user', (authUserResponse: GetAuthUserResponse) => {
+    cy.interceptWithoutCaching<GetAuthUserResponse>('/console/auth/user', authUserResponse => {
         const responseBody = {
             ...authUserResponse,
             showGettingStarted: modalEnabled
@@ -415,7 +415,10 @@ const commands = {
 
         return cy.intercept(routeMatcher, routeHandler);
     },
-    interceptWithoutCaching: (url: RouteMatcher, responseBodyInterceptor: (responseBody: any) => any = identity) =>
+    interceptWithoutCaching: <ResponseBody>(
+        url: RouteMatcher,
+        responseBodyInterceptor: (responseBody: ResponseBody) => ResponseBody = identity
+    ) =>
         cy.intercept(url, request => {
             // NOTE: Deleting `if-none-match` header to avoid getting "304 Not Modified" response
             //       which doesn't have any data in the body. For details check:


### PR DESCRIPTION
## Description
Thanks to @Blewin I adjusted `interceptWithoutCaching` to be generic.

## Screenshots / Videos
N/A

## Checklist

- [x] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [x] I followed the [UI Testing Guidelines](https://cloudifysource.atlassian.net/l/cp/udCVfvrx) and verified that all tests/checks have passed.
- [x] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [x] I added proper labels to this PR.

## Tests
Not necessary to run system tests I guess. CI only.

## Documentation
N/A