### PR TITLE
RD-6660 Use `setSearchableDropdownValue` custom command for setting blueprint ID value

### DIFF
--- a/test/cypress/integration/widgets/deployments_spec.ts
+++ b/test/cypress/integration/widgets/deployments_spec.ts
@@ -229,9 +229,7 @@ describe('Deployments widget', () => {
         cy.get('.updateDeploymentModal').within(() => {
             cy.contains(`Update deployment ${deploymentName} (${deploymentId})`);
 
-            cy.get('div[name=blueprintName]').click();
-            cy.wait('@uploadedBlueprints');
-            cy.contains(anotherBlueprintName).click();
+            cy.setSearchableDropdownValue('Blueprint', anotherBlueprintName);
 
             cy.getField('string_constraint_pattern').find('input').should('have.value', 'Ubuntu 18.04');
 


### PR DESCRIPTION
## Description

Improved setting blueprint ID value in one of the tests from Deployments widget test suite.
Before - blueprint ID was expected to be in the first 10 items visible when opening blueprint dropdown.
After - we filter by name first and then expect to see the item.

## Screenshots / Videos
N/A

## Checklist
- [x] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [ ] I followed the [UI Testing Guidelines](https://cloudifysource.atlassian.net/l/cp/udCVfvrx) and verified that all tests/checks have passed.
- [x] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [x] I added proper labels to this PR.

## Tests
1. Local - `deployments_spec` passed.
2. Jenkins
    1. [![Build Status](https://jenkins.cloudify.co/buildStatus/icon?job=Stage-UI-System-Test&build=4264)](https://jenkins.cloudify.co/view/UI%20Health%20View/job/Stage-UI-System-Test/4264/) - only `deployments_spec` - I suspect that Cloudify Manager was not ready yet to use (failed on uploading blueprint 😨)
    2. [![Build Status](https://jenkins.cloudify.co/buildStatus/icon?job=Stage-UI-System-Test&build=4265)](https://jenkins.cloudify.co/view/UI%20Health%20View/job/Stage-UI-System-Test/4265/) - all tests - `deployments_spec` passed.

## Documentation
N/A