### PR TITLE
RD-6316 RD-7116 RD-7117 RND-220 Cherry pick from master branch [7.0]

### DIFF
--- a/app/widgets/common/deployments/DeploymentActions.ts
+++ b/app/widgets/common/deployments/DeploymentActions.ts
@@ -18,7 +18,7 @@ export interface FullDeploymentData {
     description: string | null;
     latest_execution: string;
     display_name: string;
-    site_name: string;
+    site_name: string | null;
     blueprint_id: string;
     latest_execution_status: LatestExecutionStatus;
     deployment_status: DeploymentStatus;

--- a/app/widgets/common/deploymentsView/map/DeploymentsMap.tsx
+++ b/app/widgets/common/deploymentsView/map/DeploymentsMap.tsx
@@ -100,6 +100,7 @@ const getDeploymentSitePairs = (
     deployments: Deployment[]
 ): DeploymentSitePair[] =>
     deployments
-        .map((deployment): DeploymentSitePair => ({ deployment, site: sitesLookupTable[deployment.site_name] }))
+        .filter(deployment => deployment.site_name !== null)
+        .map((deployment): DeploymentSitePair => ({ deployment, site: sitesLookupTable[deployment.site_name!] }))
         // NOTE: additional filtering, since the site may not have a position, and thus not be in the lookup table
         .filter(({ site }) => !!site);

--- a/test/cypress/integration/widgets/deployments_spec.ts
+++ b/test/cypress/integration/widgets/deployments_spec.ts
@@ -1,4 +1,5 @@
 import ExecutionUtils from 'app/utils/shared/ExecutionUtils';
+import type { Deployment } from 'widgets/deployments/src/types';
 import { exampleBlueprintUrl } from '../../support/resource_urls';
 
 describe('Deployments widget', () => {
@@ -296,7 +297,7 @@ describe('Deployments widget', () => {
 
             it("should hide showFirstUserJourneyButtons view when there's at least one deployment", () => {
                 const displayName = 'deploymentDisplayName';
-                const mockedDeployment = {
+                const mockedDeployment: Deployment = {
                     blueprint_id: 'test',
                     created_at: '2022-03-21T08:52:31.251Z',
                     created_by: 'admin',
@@ -304,8 +305,10 @@ describe('Deployments widget', () => {
                     id: 'ea2d9302-6452-4f51-a224-803925d2cc6e',
                     inputs: { webserver_port: 8000 },
                     latest_execution: '28f3fada-118c-4236-9987-576b0efae71e',
+                    labels: [],
                     site_name: null,
                     updated_at: '2022-03-21T08:52:31.251Z',
+                    workflows: [],
                     visibility: 'tenant'
                 };
                 const mockedResponse = getMockedResponse([mockedDeployment]);

--- a/test/cypress/integration/widgets/deployments_view_spec.ts
+++ b/test/cypress/integration/widgets/deployments_view_spec.ts
@@ -83,16 +83,6 @@ describe('Deployments View widget', () => {
     const verifyMapHeight = (expectedHeight: number) =>
         getDeploymentsViewMap().invoke('height').should('eq', expectedHeight);
 
-    const widgetConfigurationHelpers = {
-        getFieldsDropdown: () => cy.contains('List of fields to show in the table').parent().find('[role="listbox"]'),
-        toggleFieldsDropdown: () => widgetConfigurationHelpers.getFieldsDropdown().find('.dropdown.icon').click(),
-
-        getLabelsDropdown: () => cy.contains('List of labels').parent().find('[role="combobox"]'),
-        toggleLabelsDropdown: () => widgetConfigurationHelpers.getLabelsDropdown().click(),
-
-        mapHeightInput: () => cy.contains('Map height').parent().find('input[type="number"]')
-    };
-
     const widgetHeader = {
         openRunWorkflowModal: () => {
             cy.contains('Bulk Actions').click();
@@ -118,14 +108,9 @@ describe('Deployments View widget', () => {
                 cy.contains(exampleSiteName).should('not.exist');
             });
 
-            cy.log('Show some columns');
-            cy.editWidgetConfiguration(widgetId, () => {
-                widgetConfigurationHelpers.toggleFieldsDropdown();
-                widgetConfigurationHelpers.getFieldsDropdown().within(() => {
-                    cy.get('[role="option"]').contains('Blueprint name').click();
-                });
-                widgetConfigurationHelpers.toggleFieldsDropdown();
-            });
+            cy.setMultipleDropdownConfigurationField(widgetId, 'List of fields to show in the table', [
+                'Blueprint name'
+            ]);
 
             getDeploymentsViewTable().within(() => {
                 cy.contains(deploymentName);
@@ -146,14 +131,11 @@ describe('Deployments View widget', () => {
                 cy.contains(prefixedLabelName).should('not.exist');
             });
 
-            cy.log('Show a label');
-            cy.editWidgetConfiguration(widgetId, () => {
-                widgetConfigurationHelpers.toggleLabelsDropdown();
-                widgetConfigurationHelpers.getLabelsDropdown().within(() => {
-                    cy.contains('[role="listbox"]', prefixedLabelName).click();
-                });
-                widgetConfigurationHelpers.toggleLabelsDropdown();
-            });
+            cy.setSearchableDropdownConfigurationField(
+                widgetId,
+                "List of labels' keys to show in the table as columns",
+                prefixedLabelName
+            );
 
             getDeploymentsViewTable().within(() => {
                 cy.contains(deploymentName);
@@ -171,10 +153,7 @@ describe('Deployments View widget', () => {
 
             const newHeight = 100;
 
-            cy.editWidgetConfiguration(widgetId, () => {
-                // NOTE: after clearing the input, 0 is automatically inserted. {home}{del} removes the leading 0
-                widgetConfigurationHelpers.mapHeightInput().clear().type(`${newHeight}{home}{del}`);
-            });
+            cy.setNumericConfigurationField(widgetId, 'Map height', newHeight);
 
             verifyMapHeight(newHeight);
         });

--- a/test/cypress/integration/widgets/environment_button_spec.ts
+++ b/test/cypress/integration/widgets/environment_button_spec.ts
@@ -96,7 +96,13 @@ describe('Environment button widget', () => {
             cy.get('.modal').within(() => {
                 cy.typeToFieldInput('Name', deploymentName);
                 cy.getField('Blueprint Description').get('textarea').type(blueprintDescription);
-                cy.contains('Location').next().find('input').type(`${siteName}{enter}`);
+
+                cy.contains('Location')
+                    .next()
+                    .within(() => {
+                        cy.get('input').type(siteName);
+                        cy.get(`div[option-value="${siteName}"]`).click();
+                    });
 
                 cy.addLabel(labelKey, labelValue);
 

--- a/test/cypress/support/editMode.ts
+++ b/test/cypress/support/editMode.ts
@@ -65,10 +65,17 @@ const commands = {
                         cy.get('@toggle').click();
                 })
         ),
+    setNumericConfigurationField: (widgetId: string, fieldName: string, value: number) =>
+        cy.editWidgetConfiguration(widgetId, () =>
+            // NOTE: after clearing the input, 0 is automatically inserted. {home}{del} removes the leading 0
+            cy.getField(fieldName).find('input').clear().type(`${value}{home}{del}`)
+        ),
     setStringConfigurationField: (widgetId: string, fieldName: string, value: string) =>
         cy.editWidgetConfiguration(widgetId, () => cy.getField(fieldName).find('input').clear().type(value)),
     setSearchableDropdownConfigurationField: (widgetId: string, fieldName: string, value: string) =>
-        cy.editWidgetConfiguration(widgetId, () => cy.setSearchableDropdownValue(fieldName, value))
+        cy.editWidgetConfiguration(widgetId, () => cy.setSearchableDropdownValue(fieldName, value)),
+    setMultipleDropdownConfigurationField: (widgetId: string, fieldName: string, values: string[]) =>
+        cy.editWidgetConfiguration(widgetId, () => cy.setMultipleDropdownValues(fieldName, values))
 };
 
 addCommands(commands);

--- a/widgets/deployments/src/types.ts
+++ b/widgets/deployments/src/types.ts
@@ -38,7 +38,9 @@ export const fetchedLastExecutionFields = [
 
 export type FetchedLastExecutionType = Required<Pick<Execution, typeof fetchedLastExecutionFields[number]>>;
 
-export type EnhancedDeployment = Pick<FullDeploymentData, typeof fetchedDeploymentFields[number]> & {
+export type Deployment = Pick<FullDeploymentData, typeof fetchedDeploymentFields[number]>;
+
+export type EnhancedDeployment = Deployment & {
     nodeInstancesCount: number;
     nodeInstancesStates: Record<string, number>;
     isUpdated: boolean;

--- a/widgets/deploymentsView/README.md
+++ b/widgets/deploymentsView/README.md
@@ -72,7 +72,7 @@ The columns can show:
     The counts and statuses in those columns are based on **all** child
     deployments (it does not matter whether they are directly or indirectly
     attached to the main deployment).
-
+8.  Deployment labels' values for selected label key (you can select labels' keys in widget configuration - "List of labels' keys to show in the table as columns" parameter)
 ### Sorting deployments
 
 Deployments in the table can be sorted by clicking a column's header.
@@ -287,6 +287,7 @@ filter.
   be refreshed, in seconds. Default: 10 seconds
 - `Map height` - the height of the map section in pixels
 - `List of fields to show in the table`
+- `List of labels' keys to show in the table as columns`
 - `Number of items to show at once in the table`
 - `Show map by default`
 - `Name of the saved filter to apply` - the name of a filter to use by default


### PR DESCRIPTION
## Description
Cherry pick of:
1. https://github.com/cloudify-cosmo/cloudify-stage/pull/2500, 
2. https://github.com/cloudify-cosmo/cloudify-stage/pull/2501, 
3. https://github.com/cloudify-cosmo/cloudify-stage/pull/2503,
4. https://github.com/cloudify-cosmo/cloudify-stage/pull/2504

## Screenshots / Videos
See PRs provided in Description section.

## Checklist

- [x] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [x] I followed the [UI Testing Guidelines](https://cloudifysource.atlassian.net/l/cp/udCVfvrx) and verified that all tests/checks have passed.
- [x] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [x] I added proper labels to this PR.

## Tests

1. [![Build Status](https://jenkins.cloudify.co/buildStatus/icon?job=Stage-UI-System-Test&build=4821)](https://jenkins.cloudify.co/view/UI%20Health%20View/job/Stage-UI-System-Test/4821/) - with Cloudify Manager v7.1-dev and Stage package taken from `7.0-bulk-cherry-pick` branch - all system tests passed.

2. Looks like RND-208 is solved, so triggered [![Build Status](https://jenkins.cloudify.co/buildStatus/icon?job=Stage-UI-System-Test&build=4826)](https://jenkins.cloudify.co/job/Stage-UI-System-Test/4826/) with Cloudify Manager v7 and Stage package taken from `7.0-bulk-cherry-pick` branch - failed only on `snapshots_spec`, timeout issue - looks unrelated.


## Documentation
See PRs provided in Description section.