### PR TITLE
RD-6714 Bump `flat` package

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -27,7 +27,7 @@
                 "elkjs": "^0.8.2",
                 "express": "^4.14.0",
                 "express-static-gzip": "^2.1.7",
-                "flat": "^4.1.1",
+                "flat": "^5.0.2",
                 "fs-extra": "^3.0.1",
                 "isbinaryfile": "^5.0.0",
                 "js-beautify": "1.14.1",
@@ -4086,12 +4086,9 @@
             }
         },
         "node_modules/flat": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.1.tgz",
-            "integrity": "sha512-FmTtBsHskrU6FJ2VxCnsDb84wu9zhmO3cUX2kGFb5tuwhfXxGciiT0oRY+cck35QmG+NmGh5eLz6lLCpWTqwpA==",
-            "dependencies": {
-                "is-buffer": "~2.0.3"
-            },
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+            "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
             "bin": {
                 "flat": "cli.js"
             }
@@ -4456,28 +4453,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/is-buffer": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
-            "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "engines": {
-                "node": ">=4"
             }
         },
         "node_modules/is-core-module": {
@@ -15381,12 +15356,9 @@
             }
         },
         "flat": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.1.tgz",
-            "integrity": "sha512-FmTtBsHskrU6FJ2VxCnsDb84wu9zhmO3cUX2kGFb5tuwhfXxGciiT0oRY+cck35QmG+NmGh5eLz6lLCpWTqwpA==",
-            "requires": {
-                "is-buffer": "~2.0.3"
-            }
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+            "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ=="
         },
         "fn.name": {
             "version": "1.1.0",
@@ -15638,11 +15610,6 @@
             "requires": {
                 "binary-extensions": "^2.0.0"
             }
-        },
-        "is-buffer": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
-            "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="
         },
         "is-core-module": {
             "version": "2.9.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -46,7 +46,7 @@
         "elkjs": "^0.8.2",
         "express": "^4.14.0",
         "express-static-gzip": "^2.1.7",
-        "flat": "^4.1.1",
+        "flat": "^5.0.2",
         "fs-extra": "^3.0.1",
         "isbinaryfile": "^5.0.0",
         "js-beautify": "1.14.1",


### PR DESCRIPTION
## Description
NPM audit complained about using `flat@4.1.1` and dependabot created automatic PR bumping it's version to `flat@5.0.1` (https://github.com/cloudify-cosmo/cloudify-stage/pull/2356).
Snyk reports revealed issue in `flat@5.0.1`,and suggested to go to at least `flat@5.0.2`, and that change is provided in this PR 🙂 

## Screenshots / Videos
N/A

## Checklist
- [X] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [X] I followed the [UI Testing Guidelines](https://cloudifysource.atlassian.net/l/cp/udCVfvrx) and verified that all tests/checks have passed.
- [X] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [X] I added proper labels to this PR.

## Tests
Tested locally usage of `flat` package - used when fetching user configuration - no difference between `flat@4.1.1` and `flat@5.0.2`.

## Documentation
N/A