### PR TITLE
RD-7116 Refactor Deployments View widget spec to use Cypress custom commands for setting widget configuration fields

### DIFF
--- a/test/cypress/integration/widgets/deployments_view_spec.ts
+++ b/test/cypress/integration/widgets/deployments_view_spec.ts
@@ -146,14 +146,11 @@ describe('Deployments View widget', () => {
                 cy.contains(prefixedLabelName).should('not.exist');
             });
 
-            cy.log('Show a label');
-            cy.editWidgetConfiguration(widgetId, () => {
-                widgetConfigurationHelpers.toggleLabelsDropdown();
-                widgetConfigurationHelpers.getLabelsDropdown().within(() => {
-                    cy.contains('[role="listbox"]', prefixedLabelName).click();
-                });
-                widgetConfigurationHelpers.toggleLabelsDropdown();
-            });
+            cy.setSearchableDropdownConfigurationField(
+                widgetId,
+                "List of labels' keys to show in the table as columns",
+                prefixedLabelName
+            );
 
             getDeploymentsViewTable().within(() => {
                 cy.contains(deploymentName);

--- a/test/cypress/integration/widgets/deployments_view_spec.ts
+++ b/test/cypress/integration/widgets/deployments_view_spec.ts
@@ -83,16 +83,6 @@ describe('Deployments View widget', () => {
     const verifyMapHeight = (expectedHeight: number) =>
         getDeploymentsViewMap().invoke('height').should('eq', expectedHeight);
 
-    const widgetConfigurationHelpers = {
-        getFieldsDropdown: () => cy.contains('List of fields to show in the table').parent().find('[role="listbox"]'),
-        toggleFieldsDropdown: () => widgetConfigurationHelpers.getFieldsDropdown().find('.dropdown.icon').click(),
-
-        getLabelsDropdown: () => cy.contains('List of labels').parent().find('[role="combobox"]'),
-        toggleLabelsDropdown: () => widgetConfigurationHelpers.getLabelsDropdown().click(),
-
-        mapHeightInput: () => cy.contains('Map height').parent().find('input[type="number"]')
-    };
-
     const widgetHeader = {
         openRunWorkflowModal: () => {
             cy.contains('Bulk Actions').click();
@@ -118,14 +108,9 @@ describe('Deployments View widget', () => {
                 cy.contains(exampleSiteName).should('not.exist');
             });
 
-            cy.log('Show some columns');
-            cy.editWidgetConfiguration(widgetId, () => {
-                widgetConfigurationHelpers.toggleFieldsDropdown();
-                widgetConfigurationHelpers.getFieldsDropdown().within(() => {
-                    cy.get('[role="option"]').contains('Blueprint name').click();
-                });
-                widgetConfigurationHelpers.toggleFieldsDropdown();
-            });
+            cy.setMultipleDropdownConfigurationField(widgetId, 'List of fields to show in the table', [
+                'Blueprint name'
+            ]);
 
             getDeploymentsViewTable().within(() => {
                 cy.contains(deploymentName);
@@ -168,10 +153,7 @@ describe('Deployments View widget', () => {
 
             const newHeight = 100;
 
-            cy.editWidgetConfiguration(widgetId, () => {
-                // NOTE: after clearing the input, 0 is automatically inserted. {home}{del} removes the leading 0
-                widgetConfigurationHelpers.mapHeightInput().clear().type(`${newHeight}{home}{del}`);
-            });
+            cy.setNumericConfigurationField(widgetId, 'Map height', newHeight);
 
             verifyMapHeight(newHeight);
         });

--- a/test/cypress/support/editMode.ts
+++ b/test/cypress/support/editMode.ts
@@ -65,6 +65,11 @@ const commands = {
                         cy.get('@toggle').click();
                 })
         ),
+    setNumericConfigurationField: (widgetId: string, fieldName: string, value: number) =>
+        cy.editWidgetConfiguration(widgetId, () =>
+            // NOTE: after clearing the input, 0 is automatically inserted. {home}{del} removes the leading 0
+            cy.getField(fieldName).find('input').clear().type(`${value}{home}{del}`)
+        ),
     setStringConfigurationField: (widgetId: string, fieldName: string, value: string) =>
         cy.editWidgetConfiguration(widgetId, () => cy.getField(fieldName).find('input').clear().type(value)),
     setSearchableDropdownConfigurationField: (widgetId: string, fieldName: string, value: string) =>

--- a/test/cypress/support/editMode.ts
+++ b/test/cypress/support/editMode.ts
@@ -68,7 +68,9 @@ const commands = {
     setStringConfigurationField: (widgetId: string, fieldName: string, value: string) =>
         cy.editWidgetConfiguration(widgetId, () => cy.getField(fieldName).find('input').clear().type(value)),
     setSearchableDropdownConfigurationField: (widgetId: string, fieldName: string, value: string) =>
-        cy.editWidgetConfiguration(widgetId, () => cy.setSearchableDropdownValue(fieldName, value))
+        cy.editWidgetConfiguration(widgetId, () => cy.setSearchableDropdownValue(fieldName, value)),
+    setMultipleDropdownConfigurationField: (widgetId: string, fieldName: string, values: string[]) =>
+        cy.editWidgetConfiguration(widgetId, () => cy.setMultipleDropdownValues(fieldName, values))
 };
 
 addCommands(commands);


### PR DESCRIPTION
## Description
The problem described in RD-7116 was not reproducible locally, but deduced from the video that the problem laid in faulty implementation of accessing dropdown component. I found out that we were not using already existing Cypress custom command (which are working flawlessly in other places) for setting dropdown fields in widget configuration. 

This PR changes it and simplifies/refactors section covering tests for configuration of Deployments View widget.

## Screenshots / Videos
N/A

## Checklist
- [x] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [x] I followed the [UI Testing Guidelines](https://cloudifysource.atlassian.net/l/cp/udCVfvrx) and verified that all tests/checks have passed.
- [x] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [x] I added proper labels to this PR.

## Tests
[![Build Status](https://jenkins.cloudify.co/buildStatus/icon?job=Stage-UI-System-Test&build=4798)](https://jenkins.cloudify.co/view/UI%20Health%20View/job/Stage-UI-System-Test/4798/) - only `deployments_view_spec.ts`

## Documentation
N/A
