### PR TITLE
RD-6525 Move `SERVER_HOST` and `SERVER_PORT` constants to JSON configuration file

### DIFF
--- a/backend/config.ts
+++ b/backend/config.ts
@@ -77,3 +77,8 @@ export function getClientConfig(mode: Mode): ClientConfig {
         mode
     };
 }
+
+export function getBackendConfig() {
+    const { backend } = getConfig().app;
+    return { host: backend?.host ?? 'localhost', port: backend?.port ?? 8088 };
+}

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -1,6 +1,5 @@
 import type { Server } from 'http';
 import app from './app';
-import { SERVER_HOST, SERVER_PORT } from './consts';
 import DBConnection from './db/Connection';
 import { init as initWidgetsHandler } from './handler/WidgetsHandler';
 import { init as initTemplatesHandler } from './handler/templates';
@@ -8,6 +7,7 @@ import { getLogger } from './handler/LoggerHandler';
 import { isDevelopmentOrTest } from './utils';
 
 import { init, getMode } from './serverSettings';
+import { getConfig } from './config';
 
 const logger = getLogger('Server');
 
@@ -21,14 +21,15 @@ export default DBConnection.init()
     .then(() => {
         logger.info('Widgets and templates data initialized successfully.');
         return new Promise((resolve, reject) => {
-            const server = app.listen(SERVER_PORT, SERVER_HOST);
+            const { host, port } = getConfig().app.backend;
+            const server = app.listen(port, host);
             server.on('error', reject);
             server.on('listening', () => {
                 logger.info(`Server started in mode ${getMode()}`);
                 if (isDevelopmentOrTest) {
                     logger.info('Server started for development');
                 }
-                logger.info(`Stage runs on ${SERVER_HOST}:${SERVER_PORT}!`);
+                logger.info(`Stage runs on ${host}:${port}!`);
                 resolve(server);
             });
         });

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -7,7 +7,7 @@ import { getLogger } from './handler/LoggerHandler';
 import { isDevelopmentOrTest } from './utils';
 
 import { init, getMode } from './serverSettings';
-import { getConfig } from './config';
+import { getBackendConfig } from './config';
 
 const logger = getLogger('Server');
 
@@ -21,7 +21,7 @@ export default DBConnection.init()
     .then(() => {
         logger.info('Widgets and templates data initialized successfully.');
         return new Promise((resolve, reject) => {
-            const { host, port } = getConfig().app.backend;
+            const { host, port } = getBackendConfig();
             const server = app.listen(port, host);
             server.on('error', reject);
             server.on('listening', () => {

--- a/conf/README.md
+++ b/conf/README.md
@@ -30,8 +30,11 @@ The following section describes different configuration files used in cloudify-s
 This file is meant to be updated by manager installer -
 it is not going to be installed in case of upgrade or patch.
 
+* `backend` - object, Stage backend configuration details
+  * `host` - string, backend host
+  * `port` - number, backend port
 * `db` - object, Stage PostgreSQL DB connection configuration
-  * `url` - string or array, DB URL or array of DB URLs 
+  * `url` - string or array, DB URL or array of DB URLs
 
 ## DB Options (`db.options.json`)
 

--- a/conf/app.json
+++ b/conf/app.json
@@ -1,4 +1,8 @@
 {
+  "backend": {
+    "host": "localhost",
+    "port": 8088
+  },
   "db": {
     "url": "postgres://cloudify:cloudify@localhost:5432/stage",
     "options": {

--- a/devServer.ts
+++ b/devServer.ts
@@ -5,9 +5,9 @@ import getWebpackConfig from './webpack.config';
 import startWidgetBackendWatcher from './scripts/widgetBackendWatcher';
 
 import { CONTEXT_PATH } from './backend/consts';
-import { getConfig } from './backend/config';
+import { getBackendConfig } from './backend/config';
 
-const { backend } = getConfig().app;
+const backend = getBackendConfig();
 
 const webpackConfig = getWebpackConfig({}, { mode: 'development' });
 

--- a/devServer.ts
+++ b/devServer.ts
@@ -4,24 +4,27 @@ import WebpackDevServer from 'webpack-dev-server';
 import getWebpackConfig from './webpack.config';
 import startWidgetBackendWatcher from './scripts/widgetBackendWatcher';
 
-import { CONTEXT_PATH, SERVER_HOST, SERVER_PORT } from './backend/consts';
+import { CONTEXT_PATH } from './backend/consts';
+import { getConfig } from './backend/config';
+
+const { backend } = getConfig().app;
 
 const webpackConfig = getWebpackConfig({}, { mode: 'development' });
 
 const devServerPort = 4000;
 
 const stageBackendOptions: WebpackDevServer.HttpProxyMiddlewareOptions = {
-    target: `http://${SERVER_HOST}:${SERVER_PORT}`,
+    target: `http://${backend.host}:${backend.port}`,
     secure: false
 };
 
 const authServiceOptions: WebpackDevServer.HttpProxyMiddlewareOptions = {
-    target: `http://${SERVER_HOST}`,
+    target: `http://${backend.host}`,
     secure: false
 };
 
 const options: WebpackDevServer.Configuration = {
-    host: SERVER_HOST,
+    host: backend.host,
     port: devServerPort,
     historyApiFallback: {
         index: `${CONTEXT_PATH}/static/index.html`
@@ -69,7 +72,7 @@ server.startCallback(err => {
     if (err) {
         console.log(err);
     } else {
-        console.log(`Listening at http://${SERVER_HOST}:${devServerPort}/`);
+        console.log(`Listening at http://${backend.host}:${devServerPort}/`);
     }
 });
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "cy:open": "cypress open --e2e --browser electron",
         "cy:open-ct": "cypress open --component --browser electron",
         "coverageCheck": "nyc check-coverage",
-        "devServer": "cross-env NODE_ENV=development ts-node devServer.ts",
+        "devServer": "cross-env NODE_ENV=development ts-node -O {\\\"resolveJsonModule\\\":true} devServer.ts",
         "docWidgets": "node scripts/updateReadmes.js",
         "e2e": "cypress run",
         "generate:icons-font": "fontello-cli open --config ./semantic-ui/fontello.config.json",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "cy:open": "cypress open --e2e --browser electron",
         "cy:open-ct": "cypress open --component --browser electron",
         "coverageCheck": "nyc check-coverage",
-        "devServer": "cross-env NODE_ENV=development ts-node -O {\\\"resolveJsonModule\\\":true} devServer.ts",
+        "devServer": "cross-env NODE_ENV=development ts-node devServer.ts",
         "docWidgets": "node scripts/updateReadmes.js",
         "e2e": "cypress run",
         "generate:icons-font": "fontello-cli open --config ./semantic-ui/fontello.config.json",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
     "compilerOptions": {
         "noEmit": true,
         "esModuleInterop": true,
+        "resolveJsonModule": true,
         // The flag below is being used to handle the webpack-dev-server@4.x.x typing issue.
         // The issue is explained in more details here: https://github.com/aurelia/cli/issues/700
         "skipLibCheck": true


### PR DESCRIPTION
## Description
This PR changes `SERVER_HOST` and `SERVER_PORT` constants into configurable parameters in `conf/app.json` file. This should allow others to use Stage package in docker container.

Direct trigger for introducing such change: RD-6342.

## Screenshots / Videos
N/A

## Checklist
- [x] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [x] I followed the [UI Testing Guidelines](https://cloudifysource.atlassian.net/l/cp/udCVfvrx) and verified that all tests/checks have passed.
- [x] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [x] I added proper labels to this PR.

## Tests
Local environment (`devServer`) works fine.

System tests:
1. [![Build Status](https://jenkins.cloudify.co/buildStatus/icon?job=Stage-UI-System-Test&build=4025)](https://jenkins.cloudify.co/view/UI%20Health%20View/job/Stage-UI-System-Test/4025/) - failed on running backend (no configuration available as `app.json` is handled by Cloudify Manager, fix: https://github.com/cloudify-cosmo/cloudify-stage/pull/2305/commits/34212e552729b015f36df618908784d635cb4c93)
2. [![Build Status](https://jenkins.cloudify.co/buildStatus/icon?job=Stage-UI-System-Test&build=4044)](https://jenkins.cloudify.co/view/UI%20Health%20View/job/Stage-UI-System-Test/4044/) - backend started successfully, tests seems passing, so I feel comfortable to merge it

## Documentation
Updated `conf/README.md` file.