### PR TITLE
RND-359 Extend fix for widgets adding (#2538)

### DIFF
--- a/test/cypress/integration/templateManagement/pages_edit_spec.ts
+++ b/test/cypress/integration/templateManagement/pages_edit_spec.ts
@@ -27,11 +27,7 @@ describe('Page management', () => {
         cy.log('Adding widgets');
         cy.contains('Add Widgets').click();
         cy.waitUntilWidgetsDataLoaded();
-        cy.contains('Add Widget').click();
-        cy.waitUntilWidgetsDataLoaded(20);
-        cy.get('[data-id="agents"]').click();
-        cy.get('[data-id="blueprintSources"]').click();
-        cy.contains('Add selected widgets (2)').click();
+        cy.addWidgets('agents', 'blueprintSources');
 
         cy.log('Managing tabs');
         cy.contains('Add Tabs').click();

--- a/test/cypress/integration/widgets/blueprint_num_spec.ts
+++ b/test/cypress/integration/widgets/blueprint_num_spec.ts
@@ -12,7 +12,7 @@ describe('Number of Blueprints widget', () => {
     }
 
     it('opens the default page on click', () => {
-        cy.activate().mockLogin().addWidget(widgetId);
+        cy.activate().mockLogin().enterEditMode().addWidgets(widgetId).exitEditMode();
         clickOnWidget();
         cy.verifyLocationByPageId('blueprints');
     });

--- a/test/cypress/integration/widgets/plugins_num_spec.ts
+++ b/test/cypress/integration/widgets/plugins_num_spec.ts
@@ -7,7 +7,7 @@ describe('Number of Plugins widget', () => {
         cy.getWidget(widgetId).find('.statistic').click();
     }
 
-    before(() => cy.activate('valid_trial_license').mockLogin().addPage(page).addWidget(widgetId));
+    before(() => cy.activate('valid_trial_license').mockLogin().addPage(page, widgetId));
 
     it('opens the default page on click', () => {
         const defaultPage = 'plugins';

--- a/test/cypress/integration/widgets/sites_map_spec.ts
+++ b/test/cypress/integration/widgets/sites_map_spec.ts
@@ -7,7 +7,7 @@ describe('Sites Map', () => {
     };
 
     before(() => {
-        cy.activate().deleteSites().mockLogin().addPage(sitesMapWidgetPageName).addWidget('sitesMap');
+        cy.activate().deleteSites().mockLogin().addPage(sitesMapWidgetPageName, 'sitesMap');
         navigateToMapPage();
     });
 

--- a/test/cypress/support/editMode.ts
+++ b/test/cypress/support/editMode.ts
@@ -20,17 +20,13 @@ const commands = {
         });
     },
     exitEditMode: () => cy.get('.editModeSidebar').contains('Exit').click(),
-    addWidget: (widgetId: string) => {
-        cy.enterEditMode();
-
+    addWidgets: (...widgetIds: string[]) => {
         cy.contains('Add Widget').click();
-        cy.waitUntilWidgetsDataLoaded();
-        cy.get(`*[data-id=${widgetId}]`).click();
+        cy.waitUntilWidgetsDataLoaded(20);
+        widgetIds.forEach(widgetId => cy.get(`[data-id=${widgetId}]`).click());
         cy.contains('Add selected widgets').click();
-
-        return cy.exitEditMode();
     },
-    addPage: (pageName: string) => {
+    addPage: (pageName: string, widgetId?: string) => {
         cy.enterEditMode();
 
         cy.contains('Add Page').click();
@@ -40,6 +36,7 @@ const commands = {
             cy.get('.pageTitle.input input').clear().type(pageName);
         });
         cy.contains('Add Widgets').click();
+        if (widgetId) cy.addWidgets(widgetId);
 
         return cy.exitEditMode();
     },


### PR DESCRIPTION

<!--- Provide JIRA issue ID and a general summary of your changes in the Title above -->
<!--- e.g. "RD-1234 Improve styling in SuperComponent" -->
<!--- Note that the title is used as a commit message after merging the PR -->

## Description
(cherry picked from commit b062a3dbbff504be93a3a0426a74e765469d2b8a)
<!--- Describe your changes to help reviewers understand the details. -->

## Screenshots / Videos
N/A
<!--- If applicable, add screenshot(s) or video(s) describing the changes you made. -->
<!--- Consider adding comparison screenshot(s) - before and after the change. -->
<!--- If not applicable, just write “N/A” in this section. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [x] I followed the [UI Testing Guidelines](https://cloudifysource.atlassian.net/l/cp/udCVfvrx) and verified that all tests/checks have passed.
- [X] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [X] I added proper labels to this PR.

## Tests
https://jenkins.cloudify.co/view/UI/job/Stage-UI-System-Test/4966/
<!--- If applicable, describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If applicable, provide a link to system tests, e.g: -->
<!--- [#1039](https://jenkins.cloudify.co/.../1039) (2021-08-06 07:05:50) --> 
<!--- If not applicable, just write “N/A” in this section. -->

## Documentation
N/A
<!--- If applicable, describe how you documented or plan to document your changes. -->
<!--- Check UI documentation guidelines - https://cloudifysource.atlassian.net/l/c/EYWJ0XfB - for details. -->
<!--- Provide links to JIRA issues, other PRs or related documentation pages. -->
<!--- If not applicable, just write “N/A” in this section. -->
