### PR TITLE
NE-6424 Dockerfiles: bump base image to Node 20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # and then only serve them using a simple busybox http server.
 # Build this with e.g.: `docker build . -t stage_frontend`
 
-FROM node:16 as builder
+FROM node:20.9.0 as builder
 
 WORKDIR /app
 

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -3,7 +3,7 @@
 # acting as the server proxy and widgets backend.
 # Build this with e.g.: `docker build -f Dockerfile.backend . -t stage_backend`
 
-FROM node:16
+FROM node:20.9.0
 
 ARG username=cfyuser
 ARG groupname=cfyuser


### PR DESCRIPTION
A newer Node base image contains fewer vulnerable packages. A quick manual test showed that the containers seem to work correctly.
