### PR TITLE
RD-5776 Migrate Nodes widget to TypeScript

### DIFF
--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -1596,6 +1596,10 @@
         "maintenanceModeButton": {
             "activating": "Maintenance Mode is being activated"
         },
+        "nodes": {
+            "name": "Nodes list",
+            "description": "This widget shows nodes"
+        },
         "nodesStats": {
             "name": "Nodes statistics",
             "description": "This widget shows number of node instances in different states"

--- a/app/widgets/common/deploymentsView/types.ts
+++ b/app/widgets/common/deploymentsView/types.ts
@@ -18,7 +18,7 @@ export enum DeploymentStatus {
     RequiresAttention = 'requires_attention'
 }
 
-export interface Deployment {
+export interface FullDeployment {
     id: string;
     // NOTE: the property names come from the backend
     /* eslint-disable camelcase */
@@ -39,7 +39,10 @@ export interface Deployment {
     labels?: Label[];
     inputs: { [key: string]: unknown };
     capabilities: { [key: string]: unknown };
+    groups: Record<string, { members: string[] }>;
     /* eslint-enable camelcase */
 }
+
+export type Deployment = Omit<FullDeployment, 'groups'>;
 
 export type DeploymentsResponse = Stage.Types.PaginatedResponse<Deployment>;

--- a/widgets/nodes/src/NodeInstanceModal.tsx
+++ b/widgets/nodes/src/NodeInstanceModal.tsx
@@ -1,7 +1,12 @@
-// @ts-nocheck File not migrated fully to TS
-import NodeInstancePropType from './props/NodeInstancePropType';
+import type { ExtendedNodeInstance } from './types';
 
-export default function NodeInstanceModal({ instance, onClose, open }) {
+interface NodeInstanceModalProps {
+    instance: ExtendedNodeInstance;
+    onClose: () => void;
+    open: boolean;
+}
+
+export default function NodeInstanceModal({ instance, onClose, open }: NodeInstanceModalProps) {
     const NO_DATA_MESSAGE_RELATIONSHIPS = 'There are no Relationships defined for that Node Instance.';
     const NO_DATA_MESSAGE_RUNTIME_PROPERTIES = 'There are no Runtime Properties defined for that Node Instance.';
     const { CancelButton, CopyToClipboardButton, DataTable, Modal } = Stage.Basic;
@@ -90,9 +95,3 @@ export default function NodeInstanceModal({ instance, onClose, open }) {
         </div>
     );
 }
-
-NodeInstanceModal.propTypes = {
-    instance: NodeInstancePropType.isRequired,
-    onClose: PropTypes.func.isRequired,
-    open: PropTypes.bool.isRequired
-};

--- a/widgets/nodes/src/NodeInstancesTable.tsx
+++ b/widgets/nodes/src/NodeInstancesTable.tsx
@@ -1,36 +1,38 @@
-// @ts-nocheck File not migrated fully to TS
-
+import type { ExtendedNodeInstance } from './types';
 import InstanceModal from './NodeInstanceModal';
-import NodeInstancePropType from './props/NodeInstancePropType';
 
-const EMPTY_NODE_INSTANCE_OBJ = { id: '', relationships: [], runtime_properties: {} };
+interface NodeInstancesTableProps {
+    instances: ExtendedNodeInstance[];
+    toolbox: Stage.Types.Toolbox;
+}
 
-export default class NodeInstancesTable extends React.Component {
-    constructor(props, context) {
-        super(props, context);
+interface NodeInstancesTableState {
+    instance?: ExtendedNodeInstance;
+}
+
+export default class NodeInstancesTable extends React.Component<NodeInstancesTableProps, NodeInstancesTableState> {
+    constructor(props: NodeInstancesTableProps) {
+        super(props);
 
         this.state = {
-            showModal: false,
-            instance: EMPTY_NODE_INSTANCE_OBJ
+            instance: undefined
         };
     }
 
     closeInstanceModal = () => {
         this.setState({
-            showModal: false,
-            instance: EMPTY_NODE_INSTANCE_OBJ
+            instance: undefined
         });
         return true;
     };
 
-    showInstanceModal(instance) {
+    showInstanceModal(instance: ExtendedNodeInstance) {
         this.setState({
-            showModal: true,
             instance
         });
     }
 
-    selectNodeInstance(item) {
+    selectNodeInstance(item: ExtendedNodeInstance) {
         const { toolbox } = this.props;
         const selectedNodeInstanceId = toolbox.getContext().getValue('nodeInstanceId');
         const clickedNodeInstanceId = item.id;
@@ -43,8 +45,8 @@ export default class NodeInstancesTable extends React.Component {
     }
 
     render() {
-        const { instance: selectedInstance, showModal } = this.state;
-        const { instances, widget } = this.props;
+        const { instance: selectedInstance } = this.state;
+        const { instances } = this.props;
         const NO_DATA_MESSAGE = 'There are no Node Instances of selected Node available.';
         const { CopyToClipboardButton, DataTable, Icon } = Stage.Basic;
 
@@ -71,7 +73,7 @@ export default class NodeInstancesTable extends React.Component {
                                     <Icon
                                         link
                                         className="table"
-                                        onClick={event => {
+                                        onClick={(event: Event) => {
                                             event.stopPropagation();
                                             this.showInstanceModal(instance);
                                         }}
@@ -82,19 +84,10 @@ export default class NodeInstancesTable extends React.Component {
                     })}
                 </DataTable>
 
-                <InstanceModal
-                    open={showModal}
-                    onClose={this.closeInstanceModal}
-                    widget={widget}
-                    instance={selectedInstance}
-                />
+                {selectedInstance && (
+                    <InstanceModal open onClose={this.closeInstanceModal} instance={selectedInstance} />
+                )}
             </div>
         );
     }
 }
-
-NodeInstancesTable.propTypes = {
-    instances: PropTypes.arrayOf(NodeInstancePropType).isRequired,
-    toolbox: Stage.PropTypes.Toolbox.isRequired,
-    widget: Stage.PropTypes.Widget.isRequired
-};

--- a/widgets/nodes/src/NodeType.tsx
+++ b/widgets/nodes/src/NodeType.tsx
@@ -1,0 +1,11 @@
+import { icons } from 'cloudify-ui-common-frontend';
+
+interface NodeTypeIconProps {
+    typeHierarchy: string[];
+}
+
+export default function NodeTypeIcon({ typeHierarchy }: NodeTypeIconProps) {
+    const icon = icons.getNodeIcon(_.reverse(_.clone(typeHierarchy)));
+
+    return <span style={{ fontSize: 20, fontFamily: 'cloudify' }}>{icon}</span>;
+}

--- a/widgets/nodes/src/NodesTable.tsx
+++ b/widgets/nodes/src/NodesTable.tsx
@@ -1,12 +1,27 @@
-// @ts-nocheck File not migrated fully to TS
-
-import { icons } from 'cloudify-ui-common-frontend';
+import type { DataTableProps } from 'cloudify-ui-components';
+import TypeHierarchyTree from './TypeHierarchyTree';
+import NodeTypeIcon from './NodeType';
+import type { ExtendedNode, NodesConfiguration } from './types';
 import NodeInstancesTable from './NodeInstancesTable';
-import NodeInstancePropType from './props/NodeInstancePropType';
 
-export default class NodesTable extends React.Component {
-    constructor(props, context) {
-        super(props, context);
+interface NodesTableProps {
+    data: {
+        blueprintSelected: boolean;
+        deploymentSelected: boolean;
+        items: ExtendedNode[];
+        total: number;
+    };
+    toolbox: Stage.Types.Toolbox;
+    widget: Stage.Types.Widget<NodesConfiguration>;
+}
+
+interface NodesTableState {
+    error: string | null;
+}
+
+export default class NodesTable extends React.Component<NodesTableProps, NodesTableState> {
+    constructor(props: NodesTableProps) {
+        super(props);
 
         this.state = {
             error: null
@@ -18,7 +33,7 @@ export default class NodesTable extends React.Component {
         toolbox.getEventBus().on('nodes:refresh', this.refreshData, this);
     }
 
-    shouldComponentUpdate(nextProps, nextState) {
+    shouldComponentUpdate(nextProps: NodesTableProps, nextState: NodesTableState) {
         const { data, widget } = this.props;
         return (
             !_.isEqual(widget, nextProps.widget) ||
@@ -32,7 +47,7 @@ export default class NodesTable extends React.Component {
         toolbox.getEventBus().off('nodes:refresh', this.refreshData);
     }
 
-    fetchGridData = fetchParams => {
+    fetchGridData: DataTableProps['fetchData'] = fetchParams => {
         const { toolbox } = this.props;
         return toolbox.refresh(fetchParams);
     };
@@ -42,7 +57,7 @@ export default class NodesTable extends React.Component {
         toolbox.refresh();
     }
 
-    selectNode(item) {
+    selectNode(item: ExtendedNode) {
         const { toolbox } = this.props;
         const selectedDepNodeId = toolbox.getContext().getValue('depNodeId');
         const clickedDepNodeId = item.id + item.deployment_id;
@@ -154,7 +169,7 @@ export default class NodesTable extends React.Component {
                                                         name="sitemap"
                                                         link
                                                         className="rightFloated"
-                                                        onClick={event => event.stopPropagation()}
+                                                        onClick={(event: Event) => event.stopPropagation()}
                                                     />
                                                 </Popup.Trigger>
                                                 <Popup.Header>
@@ -184,7 +199,7 @@ export default class NodesTable extends React.Component {
                                 </DataTable.Row>
 
                                 <DataTable.DataExpandable key={`${node.id + node.deployment_id}_Expanded`}>
-                                    <NodeInstancesTable instances={node.instances} widget={widget} toolbox={toolbox} />
+                                    <NodeInstancesTable instances={node.instances} toolbox={toolbox} />
                                 </DataTable.DataExpandable>
                             </DataTable.RowExpandable>
                         );
@@ -194,83 +209,3 @@ export default class NodesTable extends React.Component {
         );
     }
 }
-
-NodesTable.propTypes = {
-    data: PropTypes.shape({
-        blueprintSelected: PropTypes.bool,
-        deploymentSelected: PropTypes.bool,
-        items: PropTypes.arrayOf(
-            PropTypes.shape({
-                blueprint_id: PropTypes.string,
-                connectedTo: PropTypes.string,
-                containedIn: PropTypes.string,
-                created_by: PropTypes.string,
-                deployment_id: PropTypes.string,
-                groups: PropTypes.string,
-                host_id: PropTypes.string,
-                id: PropTypes.string,
-                instances: PropTypes.arrayOf(NodeInstancePropType),
-                isSelected: PropTypes.bool,
-                numberOfInstances: PropTypes.number,
-                type: PropTypes.string,
-                type_hierarchy: PropTypes.arrayOf(PropTypes.string)
-            })
-        ),
-        total: PropTypes.number
-    }).isRequired,
-    widget: Stage.PropTypes.Widget.isRequired,
-    toolbox: Stage.PropTypes.Toolbox.isRequired
-};
-
-function NodeTypeIcon({ typeHierarchy }) {
-    const icon = icons.getNodeIcon(_.reverse(_.clone(typeHierarchy)));
-
-    return <span style={{ fontSize: 20, fontFamily: 'cloudify' }}>{icon}</span>;
-}
-
-NodeTypeIcon.propTypes = {
-    typeHierarchy: PropTypes.arrayOf(PropTypes.string).isRequired
-};
-
-function TypeHierarchyTree({ typeHierarchy }) {
-    const { Icon, NodesTree } = Stage.Basic;
-
-    const getNodes = types => {
-        const type = types[0];
-        if (types.length > 1) {
-            return (
-                <NodesTree.Node
-                    key={type}
-                    title={
-                        <span>
-                            <Icon name="triangle down" />
-                            {type}
-                        </span>
-                    }
-                >
-                    {getNodes(_.slice(types, 1))}
-                </NodesTree.Node>
-            );
-        }
-        return (
-            <NodesTree.Node
-                key={type}
-                title={
-                    <span>
-                        <strong>{type}</strong>
-                    </span>
-                }
-            />
-        );
-    };
-
-    return (
-        <NodesTree showLine selectable={false} defaultExpandAll className="typesHierarchy">
-            {getNodes(typeHierarchy)}
-        </NodesTree>
-    );
-}
-
-TypeHierarchyTree.propTypes = {
-    typeHierarchy: PropTypes.arrayOf(PropTypes.string).isRequired
-};

--- a/widgets/nodes/src/TypeHierarchyTree.tsx
+++ b/widgets/nodes/src/TypeHierarchyTree.tsx
@@ -1,0 +1,44 @@
+import type { TypeHierarchy } from './types';
+
+interface TypeHierarchyTreeProps {
+    typeHierarchy: TypeHierarchy;
+}
+
+export default function TypeHierarchyTree({ typeHierarchy }: TypeHierarchyTreeProps) {
+    const { Icon, NodesTree } = Stage.Basic;
+
+    const getNodes = (hierarchy: TypeHierarchy) => {
+        const type = hierarchy[0];
+        if (hierarchy.length > 1) {
+            return (
+                <NodesTree.Node
+                    key={type}
+                    title={
+                        <span>
+                            <Icon name="triangle down" />
+                            {type}
+                        </span>
+                    }
+                >
+                    {getNodes(_.slice(hierarchy, 1))}
+                </NodesTree.Node>
+            );
+        }
+        return (
+            <NodesTree.Node
+                key={type}
+                title={
+                    <span>
+                        <strong>{type}</strong>
+                    </span>
+                }
+            />
+        );
+    };
+
+    return (
+        <NodesTree showLine selectable={false} defaultExpandAll className="typesHierarchy">
+            {getNodes(typeHierarchy)}
+        </NodesTree>
+    );
+}

--- a/widgets/nodes/src/props/NodeInstancePropType.ts
+++ b/widgets/nodes/src/props/NodeInstancePropType.ts
@@ -1,8 +1,0 @@
-export default PropTypes.shape({
-    id: PropTypes.string,
-    isSelected: PropTypes.bool,
-    node_id: PropTypes.string,
-    relationships: PropTypes.arrayOf(PropTypes.shape({})),
-    runtime_properties: PropTypes.shape({}),
-    state: PropTypes.string
-});

--- a/widgets/nodes/src/types.ts
+++ b/widgets/nodes/src/types.ts
@@ -1,0 +1,53 @@
+/* eslint-disable camelcase */
+
+import type { DataTableConfiguration, PollingTimeConfiguration } from 'app/utils/GenericConfig';
+
+export interface NodesConfiguration extends PollingTimeConfiguration, DataTableConfiguration {
+    fieldsToShow: string;
+}
+
+export type TypeHierarchy = string[];
+
+interface NodeRelationship {
+    target_id: string;
+    type: string;
+}
+
+export interface Node {
+    actual_number_of_instances: number;
+    blueprint_id: string;
+    created_by: string;
+    deployment_display_name: string;
+    deployment_id: string;
+    groups: string;
+    host_id: string;
+    id: string;
+    relationships: NodeRelationship[];
+    type: string;
+    type_hierarchy: TypeHierarchy;
+}
+
+export interface ExtendedNode extends Node {
+    connectedTo: string;
+    containedIn: string;
+    instances: ExtendedNodeInstance[];
+    isSelected: boolean;
+    numberOfInstances: number;
+}
+
+interface NodeInstanceRelationship extends NodeRelationship {
+    target_name: string;
+}
+
+export interface NodeInstance {
+    deployment_id: string;
+    id: string;
+    node_id: string;
+    relationships: NodeInstanceRelationship[];
+    runtime_properties: Record<string, any>;
+    state: string;
+}
+
+export interface ExtendedNodeInstance extends NodeInstance {
+    isSelected: boolean;
+}


### PR DESCRIPTION
## Description

Full migration of Nodes widget to TypeScript.

In the next PR (https://github.com/cloudify-cosmo/cloudify-stage/pull/2453) further refactoring in Nodes widget will be provided.

## Screenshots / Videos
N/A

## Checklist
- [x] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [x] I followed the [UI Testing Guidelines](https://cloudifysource.atlassian.net/l/cp/udCVfvrx) and verified that all tests/checks have passed.
- [x] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [x] I added proper labels to this PR.

## Tests
1. [![Build Status](https://jenkins.cloudify.co/buildStatus/icon?job=Stage-UI-System-Test&build=4563)](https://jenkins.cloudify.co/view/UI%20Health%20View/job/Stage-UI-System-Test/4563/) - only Nodes widget test - failed due to external issues
2. Tested locally - PASSED.

## Documentation
N/A
