### PR TITLE
NE-31906 Update cloudify-ui-common-backend to 1.3.4

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -17,7 +17,7 @@
                 "axios": "^1.7.2",
                 "body": "^5.1.0",
                 "bytes": "^3.1.2",
-                "cloudify-ui-common-backend": "^1.3.3",
+                "cloudify-ui-common-backend": "^1.3.4",
                 "cloudify-ui-common-configs": "^1.2.0",
                 "cookie": "^0.4.2",
                 "cookie-parser": "^1.4.3",
@@ -2824,11 +2824,11 @@
             }
         },
         "node_modules/cloudify-ui-common-backend": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/cloudify-ui-common-backend/-/cloudify-ui-common-backend-1.3.3.tgz",
-            "integrity": "sha512-1SIRU0mYiIZaq2tNsdoCh23+EJFxUzOX6OMuWxpQXSJZD8F0bO/XUbkuMk77ItungdzJ9jBwEDjh3fiA8DoRow==",
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/cloudify-ui-common-backend/-/cloudify-ui-common-backend-1.3.4.tgz",
+            "integrity": "sha512-8VX2ggXzPiAura4KakKj2C+m6kigQ6eJpDis57XZ0QckWDLL3WU28tUOh5wwmb3g6JclEwbDYRuY9FMb8TfPgw==",
             "dependencies": {
-                "axios": "^0.26.0",
+                "axios": "^1.7.2",
                 "js-yaml": "^4.1.0",
                 "lodash": "^4.17.21",
                 "sequelize": "^6.29.0",
@@ -2839,14 +2839,6 @@
             },
             "engines": {
                 "node": ">=16"
-            }
-        },
-        "node_modules/cloudify-ui-common-backend/node_modules/axios": {
-            "version": "0.26.1",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-            "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
-            "dependencies": {
-                "follow-redirects": "^1.14.8"
             }
         },
         "node_modules/cloudify-ui-common-configs": {
@@ -11955,11 +11947,11 @@
             }
         },
         "cloudify-ui-common-backend": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/cloudify-ui-common-backend/-/cloudify-ui-common-backend-1.3.3.tgz",
-            "integrity": "sha512-1SIRU0mYiIZaq2tNsdoCh23+EJFxUzOX6OMuWxpQXSJZD8F0bO/XUbkuMk77ItungdzJ9jBwEDjh3fiA8DoRow==",
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/cloudify-ui-common-backend/-/cloudify-ui-common-backend-1.3.4.tgz",
+            "integrity": "sha512-8VX2ggXzPiAura4KakKj2C+m6kigQ6eJpDis57XZ0QckWDLL3WU28tUOh5wwmb3g6JclEwbDYRuY9FMb8TfPgw==",
             "requires": {
-                "axios": "^0.26.0",
+                "axios": "^1.7.2",
                 "js-yaml": "^4.1.0",
                 "lodash": "^4.17.21",
                 "sequelize": "^6.29.0",
@@ -11967,16 +11959,6 @@
                 "simple-git": "^3.17.0",
                 "umzug": "^3.0.0",
                 "winston": "^3.3.3"
-            },
-            "dependencies": {
-                "axios": {
-                    "version": "0.26.1",
-                    "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-                    "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
-                    "requires": {
-                        "follow-redirects": "^1.14.8"
-                    }
-                }
             }
         },
         "cloudify-ui-common-configs": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -36,7 +36,7 @@
         "axios": "^1.7.2",
         "body": "^5.1.0",
         "bytes": "^3.1.2",
-        "cloudify-ui-common-backend": "^1.3.3",
+        "cloudify-ui-common-backend": "^1.3.4",
         "cloudify-ui-common-configs": "^1.2.0",
         "cookie": "^0.4.2",
         "cookie-parser": "^1.4.3",


### PR DESCRIPTION
This PR updates cloudify-ui-common-backend to version 1.3.4, This should fix issue with audit, where we used vulnerable version of axios inside the package.
