### PR TITLE
Fix RPM Build issue with mirror not longer available

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -110,6 +110,12 @@ pipeline {
         stage('Build RPM'){
           steps {
             container('rpmbuild'){
+              // See https://serverfault.com/questions/1161816/mirrorlist-centos-org-no-longer-resolve#answer-1161847
+              echo "Fix mirrorlist no longer available"
+              sh "sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo"
+              sh "sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo"
+              sh "sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo"
+
               echo "Install gcc 7"
               sh """
                 yum update -y && yum install centos-release-scl -y && yum install devtoolset-7-gcc* -y


### PR DESCRIPTION
## Description
Fix RPM Build step in the pipeline, by replacing no longer available mirror repo for yum with vault.

## Screenshots / Videos
N/A

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [x] I followed the [UI Testing Guidelines](https://cloudifysource.atlassian.net/l/cp/udCVfvrx) and verified that all tests/checks have passed.
- [x] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [x] I added proper labels to this PR.

## Tests
N/A

## Documentation
N/A