### PR TITLE
RD-6631 Add retries in run mode for `user_configuration_spec`

### DIFF
--- a/test/cypress/integration/user_configuration_spec.ts
+++ b/test/cypress/integration/user_configuration_spec.ts
@@ -64,8 +64,8 @@ describe('User configuration', () => {
         verifyLogoUrl('.sidebarContainer .logo');
 
         cy.log('Verifying showVersionDetails...');
-        const majorVersion = String(Consts.APP_VERSION)[0];
-        cy.get('.sidebar > div > a').should('not.contain.text', `v ${majorVersion}`);
+        const versionFirstDigit = String(Consts.APP_VERSION)[0];
+        cy.get('.sidebar > div > a').should('not.contain.text', `v ${versionFirstDigit}`);
         cy.get('a[href="/console/license"]').should('not.exist');
     });
 });

--- a/test/cypress/integration/user_configuration_spec.ts
+++ b/test/cypress/integration/user_configuration_spec.ts
@@ -25,61 +25,47 @@ describe('User configuration', () => {
         );
     }
 
-    before(cy.activate);
-
-    describe('allows to customize Login page', () => {
-        before(() => {
-            mockConfigResponse();
-            cy.visit('/console');
-            cy.contains('Welcome to the Cloudify Management Console').should('be.visible');
-        });
-
-        it('logo', () => {
-            verifyLogoUrl('.logo');
-        });
-
-        it('colors', () => {
-            cy.log('Verifying mainColor...');
-            cy.get('.fullScreenSegment').should('have.css', 'background-color', colors.blue);
-
-            cy.log('Verifying loginPageHeaderColor...');
-            cy.get('h2').should('have.css', 'color', colors.lightgrey);
-            cy.log('Verifying loginPageTextColor...');
-            cy.get('p').should('have.css', 'color', colors.black);
-        });
-
-        it('first login hint', () => {
-            cy.contains('For the first login').should('not.exist');
-        });
+    before(() => {
+        cy.activate();
+        mockConfigResponse();
     });
 
-    describe('allows to customize page', () => {
-        before(() => {
-            mockConfigResponse();
-            cy.mockLogin();
+    it('allows to customize Login page', () => {
+        cy.visit('/console');
+        cy.contains('Welcome to the Cloudify Management Console').should('be.visible');
+
+        verifyLogoUrl('.logo');
+
+        cy.log('Verifying mainColor...');
+        cy.get('.fullScreenSegment').should('have.css', 'background-color', colors.blue);
+
+        cy.log('Verifying loginPageHeaderColor...');
+        cy.get('h2').should('have.css', 'color', colors.lightgrey);
+        cy.log('Verifying loginPageTextColor...');
+        cy.get('p').should('have.css', 'color', colors.black);
+
+        cy.log('Verifying first login hint...');
+        cy.contains('For the first login').should('not.exist');
+    });
+
+    it('allows to customize page', () => {
+        cy.mockLogin();
+
+        cy.log('Verifying headerTextColor...');
+        cy.get('.sidebarContainer > div > div > a').should('have.css', 'color', colors.black);
+
+        cy.get('.sidebarContainer').within(() => {
+            cy.log('Verifying sidebarColor...');
+            cy.get('.sidebar').should('have.css', 'background-color', colors.grey);
+            cy.log('Verifying sidebarTextColor...');
+            cy.get('.pageMenuItem').should('have.css', 'color', colors.black);
         });
 
-        it('sidebar', () => {
-            cy.log('Verifying headerTextColor...');
-            cy.get('.sidebarContainer > div > div > a').should('have.css', 'color', colors.black);
+        verifyLogoUrl('.sidebarContainer .logo');
 
-            cy.get('.sidebarContainer').within(() => {
-                cy.log('Verifying sidebarColor...');
-                cy.get('.sidebar').should('have.css', 'background-color', colors.grey);
-                cy.log('Verifying sidebarTextColor...');
-                cy.get('.pageMenuItem').should('have.css', 'color', colors.black);
-            });
-        });
-
-        it('logo', () => {
-            verifyLogoUrl('.sidebarContainer .logo');
-        });
-
-        it('version details', () => {
-            const majorVersion = String(Consts.APP_VERSION)[0];
-            cy.log('Verifying showVersionDetails...');
-            cy.get('.sidebar > div > a').should('not.contain.text', `v ${majorVersion}`);
-            cy.get('a[href="/console/license"]').should('not.exist');
-        });
+        cy.log('Verifying showVersionDetails...');
+        const majorVersion = String(Consts.APP_VERSION)[0];
+        cy.get('.sidebar > div > a').should('not.contain.text', `v ${majorVersion}`);
+        cy.get('a[href="/console/license"]').should('not.exist');
     });
 });

--- a/test/cypress/integration/user_configuration_spec.ts
+++ b/test/cypress/integration/user_configuration_spec.ts
@@ -30,7 +30,7 @@ describe('User configuration', () => {
         mockConfigResponse();
     });
 
-    it('allows to customize Login page', () => {
+    it('allows to customize Login page', { retries: { runMode: 2 } }, () => {
         cy.visit('/console');
         cy.contains('Welcome to the Cloudify Management Console').should('be.visible');
 

--- a/test/cypress/integration/widgets/deployments_view_spec.ts
+++ b/test/cypress/integration/widgets/deployments_view_spec.ts
@@ -897,7 +897,11 @@ describe('Deployments View widget', () => {
             useEnvironmentsWidget();
             cy.getSearchInput().clear().type(fullDeploymentName);
             getDeploymentsViewTable().contains(fullDeploymentName);
-            getDeploymentsViewTable().within(() => cy.get('[title="Click to drill down to subservices"]').click());
+            cy.get('.input.loading').should('not.exist');
+            getDeploymentsViewTable()
+                .contains('tr', fullDeploymentName)
+                .find('[title="Click to drill down to subservices"]')
+                .click();
 
             getBreadcrumbs().contains('app-env [Services]').should('be.visible');
         });


### PR DESCRIPTION
## Description
As RD-6631 has been bothering us for a long time, I turned on test retries mechanism in `user_configuration_spec`.
In order to do that I had move problematic part out of `before` hook as according to [Test Retries - How it works](https://docs.cypress.io/guides/guides/test-retries#How-It-Works):

> failures in before and after hooks will not trigger a retry.

## Screenshots / Videos
N/A

## Checklist
- [x] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [x] I followed the [UI Testing Guidelines](https://cloudifysource.atlassian.net/l/cp/udCVfvrx) and verified that all tests/checks have passed.
- [x] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [x] I added proper labels to this PR.

## Tests
Only `user_configuration_spec`:
1. [![Build Status](https://jenkins.cloudify.co/buildStatus/icon?job=Stage-UI-System-Test&build=5086)](https://jenkins.cloudify.co/view/UI%20Health%20View/job/Stage-UI-System-Test/5086/) - hit, retry helped 
2. [![Build Status](https://jenkins.cloudify.co/buildStatus/icon?job=Stage-UI-System-Test&build=5087)](https://jenkins.cloudify.co/view/UI%20Health%20View/job/Stage-UI-System-Test/5087/)
3. [![Build Status](https://jenkins.cloudify.co/buildStatus/icon?job=Stage-UI-System-Test&build=5088)](https://jenkins.cloudify.co/view/UI%20Health%20View/job/Stage-UI-System-Test/5088/)
4. [![Build Status](https://jenkins.cloudify.co/buildStatus/icon?job=Stage-UI-System-Test&build=5089)](https://jenkins.cloudify.co/view/UI%20Health%20View/job/Stage-UI-System-Test/5089/)
5. [![Build Status](https://jenkins.cloudify.co/buildStatus/icon?job=Stage-UI-System-Test&build=5090)](https://jenkins.cloudify.co/view/UI%20Health%20View/job/Stage-UI-System-Test/5090/)

## Documentation
N/A