### PR TITLE
RD-7081 Remove `widgets/common/common.js` reference

### DIFF
--- a/app/utils/widgetDefinitionsLoader.ts
+++ b/app/utils/widgetDefinitionsLoader.ts
@@ -114,10 +114,9 @@ export default class WidgetDefinitionsLoader {
 
     public static load(manager: ManagerData): Promise<SimpleWidgetDefinition[]> {
         const internal = new Internal(manager);
-        return Promise.all([
-            new ScriptLoader(LoaderUtils.getResourceUrl('widgets/common/common.js', false)).load(), // Commons has to load before the widgets
-            internal.doGet<GetWidgetsResponse>('/widgets') // We can load the list of widgets in the meanwhile
-        ]).then(results => results[1].map(widget => ({ ...widget, loaded: false })));
+        return internal
+            .doGet<GetWidgetsResponse>('/widgets')
+            .then(widgets => widgets.map(widget => ({ ...widget, loaded: false })));
     }
 
     private static installWidget(widgetFile: File | null, widgetUrl: string, manager: ManagerData) {


### PR DESCRIPTION
## Description

RD-7081 looks like a minor leftover from RD-6162 (in specific from #2321). 
I searched for `common.js` occurrences and adjusted code accordingly.

## Screenshots / Videos
N/A

## Checklist
- [x] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [x] I followed the [UI Testing Guidelines](https://cloudifysource.atlassian.net/l/cp/udCVfvrx) and verified that all tests/checks have passed.
- [x] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [x] I added proper labels to this PR.

## Tests
1. [![Build Status](https://jenkins.cloudify.co/buildStatus/icon?job=Stage-UI-System-Test&build=4627)](https://jenkins.cloudify.co/view/UI%20Health%20View/job/Stage-UI-System-Test/4627/) (All tests) - FAILED (in addition to known issues failed on `license_spec`, `deployment_button_configuration_spec`, `pages_edit_spec`)
2. [![Build Status](https://jenkins.cloudify.co/buildStatus/icon?job=Stage-UI-System-Test&build=4632)](https://jenkins.cloudify.co/view/UI%20Health%20View/job/Stage-UI-System-Test/4632/) (Only 3 specs failing in previous run) - PASSED (I suspect that previous failures were fixed in https://github.com/cloudify-cosmo/cloudify-stage/pull/2460/)

## Documentation
N/A