### PR TITLE
RND-278 Sync widget README.md files with user documentation

### DIFF
--- a/widgets/blueprintActionButtons/README.md
+++ b/widgets/blueprintActionButtons/README.md
@@ -1,5 +1,5 @@
 # Blueprint Action Buttons
-Buttons that allow performing actions on the blueprint currently set in the context - creating a deployment from it, deleting the blueprint, downloading the blueprint or editing a copy of the blueprint in Composer (available only as part of the Premium edition).
+Buttons that allow performing actions on the blueprint currently set in the context - creating a deployment from it, deleting the blueprint, downloading the blueprint or editing a copy of the blueprint in Composer (available only as part of the Premium edition for users with correct permissions).
  
 See [notes](/working_with/console/widgets/index.html) for more information on resource context.  
 

--- a/widgets/blueprints/README.md
+++ b/widgets/blueprints/README.md
@@ -133,5 +133,5 @@ See Settings section for details on how to turn on/off this feature.
 * `Enable click to drill down` - Enables redirecting to the blueprint’s drill-down page upon clicking on a specific blueprint. Default: Yes
 * `Display style` - Defines how the blueprints list should be displayed. Can be either Catalog or Table. Default: Table
 * `Hide failed blueprints` - Allows to hide blueprints not uploaded successfully. Default: Off
-* `Show Composer options` - Allows to show {{< param cfy_composer_name >}} options in menu and in the blueprints list. Default: On
+* `Show Composer options` - Allows to show {{< param cfy_composer_name >}} options in menu and in the blueprints list for users with permission. Default: On
 * `Label filter rules` - Allows to define blueprint labels' filter rules. See [blueprint filters](/cli/orch_cli/blueprints#blueprint-filters) for more details. Default: empty


### PR DESCRIPTION
## Description

Sync PR after https://github.com/cloudify-cosmo/docs.getcloudify.org/pull/2537.

I think that the change itself is not the best. As a user I don't know what are "permissions" (Blueprint Action Buttons widget) or "correct permissions" (Blueprints widget), but... Don't have energy to fix it, just want to get Stage pipeline to be green again.

## Screenshots / Videos
N/A

## Checklist
- [x] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [x] I followed the [UI Testing Guidelines](https://cloudifysource.atlassian.net/l/cp/udCVfvrx) and verified that all tests/checks have passed.
- [x] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [x] I added proper labels to this PR.

## Tests
CI.

## Documentation
N/A