### PR TITLE
RD-6532 Remove empty input default

### DIFF
--- a/app/widgets/common/terraformModal/TerraformModal.tsx
+++ b/app/widgets/common/terraformModal/TerraformModal.tsx
@@ -44,11 +44,6 @@ const TerraformLogo = styled(Image)`
     }
 `;
 
-const terraformVersionOptions = terraformVersions.map(versionOption => ({
-    text: versionOption === defaultVersion ? `${versionOption} (${t('default')})` : versionOption,
-    value: versionOption
-}));
-
 export const inputMaxLength = 256;
 
 function LengthLimitedDynamicTableInput({
@@ -267,6 +262,15 @@ export default function TerraformModal({ onHide, toolbox }: { onHide: () => void
                 component: LengthLimitedDynamicTableInput
             }
         ],
+        undefined
+    );
+
+    const terraformVersionOptions = useMemo(
+        () =>
+            terraformVersions.map(versionOption => ({
+                text: versionOption === defaultVersion ? `${versionOption} (${t('default')})` : versionOption,
+                value: versionOption
+            })),
         undefined
     );
 

--- a/backend/templates/terraform/inputs.ejs
+++ b/backend/templates/terraform/inputs.ejs
@@ -1,5 +1,7 @@
 <% variables.forEach(variable => { if (variable.source === "input" && !variable.duplicated) { _%>
   <%= variable.name %>:
     type: string
+<% if (variable.value) { _%>
     default: '<%= String(variable.value).replace("'", "''") %>'
+<% } _%>
 <% }}) _%>

--- a/backend/test/routes/fixtures/terraform/1_blueprint.yaml
+++ b/backend/test/routes/fixtures/terraform/1_blueprint.yaml
@@ -12,7 +12,6 @@ inputs:
     default: 'defaultB'
   inputC:
     type: string
-    default: 'defaultC'
 
 node_templates:
   terraform:

--- a/backend/test/routes/fixtures/terraform/1_inputs.json
+++ b/backend/test/routes/fixtures/terraform/1_inputs.json
@@ -30,7 +30,7 @@
       "variable": "variableC",
       "source": "input",
       "name": "inputC",
-      "value": "defaultC"
+      "value": ""
     }
   ],
   "outputs": [


### PR DESCRIPTION
<!--- Provide JIRA issue ID and a general summary of your changes in the Title above -->
<!--- e.g. "RD-1234 Improve styling in SuperComponent" -->
<!--- Note that the title is used as a commit message after merging the PR -->

## Description
Removed empty input default from generated TF wrapper blueprint
<!--- Describe your changes to help reviewers understand the details. -->

## Screenshots / Videos
N/A
<!--- If applicable, add screenshot(s) or video(s) describing the changes you made. -->
<!--- Consider adding comparison screenshot(s) - before and after the change. -->
<!--- If not applicable, just write “N/A” in this section. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [x] I followed the [UI Testing Guidelines](https://cloudifysource.atlassian.net/l/cp/udCVfvrx) and verified that all tests/checks have passed.
- [X] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [X] I added proper labels to this PR.

## Tests
https://jenkins.cloudify.co/view/UI/job/Stage-UI-System-Test/4143/
<!--- If applicable, describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If applicable, provide a link to system tests, e.g: -->
<!--- [#1039](https://jenkins.cloudify.co/.../1039) (2021-08-06 07:05:50) --> 
<!--- If not applicable, just write “N/A” in this section. -->

## Documentation
N/A
<!--- If applicable, describe how you documented or plan to document your changes. -->
<!--- Check UI documentation guidelines - https://cloudifysource.atlassian.net/l/c/EYWJ0XfB - for details. -->
<!--- Provide links to JIRA issues, other PRs or related documentation pages. -->
<!--- If not applicable, just write “N/A” in this section. -->
