### PR TITLE
RD-6162 Fix for empty label in deploy modal

### DIFF
--- a/app/widgets/common/deployModal/GenericDeployModal.tsx
+++ b/app/widgets/common/deployModal/GenericDeployModal.tsx
@@ -156,8 +156,6 @@ const defaultProps: Partial<GenericDeployModalProps> = {
     deploySteps: [],
     deployValidationMessage: '',
     deployAndInstallValidationMessage: '',
-    deploymentNameLabel: t('inputs.deploymentName.label'),
-    deploymentNameHelp: t('inputs.deploymentName.help'),
     blueprintFilterRules: []
 };
 
@@ -688,9 +686,9 @@ class GenericDeployModal extends React.Component<GenericDeployModalProps, Generi
                         {showDeploymentNameInput && (
                             <Form.Field
                                 error={errors.deploymentName}
-                                label={deploymentNameLabel}
+                                label={deploymentNameLabel ?? t('inputs.deploymentName.label')}
                                 required
-                                help={deploymentNameHelp}
+                                help={deploymentNameHelp ?? t('inputs.deploymentName.help')}
                             >
                                 <Form.Input
                                     name="deploymentName"


### PR DESCRIPTION
<!--- Provide JIRA issue ID and a general summary of your changes in the Title above -->
<!--- e.g. "RD-1234 Improve styling in SuperComponent" -->
<!--- Note that the title is used as a commit message after merging the PR -->

## Description
Fix for bug introduced in https://github.com/cloudify-cosmo/cloudify-stage/pull/2321
<!--- Describe your changes to help reviewers understand the details. -->

## Screenshots / Videos
N/A
<!--- If applicable, add screenshot(s) or video(s) describing the changes you made. -->
<!--- Consider adding comparison screenshot(s) - before and after the change. -->
<!--- If not applicable, just write “N/A” in this section. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [ ] I followed the [UI Testing Guidelines](https://cloudifysource.atlassian.net/l/cp/udCVfvrx) and verified that all tests/checks have passed.
- [X] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [X] I added proper labels to this PR.

## Tests
Verified locally
<!--- If applicable, describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If applicable, provide a link to system tests, e.g: -->
<!--- [#1039](https://jenkins.cloudify.co/.../1039) (2021-08-06 07:05:50) --> 
<!--- If not applicable, just write “N/A” in this section. -->

## Documentation
N/A
<!--- If applicable, describe how you documented or plan to document your changes. -->
<!--- Check UI documentation guidelines - https://cloudifysource.atlassian.net/l/c/EYWJ0XfB - for details. -->
<!--- Provide links to JIRA issues, other PRs or related documentation pages. -->
<!--- If not applicable, just write “N/A” in this section. -->
