### PR TITLE
NE-32814 Fix Absolute Path Traversal Vulnerability

### DIFF
--- a/backend/handler/templates/PageGroupsHandler.ts
+++ b/backend/handler/templates/PageGroupsHandler.ts
@@ -3,6 +3,7 @@ import _ from 'lodash';
 import fs, { readdirSync, readJsonSync } from 'fs-extra';
 
 import moment from 'moment';
+import sanitizeFilename from 'sanitize-filename';
 import { builtInTemplatesFolder, userTemplatesFolder } from './TemplatesHandler';
 import { getLogger } from '../LoggerHandler';
 import type { CreatePageGroupData, PageGroup, PageGroupFileContent } from './types';
@@ -45,7 +46,7 @@ export function listPageGroups() {
 }
 
 function getUserPageGroupPath(id: string) {
-    return pathlib.resolve(userPageGroupsFolder, `${id}.json`);
+    return pathlib.resolve(userPageGroupsFolder, `${sanitizeFilename(id)}.json`);
 }
 
 export function checkPageGroupExists(pageGroup: CreatePageGroupData) {

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -47,7 +47,7 @@
                 "pg": "^8.7.3",
                 "pg-hstore": "^2.3.3",
                 "query-string": "^7.0.1",
-                "sanitize-filename": "^1.6.1",
+                "sanitize-filename": "^1.6.3",
                 "sharp": "^0.30.7",
                 "supertest": "^5.0.0",
                 "ts-node": "^10.2.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -66,7 +66,7 @@
         "pg": "^8.7.3",
         "pg-hstore": "^2.3.3",
         "query-string": "^7.0.1",
-        "sanitize-filename": "^1.6.1",
+        "sanitize-filename": "^1.6.3",
         "sharp": "^0.30.7",
         "supertest": "^5.0.0",
         "ts-node": "^10.2.1",


### PR DESCRIPTION
## Description
This PR updates to the latest version `sanitize-filename` and fixes vulnerability present in `getUserPageGroupPath` in `PageGroupsHandler.ts`

This fixes reported vulnerabilities: [NE-32814](https://jira.cec.lab.emc.com/browse/NE-32814) [NE-32815](https://jira.cec.lab.emc.com/browse/NE-32815) [NE-32816](https://jira.cec.lab.emc.com/browse/NE-32816) [NE-32818](https://jira.cec.lab.emc.com/browse/NE-32818)
From [NE-32196](https://jira.cec.lab.emc.com/browse/NE-32196): Absolute Path Traversal 10, 11, 12, 13
