### PR TITLE
RD-5078 Refactor use of `FullDeployment` type and reduce number of `Deployment*` types

### DIFF
--- a/app/widgets/common/actions/SearchActions.ts
+++ b/app/widgets/common/actions/SearchActions.ts
@@ -1,6 +1,6 @@
 import type { PaginatedResponse } from 'backend/types';
-import type { FullBlueprintData } from 'app/widgets/common/blueprints/BlueprintActions';
-import type { Deployment } from '../deploymentsView/types';
+import type { FullBlueprintData } from '../blueprints/BlueprintActions';
+import type { FullDeploymentData } from '../deployments/DeploymentActions';
 import type { Workflow } from '../executeWorkflow';
 import type { FilterRule } from '../filters/types';
 
@@ -51,11 +51,11 @@ export default class SearchActions {
         };
     }
 
-    doListDeployments<IncludeKeys extends keyof Deployment = keyof Deployment>(
+    doListDeployments<IncludeKeys extends keyof FullDeploymentData = keyof FullDeploymentData>(
         filterRules: FilterRule[],
         params?: ListDeploymentsParams
     ) {
-        return this.doList<Pick<Deployment, IncludeKeys>>(
+        return this.doList<Pick<FullDeploymentData, IncludeKeys>>(
             'deployments',
             filterRules,
             SearchActions.searchAlsoByDeploymentName(params)
@@ -63,7 +63,11 @@ export default class SearchActions {
     }
 
     doListAllDeployments(filterRules: FilterRule[], params?: ListDeploymentsParams) {
-        return this.doListAll<Deployment>('deployments', filterRules, SearchActions.searchAlsoByDeploymentName(params));
+        return this.doListAll<FullDeploymentData>(
+            'deployments',
+            filterRules,
+            SearchActions.searchAlsoByDeploymentName(params)
+        );
     }
 
     doListBlueprints<IncludeKeys extends keyof FullBlueprintData>(

--- a/app/widgets/common/deployModal/EnvironmentDropdown/EnvironmentDropdown.types.ts
+++ b/app/widgets/common/deployModal/EnvironmentDropdown/EnvironmentDropdown.types.ts
@@ -1,10 +1,10 @@
-import type { Deployment } from '../../deploymentsView/types';
+import type { FullDeploymentData } from '../../deployments/DeploymentActions';
 
 export interface FetchedEnvironment {
-    id: Deployment['id'];
+    id: FullDeploymentData['id'];
     // eslint-disable-next-line
-    display_name: Deployment['display_name'];
-    capabilities: Deployment['capabilities'];
+    display_name: FullDeploymentData['display_name'];
+    capabilities: FullDeploymentData['capabilities'];
 }
 
 export interface Environment {

--- a/app/widgets/common/deployments/DeploymentActions.ts
+++ b/app/widgets/common/deployments/DeploymentActions.ts
@@ -1,12 +1,43 @@
 import type { Manager } from 'cloudify-ui-components/toolbox';
 import type { PaginatedResponse } from 'backend/types';
-import type { Deployment } from 'app/widgets/common/deploymentsView/types';
+import type { DeploymentStatus, LatestExecutionStatus } from 'app/widgets/common/deploymentsView/types';
 import type { Visibility } from 'app/widgets/common/types';
 import type { Workflow } from '../executeWorkflow';
 import ExecutionActions from '../executions/ExecutionActions';
 import type { Label } from '../labels/types';
 import type { Site } from '../map/site';
 import PollHelper from '../utils/PollHelper';
+
+export interface FullDeploymentData {
+    id: string;
+    /* eslint-disable camelcase */
+    created_at: string;
+    updated_at: string;
+    created_by?: string;
+    visibility: Visibility;
+    description: string | null;
+    latest_execution: string;
+    display_name: string;
+    site_name: string;
+    blueprint_id: string;
+    latest_execution_status: LatestExecutionStatus;
+    deployment_status: DeploymentStatus;
+    environment_type: string;
+    latest_execution_total_operations: number;
+    latest_execution_finished_operations: number;
+    sub_services_count: number;
+    /** Can be null when there are no subservices */
+    sub_services_status: DeploymentStatus | null;
+    sub_environments_count: number;
+    /** Can be null when there are no subenvironments */
+    sub_environments_status: DeploymentStatus | null;
+    labels?: Label[];
+    workflows: Workflow[];
+    inputs: { [key: string]: unknown };
+    capabilities: { [key: string]: unknown };
+    groups: Record<string, { members: string[] }>;
+    /* eslint-enable camelcase */
+}
 
 export interface WorkflowOptions {
     force: boolean;
@@ -26,8 +57,8 @@ export default class DeploymentActions {
         return this.manager.doGet(`/deployments/${deployment.id}`, { params });
     }
 
-    doGetDeployments<IncludeKeys extends keyof Deployment = keyof Deployment>(params: any) {
-        return this.manager.doGet<PaginatedResponse<Pick<Deployment, IncludeKeys>>>('/deployments', { params });
+    doGetDeployments<IncludeKeys extends keyof FullDeploymentData = keyof FullDeploymentData>(params: any) {
+        return this.manager.doGet<PaginatedResponse<Pick<FullDeploymentData, IncludeKeys>>>('/deployments', { params });
     }
 
     doDelete(deployment: { id: string }) {

--- a/app/widgets/common/deployments/DeploymentDetails.tsx
+++ b/app/widgets/common/deployments/DeploymentDetails.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import type { ReactNode, CSSProperties } from 'react';
 import { isEmpty } from 'lodash';
 import type { ResourceVisibilityProps } from 'cloudify-ui-components';
-import type { DeploymentWithUpdate } from 'app/widgets/common/deploymentsView/types';
+import type { FullDeploymentData } from 'app/widgets/common/deployments/DeploymentActions';
 import NodeInstancesSummary from '../nodes/NodeInstancesSummary';
 import Consts from '../Consts';
 import { Grid, Header, ResourceVisibility } from '../../../components/basic';
@@ -31,8 +31,13 @@ function DeploymentParameter({
     );
 }
 
-interface DeploymentDetailsProps {
-    deployment: Partial<DeploymentWithUpdate>;
+export type DeploymentWithUpdate = Pick<FullDeploymentData, 'id' | 'display_name' | 'description' | 'visibility'> &
+    Partial<Pick<FullDeploymentData, 'blueprint_id' | 'site_name' | 'created_at' | 'updated_at' | 'created_by'>> & {
+        isUpdated: boolean;
+    };
+
+export interface DeploymentDetailsProps {
+    deployment: DeploymentWithUpdate;
     instancesCount: number;
     instancesStates: {
         [key: string]: number;

--- a/app/widgets/common/deployments/DeploymentDetails.tsx
+++ b/app/widgets/common/deployments/DeploymentDetails.tsx
@@ -31,8 +31,13 @@ function DeploymentParameter({
     );
 }
 
-export type DeploymentWithUpdate = Pick<FullDeploymentData, 'id' | 'display_name' | 'description' | 'visibility'> &
-    Partial<Pick<FullDeploymentData, 'blueprint_id' | 'site_name' | 'created_at' | 'updated_at' | 'created_by'>> & {
+export type DeploymentWithUpdate = Pick<FullDeploymentData, 'id' | 'display_name' | 'visibility'> &
+    Partial<
+        Pick<
+            FullDeploymentData,
+            'description' | 'blueprint_id' | 'site_name' | 'created_at' | 'updated_at' | 'created_by'
+        >
+    > & {
         isUpdated: boolean;
     };
 

--- a/app/widgets/common/deployments/UpdateDeploymentModal.tsx
+++ b/app/widgets/common/deployments/UpdateDeploymentModal.tsx
@@ -8,6 +8,7 @@ import DynamicDropdown from '../components/DynamicDropdown';
 import DataTypesButton from '../inputs/DataTypesButton';
 import SortOrderIcons from '../inputs/SortOrderIcons';
 import YamlFileButton from '../inputs/YamlFileButton';
+import type { FullDeploymentData } from './DeploymentActions';
 import DeploymentActions from './DeploymentActions';
 import type { FullBlueprintData } from '../blueprints/BlueprintActions';
 import getInputFieldInitialValue from '../inputs/utils/getInputFieldInitialValue';
@@ -22,10 +23,9 @@ import UpdateDetailsModal from './UpdateDetailsModal';
 import type { DeploymentUpdate } from './UpdateDetailsModal';
 import { useBoolean, useErrors, useInputs, useOpenProp, useResettableState } from '../../../utils/hooks';
 import StageUtils from '../../../utils/stageUtils';
-import type { Deployment } from '../deploymentsView/types';
 import IconButtonsGroup from '../components/IconButtonsGroup';
 
-type FetchedDeployment = Pick<Deployment, 'blueprint_id' | 'id' | 'inputs'>;
+type FetchedDeployment = Pick<FullDeploymentData, 'blueprint_id' | 'id' | 'inputs'>;
 
 interface UpdateDeploymentModalProps {
     toolbox: Stage.Types.Toolbox;

--- a/app/widgets/common/deploymentsView/types.ts
+++ b/app/widgets/common/deploymentsView/types.ts
@@ -1,6 +1,4 @@
-import type { Workflow } from 'app/widgets/common/executeWorkflow';
-import type { Visibility } from 'app/widgets/common/types';
-import type { Label } from '../labels/types';
+import type { FullDeploymentData } from 'app/widgets/common/deployments/DeploymentActions';
 
 export enum LatestExecutionStatus {
     Completed = 'completed',
@@ -20,39 +18,7 @@ export enum DeploymentStatus {
     RequiresAttention = 'requires_attention'
 }
 
-export interface FullDeployment {
-    id: string;
-    // NOTE: the property names come from the backend
-    /* eslint-disable camelcase */
-    created_at: string; // date string
-    updated_at: string; // date string,
-    created_by?: string;
-    visibility: Visibility;
-    description: string | null;
-    latest_execution: string;
-    display_name: string;
-    site_name: string;
-    blueprint_id: string;
-    latest_execution_status: LatestExecutionStatus;
-    deployment_status: DeploymentStatus;
-    environment_type: string;
-    latest_execution_total_operations: number;
-    latest_execution_finished_operations: number;
-    sub_services_count: number;
-    /** Can be null when there are no subservices */
-    sub_services_status: DeploymentStatus | null;
-    sub_environments_count: number;
-    /** Can be null when there are no subenvironments */
-    sub_environments_status: DeploymentStatus | null;
-    labels?: Label[];
-    workflows: Workflow[];
-    inputs: { [key: string]: unknown };
-    capabilities: { [key: string]: unknown };
-    groups: Record<string, { members: string[] }>;
-    /* eslint-enable camelcase */
-}
-
-export type Deployment = Omit<FullDeployment, 'groups'>;
+export type Deployment = Omit<FullDeploymentData, 'groups'>;
 
 export interface DeploymentWithUpdate extends Deployment {
     // Many fetching functions add this prop

--- a/app/widgets/common/deploymentsView/types.ts
+++ b/app/widgets/common/deploymentsView/types.ts
@@ -20,8 +20,4 @@ export enum DeploymentStatus {
 
 export type Deployment = Omit<FullDeploymentData, 'groups'>;
 
-export interface DeploymentWithUpdate extends Deployment {
-    // Many fetching functions add this prop
-    isUpdated: boolean;
-}
 export type DeploymentsResponse = Stage.Types.PaginatedResponse<Deployment>;

--- a/widgets/blueprintInfo/src/actions.ts
+++ b/widgets/blueprintInfo/src/actions.ts
@@ -1,5 +1,5 @@
 import type { FullBlueprintData } from 'app/widgets/common/blueprints/BlueprintActions';
-import type { Deployment } from 'app/widgets/common/deploymentsView/types';
+import type { FullDeploymentData } from 'app/widgets/common/deployments/DeploymentActions';
 
 // TODO(RD-5879): Use Awaited (introduced in TS 4.5) instead of creating custom utility type
 type Unpromise<T extends Promise<any>> = T extends Promise<infer U> ? U : never;
@@ -12,9 +12,11 @@ export default class Actions {
         const deploymentKeys = ['id', 'blueprint_id'] as const;
         type DeploymentKeys = typeof deploymentKeys[number];
 
-        return this.toolbox.getManager().doGet<Pick<Deployment, DeploymentKeys>>(`/deployments/${deploymentId}`, {
-            params: { _include: deploymentKeys.join(',') }
-        });
+        return this.toolbox
+            .getManager()
+            .doGet<Pick<FullDeploymentData, DeploymentKeys>>(`/deployments/${deploymentId}`, {
+                params: { _include: deploymentKeys.join(',') }
+            });
     }
 
     doGetBlueprintDetails(blueprintId: string) {

--- a/widgets/deploymentInfo/src/widget.tsx
+++ b/widgets/deploymentInfo/src/widget.tsx
@@ -1,3 +1,4 @@
+import type { DeploymentWithUpdate } from 'app/widgets/common/deployments/DeploymentDetails';
 import type { DeploymentInfoWidget } from './widget.types';
 import DeploymentInfo from './DeploymentInfo';
 import Consts from './consts';
@@ -74,7 +75,7 @@ Stage.defineWidget<DeploymentInfoWidget.Params, DeploymentInfoWidget.Data, Deplo
 
         if (deploymentId) {
             deployment = await manager
-                .doGet(`/deployments/${deploymentId}`, {
+                .doGet<Omit<DeploymentWithUpdate, 'isUpdated'>>(`/deployments/${deploymentId}`, {
                     params: {
                         _include: _.join(
                             _.compact([

--- a/widgets/deploymentInfo/src/widget.types.ts
+++ b/widgets/deploymentInfo/src/widget.types.ts
@@ -1,5 +1,5 @@
 import type { PollingTimeConfiguration } from 'app/utils/GenericConfig';
-import type { DeploymentWithUpdate } from 'app/widgets/common/deploymentsView/types';
+import type { DeploymentWithUpdate } from 'app/widgets/common/deployments/DeploymentDetails';
 
 export declare namespace DeploymentInfoWidget {
     export interface Params {
@@ -17,9 +17,7 @@ export declare namespace DeploymentInfoWidget {
     }
 
     export interface Data {
-        /* eslint-disable camelcase */
         deployment: DeploymentWithUpdate;
-        /* eslint-enable camelcase */
         instancesCount: number;
         instancesStates: {
             [key: string]: number;

--- a/widgets/deployments/src/DeploymentsSegment.tsx
+++ b/widgets/deployments/src/DeploymentsSegment.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import type { Deployment } from 'app/widgets/common/deploymentsView/types';
+import type { FullDeploymentData } from 'app/widgets/common/deployments/DeploymentActions';
 import ActionsMenus from './ActionsMenus';
 import ExecutionProgress from './ExecutionProgress';
 import type { DeploymentViewProps } from './types';
@@ -33,7 +33,7 @@ export default function DeploymentsSegment({
     const { IdPopup } = Stage.Shared;
     const DeploymentDetails = Stage.Common.Deployments.Details;
     const { LatestExecutionStatusIcon } = Stage.Common.Executions;
-    const formatName = (item: Pick<Deployment, 'id' | 'display_name'>) =>
+    const formatName = (item: Pick<FullDeploymentData, 'id' | 'display_name'>) =>
         Stage.Utils.formatDisplayName({ id: item.id, displayName: item.display_name });
 
     return (

--- a/widgets/deployments/src/types.ts
+++ b/widgets/deployments/src/types.ts
@@ -1,5 +1,5 @@
 import type { PaginatedResponse } from 'backend/types';
-import type { Deployment } from 'app/widgets/common/deploymentsView/types';
+import type { FullDeploymentData } from 'app/widgets/common/deployments/DeploymentActions';
 import type { FetchDataFunction } from 'cloudify-ui-components';
 import type { Execution, ExecutionAction } from 'app/utils/shared/ExecutionUtils';
 import type { Toolbox, Widget } from 'app/utils/StageAPI';
@@ -37,10 +37,9 @@ export const FetchedLastExecutionFields = [
 
 export type FetchedLastExecutionType = Required<Pick<Execution, typeof FetchedLastExecutionFields[number]>>;
 
-export type EnhancedDeployment = Pick<Deployment, typeof FetchedDeploymentFields[number]> & {
+export type EnhancedDeployment = Pick<FullDeploymentData, typeof FetchedDeploymentFields[number]> & {
     nodeInstancesCount: number;
     nodeInstancesStates: Record<string, number>;
-
     isUpdated: boolean;
     lastExecution: FetchedLastExecutionType;
 };
@@ -61,7 +60,6 @@ export interface DeploymentViewProps {
     onActOnExecution?: (execution: Execution, action: ExecutionAction, errorMessage: any) => void;
     onDeploymentAction: (deployment: EnhancedDeployment | undefined, actionName: string) => void;
     onWorkflowAction: (deployment: EnhancedDeployment | undefined, workflowName: string) => void;
-
     onSetVisibility: (id: string, visibility: Visibility) => void;
     allowedSettingTo?: Visibility[];
     noDataMessage: string;

--- a/widgets/nodes/src/widget.tsx
+++ b/widgets/nodes/src/widget.tsx
@@ -1,6 +1,6 @@
 import type { PaginatedResponse } from 'backend/types';
-import type { FullDeployment } from 'app/widgets/common/deploymentsView/types';
 import { castArray } from 'lodash';
+import type { FullDeploymentData } from 'app/widgets/common/deployments/DeploymentActions';
 import type { Node, NodeInstance, NodesConfiguration } from './types';
 import NodesTable from './NodesTable';
 import { translateWidget, widgetId } from './common';
@@ -20,7 +20,7 @@ const defaultFieldsToShow = [
 const allFieldsToShow = [...defaultFieldsToShow, 'deploymentId'];
 const translateFieldsToShow = Stage.Utils.composeT(translateWidget, 'configuration.fieldsToShow');
 
-type Deployment = Pick<FullDeployment, 'id' | 'groups'>;
+type Deployment = Pick<FullDeploymentData, 'id' | 'groups'>;
 
 function getGroups(deployments: Deployment[]) {
     const groups: Record<string, string[]> = {};


### PR DESCRIPTION
## Description

1. Extracted `FullDeploymentData` type to `app/common/widgets/DeploymentActions.ts` file
2. Refactored uses of `DeploymentWithUpdate` type

## Screenshots / Videos

N/A

## Checklist

- [x] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [x] I followed the [UI Testing Guidelines](https://cloudifysource.atlassian.net/l/cp/udCVfvrx) and verified that all tests/checks have passed.
- [x] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [x] I added proper labels to this PR.

## Tests

No functional changes, so types check only.

## Documentation

N/A