### PR TITLE
RD-6099 Add support for tenant and role selection in Invite modal

### DIFF
--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -1535,6 +1535,10 @@
                     "email": {
                         "label": "E-mail",
                         "error": "Please provide valid e-mail"
+                    },
+                    "isAdmin": {
+                        "label": "Admin",
+                        "note": "Admin users have full permissions to all tenants on the manager."
                     }
                 }
             },

--- a/test/cypress/integration/widgets/user_management_spec.ts
+++ b/test/cypress/integration/widgets/user_management_spec.ts
@@ -130,7 +130,7 @@ describe('User management widget', () => {
             cy.getField('E-mail').find('input').clear().type(email);
         }
 
-        it.only('should allow to invite users', () => {
+        it('should allow to invite users', () => {
             cy.intercept('GET', '/auth/users/me', {
                 email: 'moomin@moominvalley.fi',
                 selected_manager_address: 'moominpappa.moominvalley.fi',

--- a/test/cypress/integration/widgets/user_management_spec.ts
+++ b/test/cypress/integration/widgets/user_management_spec.ts
@@ -1,4 +1,5 @@
 import Consts from 'app/utils/consts';
+import type { PostAuthUsersInviteRequestBody } from 'widgets/userManagement/src/authServiceActions';
 
 describe('User management widget', () => {
     const widgetId = 'userManagement';
@@ -129,7 +130,7 @@ describe('User management widget', () => {
             cy.getField('E-mail').find('input').clear().type(email);
         }
 
-        it('should allow to invite users', () => {
+        it.only('should allow to invite users', () => {
             cy.intercept('GET', '/auth/users/me', {
                 email: 'moomin@moominvalley.fi',
                 selected_manager_address: 'moominpappa.moominvalley.fi',
@@ -155,11 +156,19 @@ describe('User management widget', () => {
                 verifyEmailFieldError();
 
                 typeEmail(invitedUserEmail);
+
+                cy.contains('Admin').click();
+
+                cy.setMultipleDropdownValues('Tenants', [Consts.DEFAULT_TENANT]);
+                cy.setSingleDropdownValue('Choose a role for tenant default_tenant:', 'operations');
+
                 cy.clickButton('Invite');
                 cy.wait('@postUsersInvite').then(({ request }) => {
                     expect(request.body).to.deep.equal({
-                        email: invitedUserEmail
-                    });
+                        email: invitedUserEmail,
+                        role_name: Consts.ROLE.SYS_ADMIN,
+                        tenants: [{ role_name: 'operations', tenant_name: Consts.DEFAULT_TENANT }]
+                    } as PostAuthUsersInviteRequestBody);
                 });
             });
 

--- a/widgets/userManagement/src/InviteModal.tsx
+++ b/widgets/userManagement/src/InviteModal.tsx
@@ -1,6 +1,12 @@
 import type { FunctionComponent } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import getWidgetT from './getWidgetT';
 import AuthServiceActions from './authServiceActions';
+import type { TenantItem, TenantsDropdownProps } from '../../common/src/tenants/TenantsDropdown';
+import Actions from './actions';
+import type { CancelablePromise } from '../../../app/utils/types';
+import type { RolesPickerProps } from '../../common/src/roles/RolesPicker';
+import type { RolesAssignment } from '../../common/src/tenants/utils';
 
 const tModal = (key: string) => getWidgetT()(`inviteModal.${key}`);
 
@@ -10,6 +16,7 @@ interface InviteModalProps {
 
 interface InviteModalInputs {
     email: string;
+    isAdmin: boolean;
 }
 
 const InviteModal: FunctionComponent<InviteModalProps> = ({ toolbox }) => {
@@ -17,14 +24,42 @@ const InviteModal: FunctionComponent<InviteModalProps> = ({ toolbox }) => {
 
     const [isLoading, setLoading, unsetLoading] = useBoolean();
     const [inputs, setInput, clearInputs] = useInputs<InviteModalInputs>({
-        email: ''
+        email: '',
+        isAdmin: false
     });
+    const [tenants, setTenants] = useState<RolesAssignment>({});
+    const [availableTenants, setAvailableTenants] = useState<TenantItem[]>([]);
+    type Tenants = Stage.Types.PaginatedResponse<{ name: string }>;
+    const availableTenantsPromise = useRef<CancelablePromise<Tenants> | null>(null);
     const { errors, setMessageAsError, clearErrors, setErrors } = useErrors();
 
     const [isOpen, openModal, closeModal] = useOpen(() => {
         clearInputs();
         clearErrors();
+
+        const actions = new Actions(toolbox);
+        availableTenantsPromise.current = Stage.Utils.makeCancelable(actions.doGetTenants());
+
+        availableTenantsPromise.current.promise
+            .then(resolvedTenants => {
+                unsetLoading();
+                setAvailableTenants(resolvedTenants.items);
+            })
+            .catch((err: any) => {
+                if (!err.isCanceled) {
+                    unsetLoading();
+                    setAvailableTenants([]);
+                }
+            });
     });
+
+    useEffect(() => {
+        return () => {
+            if (availableTenantsPromise.current) {
+                availableTenantsPromise.current.cancel();
+            }
+        };
+    }, []);
 
     function submitInvite() {
         const submitErrors: Partial<Record<keyof InviteModalInputs, string>> = {};
@@ -41,10 +76,26 @@ const InviteModal: FunctionComponent<InviteModalProps> = ({ toolbox }) => {
 
         const authServiceActions = new AuthServiceActions(toolbox);
 
-        authServiceActions.doInvite(inputs.email).then(closeModal).catch(setMessageAsError).finally(unsetLoading);
+        authServiceActions
+            .doInvite(inputs.email, inputs.isAdmin, tenants)
+            .then(closeModal)
+            .catch(setMessageAsError)
+            .finally(unsetLoading);
     }
 
-    const { ApproveButton, Button, CancelButton, Icon, Form, Modal } = Stage.Basic;
+    const handleTenantChange: TenantsDropdownProps['onChange'] = (_event, { value }: { value?: string[] }) => {
+        const newTenants = Stage.Common.Tenants.mapTenantsToRoles(value, tenants, toolbox);
+        setTenants(newTenants);
+    };
+
+    const handleRoleChange: RolesPickerProps['onUpdate'] = (tenant, role) => {
+        const newTenants = { ...tenants, [tenant]: role };
+        setTenants(newTenants);
+    };
+
+    const { ApproveButton, Button, CancelButton, Icon, Form, Message, Modal } = Stage.Basic;
+    const RolesPicker = Stage.Common.Roles.Picker;
+    const { TenantsDropdown } = Stage.Common.Tenants;
 
     const inviteButton = <Button content={tModal('button')} icon="add user" labelPosition="left" />;
 
@@ -59,6 +110,29 @@ const InviteModal: FunctionComponent<InviteModalProps> = ({ toolbox }) => {
                     <Form.Field label={tModal('inputs.email.label')} error={errors.email} required>
                         <Form.Input name="email" value={inputs.email} onChange={setInput} />
                     </Form.Field>
+
+                    <Form.Field error={errors.isAdmin}>
+                        <Form.Checkbox
+                            label={tModal('inputs.isAdmin.label')}
+                            name="isAdmin"
+                            checked={inputs.isAdmin}
+                            onChange={setInput}
+                        />
+                    </Form.Field>
+
+                    {inputs.isAdmin && <Message>{tModal('inputs.isAdmin.note')}</Message>}
+
+                    <TenantsDropdown
+                        value={Object.keys(tenants)}
+                        availableTenants={availableTenants}
+                        onChange={handleTenantChange}
+                    />
+                    <RolesPicker
+                        onUpdate={handleRoleChange}
+                        resources={tenants}
+                        resourceName="tenant"
+                        toolbox={toolbox}
+                    />
                 </Form>
             </Modal.Content>
 

--- a/widgets/userManagement/src/authServiceActions.ts
+++ b/widgets/userManagement/src/authServiceActions.ts
@@ -1,4 +1,7 @@
+import { isEmpty, map } from 'lodash';
 import type { Toolbox } from '../../../app/utils/StageAPI';
+import type { RolesAssignment } from '../../common/src/tenants/utils';
+import type { SystemRole } from '../../common/src/roles/types';
 
 export interface GetAuthUserResponse {
     email: string;
@@ -7,9 +10,18 @@ export interface GetAuthUserResponse {
     status: string;
 }
 
+/* eslint-disable camelcase */
+interface TenantRole {
+    tenant_name: string;
+    role_name: string;
+}
+
 export interface PostAuthUsersInviteRequestBody {
     email: string;
+    role_name: SystemRole;
+    tenants?: TenantRole[];
 }
+/* eslint-enable camelcase */
 
 export default class AuthServiceActions {
     external: ReturnType<Toolbox['getExternal']>;
@@ -27,9 +39,17 @@ export default class AuthServiceActions {
             .catch(() => false);
     }
 
-    doInvite(email: string) {
+    doInvite(email: string, isAdmin: boolean, rolesAssignments: RolesAssignment) {
+        const { sysAdminRole, defaultUserRole } = Stage.Common.Consts;
+        const body: PostAuthUsersInviteRequestBody = { email, role_name: isAdmin ? sysAdminRole : defaultUserRole };
+        const tenants: TenantRole[] = map(rolesAssignments, (roleName, tenantName) => ({
+            role_name: roleName,
+            tenant_name: tenantName
+        }));
+        if (!isEmpty(tenants)) body.tenants = tenants;
+
         return this.external.doPost<never, PostAuthUsersInviteRequestBody>('/auth/users/invite', {
-            body: { email }
+            body
         });
     }
 }


### PR DESCRIPTION
## Description
This PR aligns Invite modal in Users Management widget to API changes introduced in RD-6101 (details in: https://cloudifysource.atlassian.net/browse/RD-6099?focusedCommentId=78457).

## Screenshots / Videos
![image](https://user-images.githubusercontent.com/5202105/205281425-5c611870-50c7-4165-b87d-910a9be65ba5.png)

## Checklist
- [x] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [x] I followed the [UI Testing Guidelines](https://cloudifysource.atlassian.net/l/cp/udCVfvrx) and verified that all tests/checks have passed.
- [x] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [x] I added proper labels to this PR.

## Tests
Updated `user_management_spec`.
[![Build Status](https://jenkins.cloudify.co/buildStatus/icon?job=Stage-UI-System-Test&build=3982)](https://jenkins.cloudify.co/view/UI%20Health%20View/job/Stage-UI-System-Test/3982/) - only `user_management_spec` - PASSED

## Documentation
Will be handled in RD-6115.