### PR TITLE
RD-7133 fix environment_button_spec

### DIFF
--- a/test/cypress/integration/widgets/environment_button_spec.ts
+++ b/test/cypress/integration/widgets/environment_button_spec.ts
@@ -63,7 +63,10 @@ describe('Environment button widget', () => {
                 .within(() => {
                     cy.get('input[name=name]').type(name);
                     if (source) cy.contains(source).click({ force: true });
-                    if (value) cy.get('.value').find('input').type(value);
+                    if (value) {
+                        cy.get('.value').find('input').type(value);
+                        if (source === 'Secret') cy.get(`div[option-value="${value}"]`).click();
+                    }
                 });
         }
 
@@ -161,7 +164,7 @@ describe('Environment button widget', () => {
                     .next()
                     .find('tbody')
                     .within(() => {
-                        fillCapabilityInputs(0, secretCapabilityKey, 'Secret', `${secretKey}{enter}`);
+                        fillCapabilityInputs(0, secretCapabilityKey, 'Secret', secretKey);
                         fillCapabilityInputs(1, inputCapabilityKey, 'Input', inputCapabilityValue);
                     });
 


### PR DESCRIPTION
<!--- Provide JIRA issue ID and a general summary of your changes in the Title above -->
<!--- e.g. "RD-1234 Improve styling in SuperComponent" -->
<!--- Note that the title is used as a commit message after merging the PR -->

## Description
<!--- Describe your changes to help reviewers understand the details. -->
RD-7133

## Screenshots / Videos
<!--- If applicable, add screenshot(s) or video(s) describing the changes you made. -->
<!--- Consider adding comparison screenshot(s) - before and after the change. -->
<!--- If not applicable, just write “N/A” in this section. -->
n/a

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [ ] I followed the [UI Testing Guidelines](https://cloudifysource.atlassian.net/l/cp/udCVfvrx) and verified that all tests/checks have passed.
- [ ] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [ ] I added proper labels to this PR.

## Tests
<!--- If applicable, describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If applicable, provide a link to system tests, e.g: -->
<!--- [#1039](https://jenkins.cloudify.co/.../1039) (2021-08-06 07:05:50) --> 
<!--- If not applicable, just write “N/A” in this section. -->
https://jenkins.cloudify.co/view/UI%20Health%20View/job/Stage-UI-System-Test/4889/ ✔️ 

## Documentation
<!--- If applicable, describe how you documented or plan to document your changes. -->
<!--- Check UI documentation guidelines - https://cloudifysource.atlassian.net/l/c/EYWJ0XfB - for details. -->
<!--- Provide links to JIRA issues, other PRs or related documentation pages. -->
<!--- If not applicable, just write “N/A” in this section. -->
n/a