### PR TITLE
RD-5756 Migrate `shared` components to TypeScript - part 1 

### DIFF
--- a/app/components/layout/GridItem.tsx
+++ b/app/components/layout/GridItem.tsx
@@ -11,6 +11,7 @@ interface GridItemProps {
     y?: number;
     width?: number;
     height?: number;
+    maximized?: boolean;
 }
 
 export default class GridItem extends Component<GridItemProps> {

--- a/app/components/shared/Link.ts
+++ b/app/components/shared/Link.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck File not migrated fully to TS
 import { Link } from 'react-router-dom';
 
 export default Link;

--- a/app/components/shared/MaintenanceModeActivationButton.tsx
+++ b/app/components/shared/MaintenanceModeActivationButton.tsx
@@ -1,14 +1,20 @@
-// @ts-nocheck File not migrated fully to TS
-
-import PropTypes from 'prop-types';
+import type { ButtonProps } from 'semantic-ui-react';
 import React from 'react';
 import i18n from 'i18next';
 import { Button } from '../basic';
 
-export default function MaintenanceModeActivationButton({ activate, onClick, disabled }) {
-    const content = activate
-        ? i18n.t('maintenanceMode.activate', 'Activate Maintenance Mode')
-        : i18n.t('maintenanceMode.deactivate', 'Deactivate Maintenance Mode');
+interface MaintenanceModeActivationButtonProps {
+    activate: boolean;
+    onClick: ButtonProps['onClick'];
+    disabled: boolean;
+}
+
+export default function MaintenanceModeActivationButton({
+    activate,
+    onClick,
+    disabled = false
+}: MaintenanceModeActivationButtonProps) {
+    const content = activate ? i18n.t('maintenanceMode.activate') : i18n.t('maintenanceMode.deactivate');
 
     return (
         <Button
@@ -22,13 +28,3 @@ export default function MaintenanceModeActivationButton({ activate, onClick, dis
         />
     );
 }
-
-MaintenanceModeActivationButton.propTypes = {
-    activate: PropTypes.bool.isRequired,
-    onClick: PropTypes.func.isRequired,
-    disabled: PropTypes.bool
-};
-
-MaintenanceModeActivationButton.defaultProps = {
-    disabled: false
-};

--- a/app/components/shared/PasswordModal.tsx
+++ b/app/components/shared/PasswordModal.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck File not migrated fully to TS
 import _ from 'lodash';
 import React, { useEffect } from 'react';
 import i18n from 'i18next';
@@ -32,27 +31,18 @@ const PasswordModal: React.FunctionComponent<PasswordModalProps> = ({ onHide, op
     }, [open]);
 
     const submitPassword = () => {
-        const errorsFound = {};
+        const errorsFound: { password?: string; confirmPassword?: string } = {};
 
         if (_.isEmpty(password)) {
-            errorsFound.password = i18n.t(
-                'users.changePasswordModal.errors.noPassword',
-                'Please provide user password'
-            );
+            errorsFound.password = i18n.t('users.changePasswordModal.errors.noPassword');
         }
 
         if (_.isEmpty(confirmPassword)) {
-            errorsFound.confirmPassword = i18n.t(
-                'users.changePasswordModal.errors.noPasswordConfirmation',
-                'Please provide password confirmation'
-            );
+            errorsFound.confirmPassword = i18n.t('users.changePasswordModal.errors.noPasswordConfirmation');
         }
 
         if (!_.isEmpty(password) && !_.isEmpty(confirmPassword) && password !== confirmPassword) {
-            errorsFound.confirmPassword = i18n.t(
-                'users.changePasswordModal.errors.passwordsMismatch',
-                'Passwords do not match'
-            );
+            errorsFound.confirmPassword = i18n.t('users.changePasswordModal.errors.passwordsMismatch');
         }
 
         if (!_.isEmpty(errorsFound)) {
@@ -87,28 +77,24 @@ const PasswordModal: React.FunctionComponent<PasswordModalProps> = ({ onHide, op
         <Modal open={open} onClose={() => onHide()} className="userPasswordModal">
             <Modal.Header>
                 <Icon name="lock" />
-                {i18n.t('users.changePasswordModal.header', 'Change password for {{username}}', {
+                {i18n.t('users.changePasswordModal.header', {
                     username: username || loggedInUsername
                 })}
             </Modal.Header>
 
             <Modal.Content>
                 <Form loading={loading} errors={errors} onErrorsDismiss={clearErrors}>
-                    <Form.Field
-                        label={i18n.t('users.changePasswordModal.password', 'Password')}
-                        error={errors.password}
-                        required
-                    >
+                    <Form.Field label={i18n.t('users.changePasswordModal.password')} error={errors.password} required>
                         <Form.Input
                             name="password"
                             type="password"
                             value={password}
-                            onChange={(event, { value }) => setPassword(value)}
+                            onChange={(_event, { value }) => setPassword(value)}
                         />
                     </Form.Field>
 
                     <Form.Field
-                        label={i18n.t('users.changePasswordModal.passwordConfirm', 'Confirm password')}
+                        label={i18n.t('users.changePasswordModal.passwordConfirm')}
                         error={errors.confirmPassword}
                         required
                     >
@@ -116,7 +102,7 @@ const PasswordModal: React.FunctionComponent<PasswordModalProps> = ({ onHide, op
                             name="confirmPassword"
                             type="password"
                             value={confirmPassword}
-                            onChange={(event, { value }) => setConfirmPassword(value)}
+                            onChange={(_event, { value }) => setConfirmPassword(value)}
                         />
                     </Form.Field>
                 </Form>
@@ -127,7 +113,7 @@ const PasswordModal: React.FunctionComponent<PasswordModalProps> = ({ onHide, op
                 <ApproveButton
                     onClick={onApprove}
                     disabled={loading}
-                    content={i18n.t('users.changePasswordModal.change', 'Change')}
+                    content={i18n.t('users.changePasswordModal.change')}
                     icon="lock"
                 />
             </Modal.Actions>

--- a/app/components/shared/graphs/PieGraph.tsx
+++ b/app/components/shared/graphs/PieGraph.tsx
@@ -1,8 +1,13 @@
-// @ts-nocheck File not migrated fully to TS
-
-import PropTypes from 'prop-types';
 import React from 'react';
 import { PieChart, Pie, Legend, Cell, ResponsiveContainer } from 'recharts';
+
+export interface PieGraphProps {
+    data: {
+        color: string;
+        name: string;
+        value: number;
+    }[];
+}
 
 /**
  * PieGraph is a component to present data in form of pie chart
@@ -37,7 +42,7 @@ import { PieChart, Pie, Legend, Cell, ResponsiveContainer } from 'recharts';
  * return (<PieGraph data={formattedData} />);
  * ```
  */
-export default function PieGraph({ data }) {
+export default function PieGraph({ data }: PieGraphProps) {
     return (
         <ResponsiveContainer width="100%" height="100%">
             <PieChart>
@@ -51,13 +56,3 @@ export default function PieGraph({ data }) {
         </ResponsiveContainer>
     );
 }
-
-PieGraph.propTypes = {
-    data: PropTypes.arrayOf(
-        PropTypes.shape({
-            color: PropTypes.string,
-            name: PropTypes.string,
-            value: PropTypes.number
-        })
-    ).isRequired
-};

--- a/app/components/shared/widgets/WidgetsGrid.tsx
+++ b/app/components/shared/widgets/WidgetsGrid.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck File not migrated fully to TS
 import React from 'react';
 
 import Grid from '../../layout/Grid';

--- a/test/cypress/components/app/Graph_spec.tsx
+++ b/test/cypress/components/app/Graph_spec.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { mount } from 'cypress/react';
+
+import '../initAppContext';
+import { Graph } from 'app/components/shared';
+
+describe('Graph', () => {
+    function verifyChart(chartLabel: string) {
+        cy.get(`path[name="${chartLabel}"]`).should('be.visible');
+    }
+
+    it('renders bar chart', () => {
+        const charts = [{ name: 'value', label: 'Number of fruits', axisLabel: '' }];
+        const data = [
+            { time: '10:00', value: 300 },
+            { time: '11:00', value: 100 },
+            { time: '12:00', value: 80 },
+            { time: '13:00', value: 40 },
+            { time: '14:00', value: 30 }
+        ];
+
+        mount(<Graph charts={charts} data={data} type={Graph.BAR_CHART_TYPE} />);
+
+        verifyChart('Number of fruits');
+    });
+    it('renders line chart', () => {
+        const charts = [{ name: 'value', label: 'CPU load', axisLabel: '' }];
+        const data = [
+            { time: '17:30', value: 1 },
+            { time: '17:40', value: 2 },
+            { time: '17:50', value: 1 },
+            { time: '18:00', value: 3 },
+            { time: '18:10', value: 5 },
+            { time: '18:20', value: 8 },
+            { time: '18:30', value: 5 }
+        ];
+
+        mount(<Graph charts={charts} data={data} type={Graph.LINE_CHART_TYPE} />);
+
+        verifyChart('CPU load');
+    });
+
+    it('renders area chart', () => {
+        const charts = [{ name: 'value', label: 'CPU load', axisLabel: '' }];
+        const data = [
+            { time: '17:30', value: 1 },
+            { time: '17:40', value: 2 },
+            { time: '17:50', value: 1 },
+            { time: '18:00', value: 3 },
+            { time: '18:10', value: 5 },
+            { time: '18:20', value: 8 },
+            { time: '18:30', value: 5 }
+        ];
+
+        mount(<Graph charts={charts} data={data} type={Graph.AREA_CHART_TYPE} />);
+
+        verifyChart('CPU load');
+    });
+
+    it('renders multi-charts with one Y-axis per chart', () => {
+        const charts = [
+            { name: 'cpu_total_system', label: 'CPU - System [%]', axisLabel: '' },
+            { name: 'memory_MemFree', label: 'Memory - Free [Bytes]', axisLabel: '' },
+            { name: 'loadavg_processes_running', label: 'Load [%]', axisLabel: '' }
+        ];
+        const data = [
+            {
+                cpu_total_system: 3.5,
+                loadavg_processes_running: 3.071428571428572,
+                memory_MemFree: 146003090.2857143,
+                time: '2017-09-26 11:00:00'
+            },
+            {
+                cpu_total_system: 3.5,
+                loadavg_processes_running: 1.071428571428572,
+                memory_MemFree: 106003090.2857143,
+                time: '2017-09-26 12:00:00'
+            },
+            {
+                cpu_total_system: 3.5,
+                loadavg_processes_running: 6.071428571428572,
+                memory_MemFree: 126003090.2857143,
+                time: '2017-09-26 13:00:00'
+            }
+        ];
+
+        mount(<Graph charts={charts} data={data} type={Graph.LINE_CHART_TYPE} />);
+
+        verifyChart('CPU - System [%]');
+        verifyChart('Memory - Free [Bytes]');
+        verifyChart('Load [%]');
+    });
+});

--- a/widgets/executionsStatus/src/widget.tsx
+++ b/widgets/executionsStatus/src/widget.tsx
@@ -52,7 +52,6 @@ Stage.defineWidget<ExecutionsStatusWidget.Params, ExecutionsStatusWidget.Data, E
 
         return (
             <Graph
-                // @ts-expect-error Graph is not converted to TS yet
                 type={Graph.BAR_CHART_TYPE}
                 data={formattedData}
                 charts={charts}


### PR DESCRIPTION
## Description

First part of `shared` components migration to TypeScript.

In another PR(s) the following components are planned to be migrated:
* `app/components/shared/widgets/PageContent.tsx` (requires #2292 )
* `app/components/shared/widgets/Widget.tsx` (more complex change, need to fix widget definition types hierarchy)
* `app/components/shared/MaintenanceModeModal.tsx` (bigger change, I'm planning refactor in maintenance-related properties in Redux store first)

## Screenshots / Videos
N/A

## Checklist
- [x] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [x] I followed the [UI Testing Guidelines](https://cloudifysource.atlassian.net/l/cp/udCVfvrx) and verified that all tests/checks have passed.
- [x] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [x] I added proper labels to this PR.

## Tests
Added component test for `Graph` component.

## Documentation
N/A