### PR TITLE
RD-7092 Fix Cloudify Manager REST API port

### DIFF
--- a/backend/test/config.test.ts
+++ b/backend/test/config.test.ts
@@ -18,7 +18,7 @@ describe('Config', () => {
     it('should construct manager URL', () => {
         jest.doMock('../../conf/me.json', () => ({}));
         loadMeJson();
-        expect(getConfig('main').managerUrl).toBe('https://127.0.0.1:53333');
+        expect(getConfig('main').managerUrl).toBe('https://127.0.0.1:443');
     });
 
     it('should support `saml` section', () => {

--- a/conf/manager.json
+++ b/conf/manager.json
@@ -2,5 +2,5 @@
   "ip":"127.0.0.1",
   "apiVersion": "v3.1",
   "protocol" : "https",
-  "port": "53333"
+  "port": "443"
 }


### PR DESCRIPTION
## Description

Adjusted default value for Cloudify Manager REST API port.

Related backend change causing issues with our system tests: RD-7056.

## Screenshots / Videos
N/A

## Checklist
- [x] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [x] I followed the [UI Testing Guidelines](https://cloudifysource.atlassian.net/l/cp/udCVfvrx) and verified that all tests/checks have passed.
- [x] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [x] I added proper labels to this PR.

## Tests
[![Build Status](https://jenkins.cloudify.co/buildStatus/icon?job=Stage-UI-System-Test&build=4660)](https://jenkins.cloudify.co/job/Stage-UI-System-Test/4660/) - Stage package upload script is not overriding `manager.json` so it's not possible to test it this way :-/

## Documentation
N/A