### PR TITLE
RND-297 backend dockerfile: allow configuring port & protocol

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -12,8 +12,10 @@ ENV POSTGRES_HOST=postgresql
 ENV POSTGRES_USER=cloudify
 ENV POSTGRES_PASSWORD=cloudify
 
-# stage backend needs to be able to reach restservice at this address, port 53333
+# stage backend needs to be able to reach restservice at this address, port & proto
 ENV RESTSERVICE_ADDRESS=localhost
+ENV RESTSERVICE_PROTOCOL=https
+ENV RESTSERVICE_PORT=443
 
 # by default, listen on all interfaces
 ENV LISTEN_HOST="0.0.0.0"

--- a/packaging/entrypoint.sh
+++ b/packaging/entrypoint.sh
@@ -24,8 +24,8 @@ cat <<EOF > /app/conf/manager.json
 {
   "ip": "${RESTSERVICE_ADDRESS}",
   "apiVersion": "v3.1",
-  "protocol" : "https",
-  "port": "53333"
+  "protocol" : "${RESTSERVICE_PROTOCOL}",
+  "port": "${RESTSERVICE_PORT}"
 }
 EOF
 


### PR DESCRIPTION
Similar to setting the host, also allow setting the target port & proto via envvars.