### PR TITLE
RD-7152 Add support for Resource Filter widget configuration in Cypress tests

### DIFF
--- a/test/cypress/integration/widgets/execution_logs_spec.ts
+++ b/test/cypress/integration/widgets/execution_logs_spec.ts
@@ -16,7 +16,18 @@ describe('Execution logs widget', () => {
                 { display_name: deploymentName }
             )
             .executeWorkflow(deploymentName, 'install')
-            .usePageMock(widgetId)
+            .usePageMock(
+                widgetId,
+                {},
+                {
+                    filterWidgetConfiguration: {
+                        allowMultipleSelection: false,
+                        filterByBlueprints: false,
+                        filterByDeployments: true,
+                        filterByExecutions: true
+                    }
+                }
+            )
             .mockLogin();
     });
 

--- a/test/cypress/support/commands.ts
+++ b/test/cypress/support/commands.ts
@@ -18,6 +18,7 @@ import { addCommands } from 'cloudify-ui-common-cypress/support';
 import 'cypress-file-upload';
 import 'cypress-localstorage-commands';
 import type { GlobPattern, RouteHandler, RouteMatcher, RouteMatcherOptions } from 'cypress/types/net-stubbing';
+import type { FilterConfiguration } from 'widgets/filter/src/types';
 import { castArray, identity, isString, noop } from 'lodash';
 import './asserts';
 import './blueprints';
@@ -341,8 +342,18 @@ const commands = {
         widgetConfiguration: any = {},
         {
             widgetsWidth = 8,
-            stubTemplatesResponse = true
-        }: { widgetsWidth?: number; stubTemplatesResponse?: boolean } = {}
+            stubTemplatesResponse = true,
+            filterWidgetConfiguration = {
+                filterByBlueprints: true,
+                filterByDeployments: true,
+                filterByExecutionsStatus: true,
+                allowMultipleSelection: true
+            }
+        }: {
+            widgetsWidth?: number;
+            stubTemplatesResponse?: boolean;
+            filterWidgetConfiguration?: Partial<FilterConfiguration>;
+        } = {}
     ) => {
         const widgetIdsArray = castArray(widgetIds);
         if (stubTemplatesResponse) cy.intercept('GET', '/console/templates', []);
@@ -363,12 +374,7 @@ const commands = {
                                               id: 'filter',
                                               name: 'Resource Filter',
                                               definition: 'filter',
-                                              configuration: {
-                                                  filterByBlueprints: true,
-                                                  filterByDeployments: true,
-                                                  filterByExecutions: true,
-                                                  allowMultipleSelection: true
-                                              },
+                                              configuration: filterWidgetConfiguration,
                                               drillDownPages: {},
                                               height: 2,
                                               width: widgetsWidth,


### PR DESCRIPTION
## Description

This PR fixes issue introduced by https://github.com/cloudify-cosmo/cloudify-stage/pull/2541 and described in RD-7152.
The fix adds support for Resource Filter widget configuration (which is used in all tests using `usePageMock`) and reverts default configuration to the one used prior merging https://github.com/cloudify-cosmo/cloudify-stage/pull/2541.

## Screenshots / Videos
N/A

## Checklist
- [x] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [x] I followed the [UI Testing Guidelines](https://cloudifysource.atlassian.net/l/cp/udCVfvrx) and verified that all tests/checks have passed.
- [x] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [x] I added proper labels to this PR.

## Tests
1. Manual Cypress test execution on Resource Filter widget and Execution Logs widget specs - PASSED
2. Full system tests run - [![Build Status](https://jenkins.cloudify.co/buildStatus/icon?job=Stage-UI-System-Test&build=5029)](https://jenkins.cloudify.co/view/UI%20Health%20View/job/Stage-UI-System-Test/5029/) - failed on known issues only (RND-527, RND-533, RD-7153), so I'm considering it as PASSED

## Documentation
N/A