### PR TITLE
RND-107 Create Execution Logs widget - part 2

### DIFF
--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -1600,7 +1600,12 @@
             "name": "Execution Logs",
             "description": "This widget shows the execution logs",
             "noExecutionSelectedMessage": "Please select execution in order to see execution logs.",
-            "showMoreLogs": "Show more logs"
+            "buttons": {
+              "showMoreLogs": "Show more logs",
+              "expandMessage": "Expand message",
+              "collapseMessage": "Collapse message",
+              "showErrorCauses": "Show error causes"
+            }
         },
         "executions": {
             "name": "Executions",

--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -1599,7 +1599,8 @@
         "executionLogs": {
             "name": "Execution Logs",
             "description": "This widget shows the execution logs",
-            "noExecutionSelectedMessage": "Please select execution in order to see execution logs."
+            "noExecutionSelectedMessage": "Please select execution in order to see execution logs.",
+            "showMoreLogs": "Show more logs"
         },
         "executions": {
             "name": "Executions",

--- a/app/utils/GenericConfig.ts
+++ b/app/utils/GenericConfig.ts
@@ -24,7 +24,9 @@ export default class GenericConfig {
         };
     };
 
-    static SORT_COLUMN_CONFIG = (sortColumn: string): WidgetConfigurationDefinition => {
+    static SORT_COLUMN_CONFIG = <ColumnName extends string = string>(
+        sortColumn: ColumnName
+    ): WidgetConfigurationDefinition => {
         return {
             id: 'sortColumn',
             default: sortColumn,

--- a/test/cypress/integration/widgets/execution_logs_spec.ts
+++ b/test/cypress/integration/widgets/execution_logs_spec.ts
@@ -1,0 +1,65 @@
+describe('Execution logs widget', () => {
+    const widgetId = 'executionLogs';
+    const resourcePrefix = `${widgetId}_test_`;
+    const blueprintName = `${resourcePrefix}blueprint`;
+    const deploymentName = `${resourcePrefix}deployment`;
+
+    before(() => {
+        cy.activate()
+            .deleteDeployments(deploymentName, true)
+            .deleteBlueprints(blueprintName, true)
+            .uploadBlueprint('blueprints/simple.zip', blueprintName)
+            .deployBlueprint(
+                blueprintName,
+                deploymentName,
+                { server_ip: '127.0.0.1' },
+                { display_name: deploymentName }
+            )
+            .executeWorkflow(deploymentName, 'install')
+            .usePageMock(widgetId)
+            .mockLogin();
+    });
+
+    it('when execution ID is not set should show a message', () => {
+        cy.clearExecutionContext();
+        cy.getWidget(widgetId).within(() => {
+            cy.contains('Please select execution in order to see execution logs.');
+        });
+    });
+
+    describe('when execution ID is set should show logs table and', () => {
+        before(() => cy.clearDeploymentContext().setDeploymentContext(deploymentName).setExecutionContext('install'));
+
+        it('allow to expand/collapse long messages', () => {
+            const visibleFullMessage = "Starting 'install' workflow execution";
+            const visibleMessagePart = "'install' workflow execution failed";
+            const hiddenMessagePart = 'Traceback of cloudify_agent.installer.operations.create';
+
+            const getExpandMessageIcon = () => cy.get('[aria-label="Expand message"]');
+            const getCollapseMessageIcon = () => cy.get('[aria-label="Collapse message"]');
+
+            cy.contains('td', visibleFullMessage).within(() => {
+                getExpandMessageIcon().should('not.exist');
+                getCollapseMessageIcon().should('not.exist');
+            });
+
+            cy.contains('td', visibleMessagePart).within(() => {
+                getExpandMessageIcon().click();
+                cy.contains(hiddenMessagePart);
+                getCollapseMessageIcon().click();
+            });
+        });
+
+        it('allows to show error causes', () => {
+            const errorCausesMessagePart = "Task failed 'cloudify_agent.installer.operations.create'";
+            const errorCauseType = 'AgentInstallerConfigurationError';
+            const getErrorCausesIcon = () => cy.get('[aria-label="Show error causes"]');
+
+            cy.contains('tr', errorCausesMessagePart).within(() => getErrorCausesIcon().click());
+            cy.get('.modal').within(() => {
+                cy.contains(errorCauseType);
+                cy.clickButton('Close');
+            });
+        });
+    });
+});

--- a/test/cypress/integration/widgets/execution_logs_spec.ts
+++ b/test/cypress/integration/widgets/execution_logs_spec.ts
@@ -35,8 +35,8 @@ describe('Execution logs widget', () => {
             const visibleMessagePart = "'install' workflow execution failed";
             const hiddenMessagePart = 'Traceback of cloudify_agent.installer.operations.create';
 
-            const getExpandMessageIcon = () => cy.get('[aria-label="Expand message"]');
-            const getCollapseMessageIcon = () => cy.get('[aria-label="Collapse message"]');
+            const getExpandMessageIcon = () => cy.get('[title="Expand message"]');
+            const getCollapseMessageIcon = () => cy.get('[title="Collapse message"]');
 
             cy.contains('td', visibleFullMessage).within(() => {
                 getExpandMessageIcon().should('not.exist');
@@ -53,7 +53,7 @@ describe('Execution logs widget', () => {
         it('allows to show error causes', () => {
             const errorCausesMessagePart = "Task failed 'cloudify_agent.installer.operations.create'";
             const errorCauseType = 'AgentInstallerConfigurationError';
-            const getErrorCausesIcon = () => cy.get('[aria-label="Show error causes"]');
+            const getErrorCausesIcon = () => cy.get('[title="Show error causes"]');
 
             cy.contains('tr', errorCausesMessagePart).within(() => getErrorCausesIcon().click());
             cy.get('.modal').within(() => {

--- a/test/cypress/support/commands.ts
+++ b/test/cypress/support/commands.ts
@@ -353,7 +353,7 @@ const commands = {
                                               configuration: {
                                                   filterByBlueprints: true,
                                                   filterByDeployments: true,
-                                                  filterByExecutionsStatus: true,
+                                                  filterByExecutions: true,
                                                   allowMultipleSelection: true
                                               },
                                               drillDownPages: {},
@@ -403,6 +403,9 @@ const commands = {
 
     setDeploymentContext: (value: string) => setContext('deployment', value),
     clearDeploymentContext: () => clearContext('deployment'),
+
+    setExecutionContext: (value: string) => setContext('execution', value, false),
+    clearExecutionContext: () => clearContext('execution'),
 
     interceptSp: (method: string, spRouteMatcher: GlobPattern | RouteMatcherOptions, routeHandler?: RouteHandler) => {
         const routeMatcher: RouteMatcherOptions = { method };
@@ -541,13 +544,15 @@ Cypress.Commands.add('getTable', { prevSubject: true }, (subject: any) => {
     return cy.wrap(mappedTableValues);
 });
 
-function setContext(field: string, value: string) {
-    cy.get(`.${field}FilterField`)
+function setContext(field: string, value: string, exactValue = true) {
+    return cy
+        .get(`.${field}FilterField`)
         .click()
         .within(() => {
             cy.get('input').clear({ force: true }).type(`${value}`, { force: true });
             cy.waitUntilWidgetsDataLoaded();
-            cy.get(`[option-value="${value}"]`).click();
+            if (exactValue) cy.get(`[option-value="${value}"]`).click();
+            else cy.contains('div[role="option"]', value).click();
             cy.get('input').type('{esc}', { force: true });
         });
 }

--- a/widgets/executionLogs/src/LogMessage.tsx
+++ b/widgets/executionLogs/src/LogMessage.tsx
@@ -2,6 +2,7 @@ import type { FunctionComponent } from 'react';
 import React from 'react';
 import styled from 'styled-components';
 import { useIsOverflow } from './useIsOverflow';
+import { translate } from './consts';
 
 const ExpandableMessage = styled.div<{ expanded: boolean }>`
     overflow: hidden;
@@ -30,6 +31,7 @@ const LogMessage: FunctionComponent<LogMessageProps> = ({ message }) => {
         <>
             {showExpandCollapseIcon && (
                 <Icon
+                    aria-label={translate(isExpanded ? 'buttons.collapseMessage' : 'buttons.expandMessage')}
                     link
                     name={isExpanded ? 'chevron up' : 'chevron down'}
                     onClick={toggleExpandCollapse}

--- a/widgets/executionLogs/src/LogMessage.tsx
+++ b/widgets/executionLogs/src/LogMessage.tsx
@@ -31,7 +31,7 @@ const LogMessage: FunctionComponent<LogMessageProps> = ({ message }) => {
         <>
             {showExpandCollapseIcon && (
                 <Icon
-                    aria-label={translate(isExpanded ? 'buttons.collapseMessage' : 'buttons.expandMessage')}
+                    title={translate(isExpanded ? 'buttons.collapseMessage' : 'buttons.expandMessage')}
                     link
                     name={isExpanded ? 'chevron up' : 'chevron down'}
                     onClick={toggleExpandCollapse}

--- a/widgets/executionLogs/src/LogsTable.tsx
+++ b/widgets/executionLogs/src/LogsTable.tsx
@@ -53,7 +53,7 @@ export default function LogsTable({ items, executionId, moreItemsAvailable, page
                         return (
                             <Table.Row
                                 // eslint-disable-next-line no-underscore-dangle
-                                key={`${item._storage_id} + ${item.reported_timestamp}`}
+                                key={item._storage_id + item.reported_timestamp}
                                 error={isErrorLog}
                                 verticalAlign="top"
                             >

--- a/widgets/executionLogs/src/LogsTable.tsx
+++ b/widgets/executionLogs/src/LogsTable.tsx
@@ -64,7 +64,7 @@ export default function LogsTable({ items, executionId, moreItemsAvailable, page
                                 {hasErrorCauses && (
                                     <Table.Cell collapsing>
                                         <Icon
-                                            aria-label={translate('buttons.showErrorCauses')}
+                                            title={translate('buttons.showErrorCauses')}
                                             name="zoom"
                                             link
                                             onClick={() => setEvent(item)}

--- a/widgets/executionLogs/src/LogsTable.tsx
+++ b/widgets/executionLogs/src/LogsTable.tsx
@@ -1,30 +1,62 @@
 import { isEmpty } from 'lodash';
+import { useEffect } from 'react';
 import LogMessage from './LogMessage';
 import type { Event, ExecutionLogsData } from './types';
+import { basePageSize, translate } from './consts';
 
 interface LogsTableProps {
-    data: ExecutionLogsData;
+    items: ExecutionLogsData['items'];
+    executionId: string;
+    moreItemsAvailable: boolean;
+    pageSize: number;
+    toolbox: Stage.Types.Toolbox;
 }
-export default function LogsTable({ data }: LogsTableProps) {
-    const { Icon, Table } = Stage.Basic;
+export default function LogsTable({ items, executionId, moreItemsAvailable, pageSize, toolbox }: LogsTableProps) {
+    const { Button, Icon, Table } = Stage.Basic;
     const { ErrorCausesModal, Utils } = Stage.Common.Events;
     const { Json } = Stage.Utils;
     const { useResettableState } = Stage.Hooks;
     const [event, setEvent, resetEvent] = useResettableState<Event | undefined>(undefined);
 
+    const setPageSize = (size: number) => toolbox.refresh({ gridParams: { pageSize: size } });
+    const showMoreLogs = () => setPageSize(pageSize + basePageSize);
+
+    useEffect(() => {
+        setPageSize(basePageSize);
+    }, [executionId]);
+
     return (
         <>
             <Table basic color="black" compact inverted>
+                {!moreItemsAvailable && (
+                    <Table.Header>
+                        <Table.Row>
+                            <Table.HeaderCell colspan={3} textAlign="center">
+                                <Button
+                                    basic
+                                    compact
+                                    content={translate('showMoreLogs')}
+                                    inverted
+                                    onClick={showMoreLogs}
+                                />
+                            </Table.HeaderCell>
+                        </Table.Row>
+                    </Table.Header>
+                )}
                 <Table.Body>
-                    {data.items.map(item => {
+                    {items.map(item => {
                         const messageText = Json.stringify(item.message, false);
                         const isErrorLog = Utils.isError(item);
                         const hasErrorCauses = !isEmpty(item.error_causes);
                         const timestamp = Utils.getFormattedTimestamp(item);
 
                         return (
-                            // eslint-disable-next-line no-underscore-dangle
-                            <Table.Row key={item._storage_id} error={isErrorLog} verticalAlign="top">
+                            <Table.Row
+                                // eslint-disable-next-line no-underscore-dangle
+                                key={`${item._storage_id} + ${item.reported_timestamp}`}
+                                error={isErrorLog}
+                                verticalAlign="top"
+                            >
                                 <Table.Cell collapsing>{timestamp}</Table.Cell>
                                 <Table.Cell colSpan={hasErrorCauses ? 1 : 2}>
                                     <LogMessage message={messageText} />

--- a/widgets/executionLogs/src/LogsTable.tsx
+++ b/widgets/executionLogs/src/LogsTable.tsx
@@ -35,7 +35,7 @@ export default function LogsTable({ items, executionId, moreItemsAvailable, page
                                 <Button
                                     basic
                                     compact
-                                    content={translate('showMoreLogs')}
+                                    content={translate('buttons.showMoreLogs')}
                                     inverted
                                     onClick={showMoreLogs}
                                 />
@@ -63,7 +63,12 @@ export default function LogsTable({ items, executionId, moreItemsAvailable, page
                                 </Table.Cell>
                                 {hasErrorCauses && (
                                     <Table.Cell collapsing>
-                                        <Icon name="zoom" link onClick={() => setEvent(item)} />
+                                        <Icon
+                                            aria-label={translate('buttons.showErrorCauses')}
+                                            name="zoom"
+                                            link
+                                            onClick={() => setEvent(item)}
+                                        />
                                     </Table.Cell>
                                 )}
                             </Table.Row>

--- a/widgets/executionLogs/src/consts.ts
+++ b/widgets/executionLogs/src/consts.ts
@@ -1,3 +1,9 @@
+export const widgetId = 'executionLogs';
+
+export const translate = Stage.Utils.getT(`widgets.${widgetId}`);
+
+export const basePageSize = 50;
+
 export const commonIncludeKeys = [
     '_storage_id',
     'execution_id',

--- a/widgets/executionLogs/src/widget.tsx
+++ b/widgets/executionLogs/src/widget.tsx
@@ -4,11 +4,8 @@ import type { ExecutionLogsData } from './types';
 import { basePageSize, commonIncludeKeys, translate, widgetId } from './consts';
 import LogsTable from './LogsTable';
 
-const includeKeys: (keyof FullEventData | keyof CloudifyLogEventPart | keyof CloudifyEventPart)[] = [
-    ...commonIncludeKeys,
-    'event_type',
-    'level'
-];
+type IncludeKey = keyof FullEventData | keyof CloudifyLogEventPart | keyof CloudifyEventPart;
+const includeKeys: IncludeKey[] = [...commonIncludeKeys, 'event_type', 'level'];
 
 interface ExecutionLogsParams {
     // eslint-disable-next-line camelcase
@@ -29,7 +26,7 @@ Stage.defineWidget<ExecutionLogsParams, ExecutionLogsData, ExecutionLogsConfigur
     initialConfiguration: [
         Stage.GenericConfig.POLLING_TIME_CONFIG(2),
         Stage.GenericConfig.PAGE_SIZE_CONFIG(basePageSize),
-        Stage.GenericConfig.SORT_COLUMN_CONFIG('reported_timestamp'),
+        Stage.GenericConfig.SORT_COLUMN_CONFIG<IncludeKey>('reported_timestamp'),
         Stage.GenericConfig.SORT_ASCENDING_CONFIG(false)
     ],
 

--- a/widgets/executionLogs/src/widget.tsx
+++ b/widgets/executionLogs/src/widget.tsx
@@ -1,11 +1,9 @@
-import type { PageSizeConfiguration, PollingTimeConfiguration } from 'app/utils/GenericConfig';
+import type { DataTableConfiguration, PollingTimeConfiguration } from 'app/utils/GenericConfig';
 import type { CloudifyEventPart, CloudifyLogEventPart, FullEventData } from 'app/widgets/common/events';
 import type { ExecutionLogsData } from './types';
-import { commonIncludeKeys } from './consts';
+import { basePageSize, commonIncludeKeys, translate, widgetId } from './consts';
 import LogsTable from './LogsTable';
 
-const widgetId = 'executionLogs';
-const translate = Stage.Utils.getT(`widgets.${widgetId}`);
 const includeKeys: (keyof FullEventData | keyof CloudifyLogEventPart | keyof CloudifyEventPart)[] = [
     ...commonIncludeKeys,
     'event_type',
@@ -17,7 +15,7 @@ interface ExecutionLogsParams {
     execution_id: string;
 }
 
-type ExecutionLogsConfiguration = PollingTimeConfiguration & PageSizeConfiguration;
+type ExecutionLogsConfiguration = PollingTimeConfiguration & DataTableConfiguration;
 
 Stage.defineWidget<ExecutionLogsParams, ExecutionLogsData, ExecutionLogsConfiguration>({
     id: widgetId,
@@ -28,7 +26,12 @@ Stage.defineWidget<ExecutionLogsParams, ExecutionLogsData, ExecutionLogsConfigur
     permission: Stage.GenericConfig.WIDGET_PERMISSION(widgetId),
     categories: [Stage.GenericConfig.CATEGORY.SYSTEM_RESOURCES],
 
-    initialConfiguration: [Stage.GenericConfig.POLLING_TIME_CONFIG(2), Stage.GenericConfig.PAGE_SIZE_CONFIG(50)],
+    initialConfiguration: [
+        Stage.GenericConfig.POLLING_TIME_CONFIG(2),
+        Stage.GenericConfig.PAGE_SIZE_CONFIG(basePageSize),
+        Stage.GenericConfig.SORT_COLUMN_CONFIG('reported_timestamp'),
+        Stage.GenericConfig.SORT_ASCENDING_CONFIG(false)
+    ],
 
     fetchParams(_widget, toolbox) {
         const executionId = toolbox.getContext().getValue('executionId');
@@ -38,7 +41,7 @@ Stage.defineWidget<ExecutionLogsParams, ExecutionLogsData, ExecutionLogsConfigur
         };
     },
 
-    render(_widget, data, _error, toolbox) {
+    render(widget, data, _error, toolbox) {
         const { Loading, Message } = Stage.Basic;
 
         if (Stage.Utils.isEmptyWidgetData(data)) {
@@ -51,6 +54,17 @@ Stage.defineWidget<ExecutionLogsParams, ExecutionLogsData, ExecutionLogsConfigur
             return <Message>{translate('noExecutionSelectedMessage')}</Message>;
         }
 
-        return <LogsTable data={data} />;
+        const items = [...data.items].reverse();
+        const moreItemsAvailable = data.metadata.pagination.size >= data.metadata.pagination.total;
+
+        return (
+            <LogsTable
+                items={items}
+                executionId={executionId}
+                moreItemsAvailable={moreItemsAvailable}
+                pageSize={widget.configuration.pageSize}
+                toolbox={toolbox}
+            />
+        );
     }
 });


### PR DESCRIPTION
## Description

This PR extends #2533 with "Show more logs" button and basic tests for new widget.

## Screenshots / Videos

https://user-images.githubusercontent.com/5202105/232470804-aa4b0021-ffac-4b41-8de6-5013ab931605.mp4

## Checklist
- [x] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [x] I followed the [UI Testing Guidelines](https://cloudifysource.atlassian.net/l/cp/udCVfvrx) and verified that all tests/checks have passed.
- [x] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [x] I added proper labels to this PR.

## Tests
[![Build Status](https://jenkins.cloudify.co/buildStatus/icon?job=Stage-UI-System-Test&build=4979)](https://jenkins.cloudify.co/view/UI%20Health%20View/job/Stage-UI-System-Test/4979/) - full run - 3 tests failed (RD-4589, RD-6838 and something new from `snapshots_spec`), none of them seems related

## Documentation
Will be added as part of [RND-115](https://cloudifysource.atlassian.net/browse/RND-115).

[RND-115]: https://cloudifysource.atlassian.net/browse/RND-115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ