### PR TITLE
Correct local backend address when starting frontend dev server

### DIFF
--- a/devServer.ts
+++ b/devServer.ts
@@ -8,6 +8,7 @@ import { CONTEXT_PATH } from './backend/consts';
 import { getBackendConfig } from './backend/config';
 
 const backend = getBackendConfig();
+backend.host = backend.host ?? 'localhost';
 
 const webpackConfig = getWebpackConfig({}, { mode: 'development' });
 

--- a/jenkins/build-pod.yaml
+++ b/jenkins/build-pod.yaml
@@ -25,7 +25,7 @@ spec:
     image: cypress/browsers:node-18.20.3-chrome-125.0.6422.141-1-ff-126.0.1-edge-125.0.2535.85-1
     resources:
       requests:
-        cpu: 3.5
+        cpu: 2.5
         memory: 8Gi
         ephemeral-storage: "15Gi"
       limits:

--- a/jenkins/build-pod.yaml
+++ b/jenkins/build-pod.yaml
@@ -25,7 +25,7 @@ spec:
     image: cypress/browsers:node-18.20.3-chrome-125.0.6422.141-1-ff-126.0.1-edge-125.0.2535.85-1
     resources:
       requests:
-        cpu: 2.5
+        cpu: 3.5
         memory: 8Gi
         ephemeral-storage: "15Gi"
       limits:


### PR DESCRIPTION
## Description

After latest change from #2647 `npm run devStart` stopped resolving correctly backend address due to it not longer defaulting to `localhost`. In the context of resolving backend address, we can safely fallback on `localhost`, hence this change.

## Screenshots / Videos
N/A

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the [UI Code Style](https://cloudifysource.atlassian.net/l/c/x8fq902p).
- [x] I followed the [UI Testing Guidelines](https://cloudifysource.atlassian.net/l/cp/udCVfvrx) and verified that all tests/checks have passed.
- [x] I verified if that change requires any update in the [documentation](https://cloudifysource.atlassian.net/l/c/4XKtPocy).
- [x] I added proper labels to this PR.

## Tests
N/A

## Documentation
N/A