### PR TITLE
Remove default host from server.listen to allow by default to listen on ipv6 and ipv4

### DIFF
--- a/backend/config.ts
+++ b/backend/config.ts
@@ -117,5 +117,5 @@ export function getClientConfig(mode: Mode): ClientConfig {
 
 export function getBackendConfig() {
     const { backend } = getConfig().app;
-    return { host: backend?.host ?? 'localhost', port: backend?.port ?? 8088 };
+    return { host: backend?.host, port: backend?.port ?? 8088 };
 }

--- a/backend/routes/Config.types.ts
+++ b/backend/routes/Config.types.ts
@@ -11,7 +11,12 @@ export type UserConfig = typeof userConfig;
 
 export type AppConfig = typeof app &
     typeof root &
-    typeof logging & { db: { options: typeof dbOptions } } & typeof userConfig;
+    typeof logging & { db: { options: typeof dbOptions } } & typeof userConfig & {
+        backend: {
+            host?: string;
+            port: number;
+        };
+    };
 
 export interface Config {
     app: AppConfig;

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -22,7 +22,7 @@ export default DBConnection.init()
         logger.info('Widgets and templates data initialized successfully.');
         return new Promise((resolve, reject) => {
             const { host, port } = getBackendConfig();
-            const server = app.listen(port, host);
+            const server = host ? app.listen(port, host) : app.listen(port);
             server.on('error', reject);
             server.on('listening', () => {
                 logger.info(`Server started in mode ${getMode()}`);

--- a/conf/app.json
+++ b/conf/app.json
@@ -1,6 +1,5 @@
 {
   "backend": {
-    "host": "localhost",
     "port": 8088
   },
   "db": {

--- a/jenkins/build-pod.yaml
+++ b/jenkins/build-pod.yaml
@@ -25,7 +25,7 @@ spec:
     image: cypress/browsers:node-18.20.3-chrome-125.0.6422.141-1-ff-126.0.1-edge-125.0.2535.85-1
     resources:
       requests:
-        cpu: 3.5
+        cpu: 2.5
         memory: 8Gi
         ephemeral-storage: "15Gi"
       limits:

--- a/jenkins/build-pod.yaml
+++ b/jenkins/build-pod.yaml
@@ -25,7 +25,7 @@ spec:
     image: cypress/browsers:node-18.20.3-chrome-125.0.6422.141-1-ff-126.0.1-edge-125.0.2535.85-1
     resources:
       requests:
-        cpu: 2.5
+        cpu: 3.5
         memory: 8Gi
         ephemeral-storage: "15Gi"
       limits:


### PR DESCRIPTION
## Description

From node documentation:

> If host is omitted, the server will accept connections on the [unspecified IPv6 address](https://en.wikipedia.org/wiki/IPv6_address#Unspecified_address) (::) when IPv6 is available, or the [unspecified IPv4 address](https://en.wikipedia.org/wiki/0.0.0.0) (0.0.0.0) otherwise.
>
> In most operating systems, listening to the [unspecified IPv6 address](https://en.wikipedia.org/wiki/IPv6_address#Unspecified_address) (::) may cause the net.Server to also listen on the [unspecified IPv4 address](https://en.wikipedia.org/wiki/0.0.0.0) (0.0.0.0).

We were setting `localhost` by default in the configuration, which on some systems where ipv6 was available, it would listen only on ipv6 interface. Omitting the default host, would in turn allow to listen by default on both interfaces if not specified in the configuration by user.

This cherry-picks changes from #2646 to master branch.

## Screenshots / Videos
N/A

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [x] I followed the [UI Testing Guidelines](https://cloudifysource.atlassian.net/l/cp/udCVfvrx) and verified that all tests/checks have passed.
- [x] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [x] I added proper labels to this PR.

## Tests
N/A

## Documentation
N/A