### PR TITLE
CYBL-2046 Fix data source in Deployment ID input field

### DIFF
--- a/app/widgets/common/inputs/fields/DeploymentIdInputField.tsx
+++ b/app/widgets/common/inputs/fields/DeploymentIdInputField.tsx
@@ -10,7 +10,7 @@ export default function DeploymentIdInputField({
     onChange,
     ...restProps
 }: DynamicDropdownInputFieldProps) {
-    const fetchUrl = '/deployments?_include=id,display_name';
+    const fetchUrl = '/searches/deployments?_include=id,display_name';
 
     return (
         <DynamicDropdown

--- a/test/cypress/integration/widgets/deployment_button_deployment_inputs_spec.ts
+++ b/test/cypress/integration/widgets/deployment_button_deployment_inputs_spec.ts
@@ -67,14 +67,16 @@ describe('Create Deployment modal handles deployment inputs', () => {
             cy.get('div.dropdown').click();
         }
 
-        const contains = typedPrefix ? ` :contains("${typedPrefix}")` : '';
-        if (number === 0) {
-            cy.get('.menu').contains('No results found.').should('be.visible');
-        } else if (atLeast) {
-            cy.get(`.menu .item[role="option"]${contains}`).should('have.length.at.least', number);
-        } else {
-            cy.get(`.menu .item[role="option"]${contains}`).should('have.length', number);
-        }
+        cy.get('.menu').within(() => {
+            if (number === 0) {
+                cy.contains('No results found.');
+            } else {
+                cy.get(
+                    `.item[role="option"]:not(".disabled")${typedPrefix ? `:contains("${typedPrefix}")` : ''}`
+                ).should(`have.length${atLeast ? '.at.least' : ''}`, number);
+            }
+        });
+
         cy.get('label').click();
     };
 


### PR DESCRIPTION
## Description

Fixed URL in `DeploymentIdInputField` component (it was by mistake changed long time ago within #2324 ).

The bug was not detected by our test (`deployment_button_deployment_inputs_spec.ts`), because the method used in that test to verify input field options was buggy. Test fix is part of this PR.

Once merged, this PR will be cherry-picked on `7.0.1-build` branch.

## Screenshots / Videos
N/A

## Checklist
- [x] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [x] I followed the [UI Testing Guidelines](https://cloudifysource.atlassian.net/l/cp/udCVfvrx) and verified that all tests/checks have passed.
- [x] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [x] I added proper labels to this PR.

## Tests
[![Build Status](https://jenkins.cloudify.co/buildStatus/icon?job=Stage-UI-System-Test&build=5179)](https://jenkins.cloudify.co/view/UI%20Health%20View/job/Stage-UI-System-Test/5179/) - failed on `environment_button_spec`, seems like due to test flakiness, retested locally and it passes => I consider tests as PASSED

## Documentation
N/A